### PR TITLE
hotfix🔥 : restdocs 테스트 경로 수정

### DIFF
--- a/src/docs/asciidoc/api/user/user-login.adoc
+++ b/src/docs/asciidoc/api/user/user-login.adoc
@@ -25,9 +25,9 @@ POST /api/v1/oauth/login
 ----
 
 [discrete]
-include::{snippets}/user/user/request-fields.adoc[]
-include::{snippets}/user/user/request-body.adoc[]
+include::{snippets}/user/user-login/request-fields.adoc[]
+include::{snippets}/user/user-login/request-body.adoc[]
 
 [discrete]
-include::{snippets}/user/user/response-fields.adoc[]
-include::{snippets}/user/user/http-response.adoc[]
+include::{snippets}/user/user-login/response-fields.adoc[]
+include::{snippets}/user/user-login/http-response.adoc[]

--- a/src/docs/asciidoc/api/user/user-reissue.adoc
+++ b/src/docs/asciidoc/api/user/user-reissue.adoc
@@ -23,12 +23,12 @@ POST /api/v1/oauth/reissue
 ----
 
 [discrete]
-include::{snippets}/user/user/request-fields.adoc[]
-include::{snippets}/user/user/request-body.adoc[]
+include::{snippets}/user/user-reissue/request-fields.adoc[]
+include::{snippets}/user/user-reissue//request-body.adoc[]
 
 [discrete]
-include::{snippets}/user/user/response-fields.adoc[]
-include::{snippets}/user/user/http-response.adoc[]
+include::{snippets}/user/user-reissue//response-fields.adoc[]
+include::{snippets}/user/user-reissue//http-response.adoc[]
 
 
 

--- a/src/test/java/app/bottlenote/docs/user/OauthControllerDocsTest.java
+++ b/src/test/java/app/bottlenote/docs/user/OauthControllerDocsTest.java
@@ -56,7 +56,7 @@ class OauthControllerDocsTest extends AbstractRestDocs {
 			.andExpect(status().isOk())
 
 			.andDo(
-				document("user/user",
+				document("user/user-login",
 					requestFields(
 						fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
 						fieldWithPath("gender").type(JsonFieldType.STRING).description("성별")
@@ -106,7 +106,7 @@ class OauthControllerDocsTest extends AbstractRestDocs {
 			.andExpect(status().isOk())
 
 			.andDo(
-				document("user/user",
+				document("user/user-reissue",
 					requestFields(
 						fieldWithPath("accessToken").type(JsonFieldType.STRING).description("이메일"),
 						fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("성별")


### PR DESCRIPTION

### PR 제목 (Title)

* restdocs 테스트코드의 경로가 중복되어 로그인, 토큰재발급 모두 reqeust, response가 똑같이 출력되는 오류가 있었습니다.

### 변경 사항 (Changes)

* 경로 수정