### PR TITLE
hotfix :  리뷰 수정시 발생하는 문제들을 해결한다

### DIFF
--- a/src/main/java/app/bottlenote/review/domain/constant/SizeType.java
+++ b/src/main/java/app/bottlenote/review/domain/constant/SizeType.java
@@ -1,7 +1,22 @@
 package app.bottlenote.review.domain.constant;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@AllArgsConstructor
+@Slf4j
 public enum SizeType{
 
-	GLASS, BOTTLE
+	GLASS, BOTTLE;
 
+	@JsonCreator
+	public static SizeType parsing(String source) {
+		if (source == null || source.isEmpty()) {
+			return null;
+		}
+		return SizeType.valueOf(source.toUpperCase());
+	}
 }

--- a/src/main/java/app/bottlenote/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/app/bottlenote/review/dto/request/ReviewCreateRequest.java
@@ -2,15 +2,15 @@ package app.bottlenote.review.dto.request;
 
 import app.bottlenote.review.domain.constant.ReviewDisplayStatus;
 import app.bottlenote.review.domain.constant.SizeType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.extern.slf4j.Slf4j;
-
 import java.math.BigDecimal;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public record ReviewCreateRequest(
@@ -29,6 +29,7 @@ public record ReviewCreateRequest(
 	@DecimalMax(value = "1000000000000", message = "입력할 수 있는 가격의 범위가 아닙니다.")
 	BigDecimal price,
 
+	@Valid
 	LocationInfo locationInfo,
 
 	List<ReviewImageInfo> imageUrlList,

--- a/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequest.java
+++ b/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequest.java
@@ -2,18 +2,19 @@ package app.bottlenote.review.dto.request;
 
 import app.bottlenote.review.domain.constant.ReviewDisplayStatus;
 import app.bottlenote.review.domain.constant.SizeType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
 import java.math.BigDecimal;
 import java.util.List;
 
-
 public record ReviewModifyRequest(
+
 	@NotEmpty(message = "리뷰 내용을 입력해주세요")
 	@Size(max = 500)
 	String content,
@@ -23,20 +24,25 @@ public record ReviewModifyRequest(
 
 	@DecimalMin(value = "0.0", message = "가격은 0 이상이어야 합니다.")
 	@DecimalMax(value = "1000000000000", message = "입력할 수 있는 가격의 범위가 아닙니다.")
-	@NotNull
+	@JsonInclude()
+	@JsonProperty(required = true)
 	BigDecimal price,
 
-	@NotNull
+	@JsonInclude()
+	@JsonProperty(required = true)
 	List<ReviewImageInfo> imageUrlList,
 
-	@NotNull
+	@JsonInclude()
+	@JsonProperty(required = true)
 	SizeType sizeType,
 
-	@NotNull
+	@JsonInclude()
+	@JsonProperty(required = true)
 	List<String> tastingTagList,
 
 	@Valid
-	@NotNull
+	@JsonInclude()
+	@JsonProperty(required = true)
 	LocationInfo locationInfo
 
 ) {

--- a/src/main/java/app/bottlenote/review/dto/vo/ReviewModifyVO.java
+++ b/src/main/java/app/bottlenote/review/dto/vo/ReviewModifyVO.java
@@ -28,8 +28,8 @@ public class ReviewModifyVO {
 		this.reviewDisplayStatus = reviewModifyRequest.status();
 		this.price = reviewModifyRequest.price();
 		this.sizeType = reviewModifyRequest.sizeType();
-		this.zipCode = reviewModifyRequest.locationInfo().zipCode();
-		this.address = reviewModifyRequest.locationInfo().address();
-		this.detailAddress = reviewModifyRequest.locationInfo().detailAddress();
+		this.zipCode = reviewModifyRequest.locationInfo() == null ? null : reviewModifyRequest.locationInfo().zipCode();
+		this.address = reviewModifyRequest.locationInfo() == null ? null : reviewModifyRequest.locationInfo().address();
+		this.detailAddress = reviewModifyRequest.locationInfo() == null ? null : reviewModifyRequest.locationInfo().detailAddress();
 	}
 }

--- a/src/main/java/app/bottlenote/review/dto/vo/ReviewModifyVO.java
+++ b/src/main/java/app/bottlenote/review/dto/vo/ReviewModifyVO.java
@@ -4,6 +4,7 @@ import app.bottlenote.review.domain.constant.ReviewDisplayStatus;
 import app.bottlenote.review.domain.constant.SizeType;
 import app.bottlenote.review.dto.request.ReviewModifyRequest;
 import java.math.BigDecimal;
+import java.util.Objects;
 import lombok.Getter;
 
 @Getter
@@ -28,8 +29,15 @@ public class ReviewModifyVO {
 		this.reviewDisplayStatus = reviewModifyRequest.status();
 		this.price = reviewModifyRequest.price();
 		this.sizeType = reviewModifyRequest.sizeType();
-		this.zipCode = reviewModifyRequest.locationInfo() == null ? null : reviewModifyRequest.locationInfo().zipCode();
-		this.address = reviewModifyRequest.locationInfo() == null ? null : reviewModifyRequest.locationInfo().address();
-		this.detailAddress = reviewModifyRequest.locationInfo() == null ? null : reviewModifyRequest.locationInfo().detailAddress();
+		if (Objects.isNull(reviewModifyRequest.locationInfo())) {
+			this.zipCode = null;
+			this.address = null;
+			this.detailAddress = null;
+		} else {
+			this.zipCode = reviewModifyRequest.locationInfo().zipCode();
+			this.address = reviewModifyRequest.locationInfo().address();
+			this.detailAddress = reviewModifyRequest.locationInfo().detailAddress();
+		}
+
 	}
 }

--- a/src/main/java/app/bottlenote/review/repository/custom/CustomReviewQueryRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/review/repository/custom/CustomReviewQueryRepositoryImpl.java
@@ -1,19 +1,19 @@
 package app.bottlenote.review.repository.custom;
 
-import app.bottlenote.alcohols.dto.response.detail.ReviewsDetailInfo;
-import app.bottlenote.review.repository.ReviewQuerySupporter;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.List;
-
 import static app.bottlenote.alcohols.dto.response.detail.ReviewsDetailInfo.ReviewInfo;
 import static app.bottlenote.like.domain.QLikes.likes;
 import static app.bottlenote.rating.domain.QRating.rating;
 import static app.bottlenote.review.domain.QReview.review;
 import static app.bottlenote.review.domain.QReviewReply.reviewReply;
 import static app.bottlenote.user.domain.QUser.user;
+
+import app.bottlenote.alcohols.dto.response.detail.ReviewsDetailInfo;
+import app.bottlenote.review.domain.constant.ReviewActiveStatus;
+import app.bottlenote.review.repository.ReviewQuerySupporter;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CustomReviewQueryRepositoryImpl implements CustomReviewQueryRepository {
 
@@ -42,7 +42,7 @@ public class CustomReviewQueryRepositoryImpl implements CustomReviewQueryReposit
 			.leftJoin(review.reviewReplies, reviewReply)
 			.leftJoin(rating).on(rating.alcohol.id.eq(review.alcoholId).and(rating.user.id.eq(user.id)))
 			.leftJoin(likes).on(likes.review.id.eq(review.id))
-			.where(review.alcoholId.eq(alcoholId))
+			.where(review.alcoholId.eq(alcoholId).and(review.activeStatus.eq(ReviewActiveStatus.ACTIVE)))
 			.groupBy(user.id, user.imageUrl, user.nickName, review.id, review.content, rating.ratingPoint, review.createAt)
 			.orderBy(reviewReply.count().coalesce(0L)
 				.add(likes.count().coalesce(0L))
@@ -71,7 +71,10 @@ public class CustomReviewQueryRepositoryImpl implements CustomReviewQueryReposit
 			.leftJoin(review.reviewReplies, reviewReply)
 			.leftJoin(rating).on(rating.alcohol.id.eq(review.alcoholId).and(rating.user.id.eq(user.id)))
 			.leftJoin(likes).on(likes.review.id.eq(review.id))
-			.where(review.alcoholId.eq(alcoholId), review.id.notIn(ids))
+			.where(
+				review.alcoholId.eq(alcoholId),
+				review.id.notIn(ids),
+				review.activeStatus.eq(ReviewActiveStatus.ACTIVE))
 			.groupBy(user.id, user.imageUrl, user.nickName, review.id, review.content, rating.ratingPoint, review.createAt)
 			.orderBy(review.createAt.desc())
 			.limit(4)
@@ -84,7 +87,7 @@ public class CustomReviewQueryRepositoryImpl implements CustomReviewQueryReposit
 		return queryFactory
 			.select(review.id.count())
 			.from(review)
-			.where(review.alcoholId.eq(alcoholId))
+			.where(review.alcoholId.eq(alcoholId).and(review.activeStatus.eq(ReviewActiveStatus.ACTIVE)))
 			.fetchOne();
 	}
 

--- a/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
@@ -140,7 +140,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 		Long totalCount = queryFactory
 			.select(review.id.count())
 			.from(review)
-			.where(review.userId.eq(userId))
+			.where(review.userId.eq(userId).and(review.activeStatus.eq(ACTIVE)))
 			.fetchOne();
 
 		CursorPageable cursorPageable = getCursorPageable(pageableRequest, fetch);

--- a/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
@@ -108,7 +108,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 		Long totalCount = queryFactory
 			.select(review.id.count())
 			.from(review)
-			.where(review.alcoholId.eq(alcoholId))
+			.where(review.alcoholId.eq(alcoholId).and(review.activeStatus.eq(ACTIVE)))
 			.fetchOne();
 
 		CursorPageable cursorPageable = getCursorPageable(pageableRequest, fetch);

--- a/src/main/java/app/bottlenote/review/service/ReviewImageSupport.java
+++ b/src/main/java/app/bottlenote/review/service/ReviewImageSupport.java
@@ -49,27 +49,29 @@ public class ReviewImageSupport {
 	}
 
 	public void updateImages(List<ReviewImageInfo> imageList, Review review) {
-
 		if (CollectionUtils.isEmpty(imageList)) {
+
 			review.updateImages(Collections.emptyList());
+
+		} else {
+			
+			List<ReviewImage> reviewImageList = imageList.stream()
+				.map(image -> ReviewImage.builder()
+					.order(image.order())
+					.imageUrl(image.viewUrl())
+					.imagePath(ImageUtil.getImagePath(image.viewUrl()))
+					.imageKey(ImageUtil.getImageKey(image.viewUrl()))
+					.imageName(ImageUtil.getImageName(image.viewUrl()))
+					.review(review)
+					.build()
+				).toList();
+
+			if (isOverMaxSize(reviewImageList)) {
+				throw new ReviewException(INVALID_IMAGE_URL_MAX_SIZE);
+			}
+
+			review.updateImages(reviewImageList);
 		}
-		List<ReviewImage> reviewImageList = imageList.stream()
-			.map(image -> ReviewImage.builder()
-				.order(image.order())
-				.imageUrl(image.viewUrl())
-				.imagePath(ImageUtil.getImagePath(image.viewUrl()))
-				.imageKey(ImageUtil.getImageKey(image.viewUrl()))
-				.imageName(ImageUtil.getImageName(image.viewUrl()))
-				.review(review)
-				.build()
-			).toList();
-
-		if (isOverMaxSize(reviewImageList)) {
-			throw new ReviewException(INVALID_IMAGE_URL_MAX_SIZE);
-		}
-
-		review.updateImages(reviewImageList);
-
 	}
 
 	private boolean isOverMaxSize(List<ReviewImage> reviewImageList) {

--- a/src/main/java/app/bottlenote/review/service/ReviewTastingTagSupport.java
+++ b/src/main/java/app/bottlenote/review/service/ReviewTastingTagSupport.java
@@ -38,22 +38,25 @@ public class ReviewTastingTagSupport {
 	public void updateReviewTastingTags(List<String> tastingTags, Review review) {
 
 		if (CollectionUtils.isEmpty(tastingTags)) {
+			
 			review.updateTastingTags(Collections.emptySet());
+
+		} else {
+
+			Set<ReviewTastingTag> reviewTastingTags = tastingTags.stream()
+				.distinct() // 중복 제거
+				.map(tastingTag -> ReviewTastingTag.builder()
+					.review(review)
+					.tastingTag(tastingTag)
+					.build())
+				.collect(Collectors.toSet());
+
+			if (!isValidReviewTastingTag(reviewTastingTags)) {
+				throw new ReviewException(INVALID_TASTING_TAG_LIST_SIZE);
+			}
+
+			review.updateTastingTags(reviewTastingTags);
 		}
-
-		Set<ReviewTastingTag> reviewTastingTags = tastingTags.stream()
-			.distinct() // 중복 제거
-			.map(tastingTag -> ReviewTastingTag.builder()
-				.review(review)
-				.tastingTag(tastingTag)
-				.build())
-			.collect(Collectors.toSet());
-
-		if (!isValidReviewTastingTag(reviewTastingTags)) {
-			throw new ReviewException(INVALID_TASTING_TAG_LIST_SIZE);
-		}
-
-		review.updateTastingTags(reviewTastingTags);
 	}
 
 

--- a/src/test/java/app/bottlenote/review/controller/ReviewControllerTest.java
+++ b/src/test/java/app/bottlenote/review/controller/ReviewControllerTest.java
@@ -25,7 +25,6 @@ import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.global.service.cursor.SortOrder;
 import app.bottlenote.review.domain.constant.ReviewDisplayStatus;
 import app.bottlenote.review.domain.constant.ReviewSortType;
-import app.bottlenote.review.domain.constant.SizeType;
 import app.bottlenote.review.dto.request.LocationInfo;
 import app.bottlenote.review.dto.request.PageableRequest;
 import app.bottlenote.review.dto.request.ReviewCreateRequest;
@@ -443,8 +442,6 @@ class ReviewControllerTest {
 		@Test
 		void modify_review_success() throws Exception {
 
-			Long reviewId = 99L;
-
 			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
 
 			when(reviewService.modifyReview(reviewModifyRequest, reviewId, userId))
@@ -467,8 +464,6 @@ class ReviewControllerTest {
 		@Test
 		void modify_review_fail_unauthorized_user() throws Exception {
 
-			Long reviewId = 1L;
-
 			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.empty());
 
 			when(reviewService.modifyReview(reviewModifyRequest, reviewId, userId))
@@ -490,8 +485,6 @@ class ReviewControllerTest {
 		@Test
 		void modify_review_fail_not_exist_review() throws Exception {
 
-			Long reviewId = 1L;
-
 			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
 
 			when(reviewService.modifyReview(reviewModifyRequest, reviewId, userId))
@@ -509,19 +502,18 @@ class ReviewControllerTest {
 				.modifyReview(any(ReviewModifyRequest.class), anyLong(), anyLong());
 		}
 
-		@DisplayName("Request Body에 Null인 필드가 포함되면 리뷰를 수정할 수 없다..")
+		@DisplayName("status와 content를 제외한 필드가 null 인 경우 리뷰 수정이 가능하다.")
 		@Test
 		void modify_review_fail_when_request_body_has_null() throws Exception {
 
 			ReviewModifyRequest wrongRequest = new ReviewModifyRequest(
 				"그저 그래요",
 				ReviewDisplayStatus.PUBLIC,
-				BigDecimal.valueOf(10000L),
 				null,
-				SizeType.GLASS,
-				List.of(),
+				null,
+				null,
+				null,
 				new LocationInfo(null, null, null));
-			Long reviewId = 99L;
 
 			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
 
@@ -533,11 +525,8 @@ class ReviewControllerTest {
 					.content(mapper.writeValueAsString(wrongRequest))
 					.with(csrf())
 				)
-				.andExpect(status().isBadRequest())
+				.andExpect(status().isOk())
 				.andDo(print());
-
-			verify(reviewService, never())
-				.modifyReview(any(ReviewModifyRequest.class), anyLong(), anyLong());
 		}
 	}
 
@@ -593,8 +582,6 @@ class ReviewControllerTest {
 		@DisplayName("존재하지 않은 리뷰를 삭제할 수 없다.")
 		@Test
 		void delete_review_fail_not_exist_review() throws Exception {
-
-			Long reviewId = 1L;
 
 			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
 

--- a/src/test/java/app/bottlenote/review/controller/ReviewControllerTest.java
+++ b/src/test/java/app/bottlenote/review/controller/ReviewControllerTest.java
@@ -81,6 +81,9 @@ class ReviewControllerTest {
 	private final ReviewCreateResponse reviewCreateResponse = ReviewObjectFixture.getReviewCreateResponse();
 
 	private final ReviewModifyRequest reviewModifyRequest = ReviewObjectFixture.getReviewModifyRequest();
+	private final ReviewModifyRequest nullableReviewModifyRequest = ReviewObjectFixture.getNullableReviewModifyRequest();
+	private final ReviewModifyRequest wrongReviewModifyRequest = ReviewObjectFixture.getWrongReviewModifyRequest();
+
 	private final PageResponse<ReviewListResponse> reviewListResponse = ReviewObjectFixture.getReviewListResponse();
 
 	private final ReviewDetailResponse reviewDetailResponse = ReviewObjectFixture.getReviewDetailResponse();
@@ -506,27 +509,39 @@ class ReviewControllerTest {
 		@Test
 		void modify_review_fail_when_request_body_has_null() throws Exception {
 
-			ReviewModifyRequest wrongRequest = new ReviewModifyRequest(
-				"그저 그래요",
-				ReviewDisplayStatus.PUBLIC,
-				null,
-				null,
-				null,
-				null,
-				new LocationInfo(null, null, null));
-
 			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
 
-			when(reviewService.modifyReview(wrongRequest, reviewId, userId))
+			when(reviewService.modifyReview(nullableReviewModifyRequest, reviewId, userId))
 				.thenReturn(response);
 
 			mockMvc.perform(patch("/api/v1/reviews/{reviewId}", reviewId)
 					.contentType(MediaType.APPLICATION_JSON)
-					.content(mapper.writeValueAsString(wrongRequest))
+					.content(mapper.writeValueAsString(nullableReviewModifyRequest))
 					.with(csrf())
 				)
 				.andExpect(status().isOk())
 				.andDo(print());
+		}
+
+		@DisplayName("Not Null인 필드가 null인 경우 리뷰를 수정할 수 없다.")
+		@Test
+		void modify_review_fail_when_null_in_not_nullable_field() throws Exception {
+			// given
+
+			// when
+			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
+
+			when(reviewService.modifyReview(wrongReviewModifyRequest, reviewId, userId))
+				.thenReturn(response);
+
+			mockMvc.perform(patch("/api/v1/reviews/{reviewId}", reviewId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(wrongReviewModifyRequest))
+					.with(csrf())
+				)
+				.andExpect(status().isBadRequest())
+				.andDo(print());
+			// then
 		}
 	}
 

--- a/src/test/java/app/bottlenote/review/fixture/ReviewObjectFixture.java
+++ b/src/test/java/app/bottlenote/review/fixture/ReviewObjectFixture.java
@@ -167,6 +167,40 @@ public class ReviewObjectFixture {
 	}
 
 	/**
+	 * 리뷰 수정 요청 객체 중 Nullable한 필드를 null로 요청하는 객체입니다.
+	 *
+	 * @return the nullable review modify request
+	 */
+	public static ReviewModifyRequest getNullableReviewModifyRequest() {
+		return new ReviewModifyRequest(
+			content,
+			ReviewDisplayStatus.PUBLIC,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+	}
+
+	/**
+	 * Not Null인 필드를 null로 요청을 보내는 잘못된 리뷰 수정 요청 객체입니다.
+	 *
+	 * @return Wrong review modify request
+	 */
+	public static ReviewModifyRequest getWrongReviewModifyRequest() {
+		return new ReviewModifyRequest(
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+	}
+
+	/**
 	 * 리뷰 댓글 응답 객체를 반환합니다.
 	 *
 	 * @return the review reply response

--- a/src/test/java/app/bottlenote/review/integration/ReviewIntegerationTest.java
+++ b/src/test/java/app/bottlenote/review/integration/ReviewIntegerationTest.java
@@ -1,0 +1,142 @@
+package app.bottlenote.review.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.bottlenote.IntegrationTestSupport;
+import app.bottlenote.global.security.SecurityContextUtil;
+import app.bottlenote.review.domain.Review;
+import app.bottlenote.review.domain.ReviewRepository;
+import app.bottlenote.review.dto.request.ReviewModifyRequest;
+import app.bottlenote.review.fixture.ReviewObjectFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.jdbc.Sql;
+
+@DisplayName("[Integration] 리뷰 통합 테스트")
+class ReviewIntegerationTest extends IntegrationTestSupport {
+
+	private MockedStatic<SecurityContextUtil> mockedSecurityUtil;
+	private ReviewModifyRequest reviewModifyRequest;
+	private ReviewModifyRequest nullableReviewModifyRequest;
+	private ReviewModifyRequest wrongReviewModifyRequest;
+
+	@Autowired
+	private ReviewRepository reviewRepository;
+
+	@BeforeEach
+	void setUp() {
+		mockedSecurityUtil = mockStatic(SecurityContextUtil.class);
+		reviewModifyRequest = ReviewObjectFixture.getReviewModifyRequest();
+		nullableReviewModifyRequest = ReviewObjectFixture.getNullableReviewModifyRequest();
+		wrongReviewModifyRequest = ReviewObjectFixture.getWrongReviewModifyRequest();
+	}
+
+	@AfterEach
+	void tearDown() {
+		mockedSecurityUtil.close();
+	}
+
+	@Sql(scripts = {
+		"/init-script/init-alcohol.sql",
+		"/init-script/init-user.sql",
+		"/init-script/init-review.sql",
+		"/init-script/init-review-reply.sql"}
+	)
+
+	@Nested
+	@DisplayName("[Integration] 리뷰 수정 통합테스트")
+	@WithMockUser
+	class ReviewModifyIntegrationTest extends IntegrationTestSupport {
+
+		@DisplayName("리뷰 수정에 성공한다.")
+		@Test
+		void test_1() throws Exception {
+			log.info("using port : {}", MY_SQL_CONTAINER.getFirstMappedPort());
+
+			final Long reviewId = 1L;
+			final Long userId = 2L;
+
+			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
+
+			mockMvc.perform(patch("/api/v1/reviews/{reviewId}", reviewId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(reviewModifyRequest))
+					.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
+
+			Review savedReview = reviewRepository.findById(reviewId).orElseGet(null);
+
+			assertEquals(savedReview.getContent(), reviewModifyRequest.content());
+		}
+
+		@DisplayName("content와 status를 제외한 필드에 null이 할당되어도 수정에 성공한다.")
+		@Test
+		void test_2() throws Exception {
+			log.info("using port : {}", MY_SQL_CONTAINER.getFirstMappedPort());
+
+			final Long reviewId = 1L;
+			final Long userId = 2L;
+
+			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
+
+			mockMvc.perform(patch("/api/v1/reviews/{reviewId}", reviewId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(nullableReviewModifyRequest))
+					.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
+
+			Review savedReview = reviewRepository.findById(reviewId).orElseGet(null);
+
+			assertEquals(savedReview.getContent(), nullableReviewModifyRequest.content());
+		}
+
+		@DisplayName("Not Null인 필드에 null이 할당되면 리뷰 수정에 실패한다.")
+		@Test
+		void test_3() throws Exception {
+			log.info("using port : {}", MY_SQL_CONTAINER.getFirstMappedPort());
+
+			final Long reviewId = 1L;
+			final Long userId = 2L;
+
+			when(SecurityContextUtil.getUserIdByContext()).thenReturn(Optional.of(userId));
+
+			mockMvc.perform(patch("/api/v1/reviews/{reviewId}", reviewId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(wrongReviewModifyRequest))
+					.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value(400))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
+
+		}
+	}
+
+}


### PR DESCRIPTION
Resolves #{이슈-번호}

#198 

# 해결하려는 문제가 무엇인가요?

- 리뷰 등록 시점에 값을 입력하지 않은 내용들(사이즈 타입, 가격, 위치정보)이 리뷰 수정 시점에 Json 요청에 null 값이 허용되지 않은 문제들을 해결했습니다.

- **알콜 조회시 함께 조회되는 리뷰에서도 삭제된 리뷰가 조회되어 where절을 추가했습니다.**
- **추가로, count 쿼리에서도 삭제된 리뷰가 카운트에 포함되지 않도록 조건절을 추가했습니다.**

- 테스트 컨테이너를 활용한 통합테스트를 수행하여 검증했습니다.

# 어떻게 해결했나요?

- ReviewModifyRequest에서 @NotNull을 제거하고, @JsonInclue와 @JsonProperty 어노테이션을 사용했습니다.
- Json필드가 포함되지 않은 경우는 검증하고, null인 경우는 허용합니다.
---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
