### PR TITLE
hotfix : 유저 테이블 컬럼 2개 추가

### DIFF
--- a/.github/init-sql-backup/init-user.sql
+++ b/.github/init-sql-backup/init-user.sql
@@ -5,6 +5,8 @@ CREATE TABLE `users`
     `nick_name`      VARCHAR(255) NOT NULL COMMENT '사용자 소셜 닉네임 ( 수정 가능 )',
     `age`            integer      NULL COMMENT '사용자 나이',
     `image_url`      VARCHAR(255) NULL COMMENT '사용자 프로필 이미지',
+    `image_key`      VARCHAR(255) NULL COMMENT '업로드된 루트 경로(버킷부터 이미지 이름까지)',
+    `image_path`     VARCHAR(255) NULL COMMENT '저장된 이미지 경로(버킷부터 최종폴더까지)',
     `gender`         VARCHAR(255) NULL,
     `role`           VARCHAR(255) NOT NULL DEFAULT 'GUEST',
     `social_type`    VARCHAR(255) NOT NULL COMMENT '소셜 타입 (NAVER, GOOGLE, APPLE)',


### PR DESCRIPTION
- db 컬럼추가 후 init-user.sql에 추가함

Resolves #156 

# 해결하려는 문제가 무엇인가요?

- 유저 프로필 변경을 위해서 유저 테이블에 image_key, image_path 컬럼을 추가해야합니다.

# 어떻게 해결했나요?

- DB에 컬럼을 추가 후 user-init.sql에 추가했습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?

- 잘 추가했는지 검토부탁드립니다.

## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
