### PR TITLE
hotfix :  review 도메인에 프론트 요청사항을 반영한다

### DIFF
--- a/src/main/java/app/bottlenote/alcohols/dto/response/detail/AlcoholDetail.java
+++ b/src/main/java/app/bottlenote/alcohols/dto/response/detail/AlcoholDetail.java
@@ -3,9 +3,10 @@ package app.bottlenote.alcohols.dto.response.detail;
 public record AlcoholDetail(
 	AlcoholDetailInfo alcohols,
 	FriendsDetailInfo friendsInfo,
-	ReviewsDetailInfo reviews
+	ReviewsDetailInfo reviewList
 ) {
-	public static AlcoholDetail of(AlcoholDetailInfo alcohols, FriendsDetailInfo friendsInfo, ReviewsDetailInfo reviews) {
-		return new AlcoholDetail(alcohols, friendsInfo, reviews);
+
+	public static AlcoholDetail of(AlcoholDetailInfo alcohols, FriendsDetailInfo friendsInfo, ReviewsDetailInfo reviewList) {
+		return new AlcoholDetail(alcohols, friendsInfo, reviewList);
 	}
 }

--- a/src/main/java/app/bottlenote/review/dto/response/ReviewListResponse.java
+++ b/src/main/java/app/bottlenote/review/dto/response/ReviewListResponse.java
@@ -2,11 +2,10 @@ package app.bottlenote.review.dto.response;
 
 import app.bottlenote.review.domain.constant.ReviewDisplayStatus;
 import app.bottlenote.review.domain.constant.SizeType;
-import lombok.Builder;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
 
 public record ReviewListResponse(
 	Long totalCount,
@@ -45,7 +44,8 @@ public record ReviewListResponse(
 
 		Boolean isMyReview,
 		Boolean isLikedByMe,
-		Boolean hasReplyByMe
+		Boolean hasReplyByMe,
+		Boolean isBestReview
 	) {
 	}
 }

--- a/src/main/java/app/bottlenote/review/repository/ReviewQuerySupporter.java
+++ b/src/main/java/app/bottlenote/review/repository/ReviewQuerySupporter.java
@@ -1,5 +1,11 @@
 package app.bottlenote.review.repository;
 
+import static app.bottlenote.like.domain.QLikes.likes;
+import static app.bottlenote.rating.domain.QRating.rating;
+import static app.bottlenote.review.domain.QReview.review;
+import static app.bottlenote.review.domain.QReviewReply.reviewReply;
+import static app.bottlenote.user.domain.QUser.user;
+
 import app.bottlenote.alcohols.dto.response.detail.ReviewsDetailInfo;
 import app.bottlenote.review.dto.response.ReviewDetailResponse;
 import app.bottlenote.review.dto.response.ReviewListResponse;
@@ -9,18 +15,12 @@ import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
-import org.springframework.stereotype.Component;
-
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
-
-import static app.bottlenote.like.domain.QLikes.likes;
-import static app.bottlenote.rating.domain.QRating.rating;
-import static app.bottlenote.review.domain.QReview.review;
-import static app.bottlenote.review.domain.QReviewReply.reviewReply;
-import static app.bottlenote.user.domain.QUser.user;
+import org.springframework.stereotype.Component;
 
 @Component
 public class ReviewQuerySupporter {
@@ -58,7 +58,7 @@ public class ReviewQuerySupporter {
 	 * @param userId 유저 ID
 	 * @return ReviewListResponse.ReviewInfo
 	 */
-	public ConstructorExpression<ReviewListResponse.ReviewInfo> reviewResponseConstructor(Long userId) {
+	public ConstructorExpression<ReviewListResponse.ReviewInfo> reviewResponseConstructor(Long userId, Long bestReviewId) {
 		return Projections.constructor(
 			ReviewListResponse.ReviewInfo.class,
 			review.id.as("reviewId"),
@@ -76,7 +76,8 @@ public class ReviewQuerySupporter {
 			review.status.as("status"),
 			isMyReviewSubquery(userId),
 			isLikeByMeSubquery(userId),
-			hasReplyByMeSubquery(userId)
+			hasReplyByMeSubquery(userId),
+			isBestReviewSubquery(bestReviewId, review.id.longValue())
 		);
 	}
 
@@ -125,6 +126,10 @@ public class ReviewQuerySupporter {
 	 */
 	public BooleanExpression isBestReviewSubquery(Long bestReviewId, Long reviewId) {
 		return Objects.equals(bestReviewId, reviewId) ? Expressions.asBoolean(true) : Expressions.asBoolean(false);
+	}
+
+	public BooleanExpression isBestReviewSubquery(Long bestReviewId, NumberExpression<Long> reviewId) {
+		return reviewId.eq(bestReviewId);
 	}
 
 	/**

--- a/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
@@ -90,8 +90,24 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 		PageableRequest pageableRequest,
 		Long userId
 	) {
+		Long bestReviewId = queryFactory
+			.select(review.id)
+			.from(review)
+			.join(user).on(review.userId.eq(user.id))
+			.leftJoin(review.reviewReplies, reviewReply)
+			.leftJoin(rating).on(rating.alcohol.id.eq(review.alcoholId))
+			.leftJoin(likes).on(likes.review.id.eq(review.id))
+			.groupBy(user.id, user.imageUrl, user.nickName, review.id, review.content, rating.ratingPoint, review.createAt)
+			.orderBy(reviewReply.count().coalesce(0L)
+				.add(likes.count().coalesce(0L))
+				.add(rating.ratingPoint.rating.coalesce(0.0).avg())
+				.desc()
+			)
+			.limit(1)
+			.fetchOne();
+
 		List<ReviewListResponse.ReviewInfo> fetch = queryFactory
-			.select(supporter.reviewResponseConstructor(userId))
+			.select(supporter.reviewResponseConstructor(userId, bestReviewId))
 			.from(review)
 			.join(user).on(review.userId.eq(user.id))
 			.leftJoin(likes).on(review.id.eq(likes.review.id))
@@ -123,8 +139,25 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 		PageableRequest pageableRequest,
 		Long userId
 	) {
+
+		Long bestReviewId = queryFactory
+			.select(review.id)
+			.from(review)
+			.join(user).on(review.userId.eq(user.id))
+			.leftJoin(review.reviewReplies, reviewReply)
+			.leftJoin(rating).on(rating.alcohol.id.eq(review.alcoholId))
+			.leftJoin(likes).on(likes.review.id.eq(review.id))
+			.groupBy(user.id, user.imageUrl, user.nickName, review.id, review.content, rating.ratingPoint, review.createAt)
+			.orderBy(reviewReply.count().coalesce(0L)
+				.add(likes.count().coalesce(0L))
+				.add(rating.ratingPoint.rating.coalesce(0.0).avg())
+				.desc()
+			)
+			.limit(1)
+			.fetchOne();
+
 		List<ReviewListResponse.ReviewInfo> fetch = queryFactory
-			.select(supporter.reviewResponseConstructor(userId))
+			.select(supporter.reviewResponseConstructor(userId, bestReviewId))
 			.from(review)
 			.join(user).on(review.userId.eq(user.id))
 			.leftJoin(likes).on(review.id.eq(likes.review.id))

--- a/src/test/java/app/bottlenote/docs/alcohols/RestAlcoholQueryControllerTest.java
+++ b/src/test/java/app/bottlenote/docs/alcohols/RestAlcoholQueryControllerTest.java
@@ -1,19 +1,5 @@
 package app.bottlenote.docs.alcohols;
 
-import app.bottlenote.alcohols.controller.AlcoholQueryController;
-import app.bottlenote.alcohols.dto.request.AlcoholSearchRequest;
-import app.bottlenote.alcohols.dto.response.AlcoholSearchResponse;
-import app.bottlenote.alcohols.dto.response.CategoryResponse;
-import app.bottlenote.alcohols.dto.response.detail.AlcoholDetail;
-import app.bottlenote.alcohols.fixture.AlcoholQueryFixture;
-import app.bottlenote.alcohols.service.AlcoholQueryService;
-import app.bottlenote.docs.AbstractRestDocs;
-import app.bottlenote.global.service.cursor.PageResponse;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static app.bottlenote.alcohols.domain.constant.AlcoholCategoryGroup.SINGLE_MALT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -26,6 +12,19 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.bottlenote.alcohols.controller.AlcoholQueryController;
+import app.bottlenote.alcohols.dto.request.AlcoholSearchRequest;
+import app.bottlenote.alcohols.dto.response.AlcoholSearchResponse;
+import app.bottlenote.alcohols.dto.response.CategoryResponse;
+import app.bottlenote.alcohols.dto.response.detail.AlcoholDetail;
+import app.bottlenote.alcohols.fixture.AlcoholQueryFixture;
+import app.bottlenote.alcohols.service.AlcoholQueryService;
+import app.bottlenote.docs.AbstractRestDocs;
+import app.bottlenote.global.service.cursor.PageResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 @DisplayName("alcohol 컨트롤러 RestDocs용 테스트")
 class RestAlcoholQueryControllerTest extends AbstractRestDocs {
@@ -154,40 +153,40 @@ class RestAlcoholQueryControllerTest extends AbstractRestDocs {
 						fieldWithPath("data.friendsInfo.friends[].nickName").description("친구의 닉네임"),
 						fieldWithPath("data.friendsInfo.friends[].rating").description("친구의 평점"),
 
-						fieldWithPath("data.reviews.totalReviewCount").description("해당 술의 총 리뷰 수"),
-						fieldWithPath("data.reviews.bestReviewInfos[].userId").description("베스트 리뷰 작성자 ID"),
-						fieldWithPath("data.reviews.bestReviewInfos[].imageUrl").description("베스트 리뷰 작성자 프로필 이미지 URL"),
-						fieldWithPath("data.reviews.bestReviewInfos[].nickName").description("베스트 리뷰 작성자 닉네임"),
-						fieldWithPath("data.reviews.bestReviewInfos[].reviewId").description("베스트 리뷰 ID"),
-						fieldWithPath("data.reviews.bestReviewInfos[].reviewContent").description("베스트 리뷰 내용"),
-						fieldWithPath("data.reviews.bestReviewInfos[].rating").description("베스트 리뷰 평점"),
-						fieldWithPath("data.reviews.bestReviewInfos[].sizeType").optional().description("베스트 리뷰 사이즈 타입"),
-						fieldWithPath("data.reviews.bestReviewInfos[].price").description("베스트 리뷰 가격"),
-						fieldWithPath("data.reviews.bestReviewInfos[].viewCount").description("베스트 리뷰 조회수"),
-						fieldWithPath("data.reviews.bestReviewInfos[].likeCount").description("베스트 리뷰 좋아요 수"),
-						fieldWithPath("data.reviews.bestReviewInfos[].isLikedByMe").description("베스트 리뷰 내가 좋아요를 눌렀는지 여부"),
-						fieldWithPath("data.reviews.bestReviewInfos[].replyCount").description("베스트 리뷰 댓글 수"),
-						fieldWithPath("data.reviews.bestReviewInfos[].hasReplyByMe").description("베스트 리뷰 내가 댓글을 달았는지 여부"),
-						fieldWithPath("data.reviews.bestReviewInfos[].status").description("리뷰 공개 비공개 여부 (PUBLIC/PRIVATE)"),
-						fieldWithPath("data.reviews.bestReviewInfos[].reviewImageUrl").description("베스트 리뷰 이미지 URL"),
-						fieldWithPath("data.reviews.bestReviewInfos[].createAt").description("베스트 리뷰 작성 날짜"),
+						fieldWithPath("data.reviewList.totalReviewCount").description("해당 술의 총 리뷰 수"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].userId").description("베스트 리뷰 작성자 ID"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].imageUrl").description("베스트 리뷰 작성자 프로필 이미지 URL"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].nickName").description("베스트 리뷰 작성자 닉네임"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].reviewId").description("베스트 리뷰 ID"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].reviewContent").description("베스트 리뷰 내용"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].rating").description("베스트 리뷰 평점"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].sizeType").optional().description("베스트 리뷰 사이즈 타입"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].price").description("베스트 리뷰 가격"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].viewCount").description("베스트 리뷰 조회수"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].likeCount").description("베스트 리뷰 좋아요 수"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].isLikedByMe").description("베스트 리뷰 내가 좋아요를 눌렀는지 여부"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].replyCount").description("베스트 리뷰 댓글 수"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].hasReplyByMe").description("베스트 리뷰 내가 댓글을 달았는지 여부"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].status").description("리뷰 공개 비공개 여부 (PUBLIC/PRIVATE)"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].reviewImageUrl").description("베스트 리뷰 이미지 URL"),
+						fieldWithPath("data.reviewList.bestReviewInfos[].createAt").description("베스트 리뷰 작성 날짜"),
 
-						fieldWithPath("data.reviews.recentReviewInfos[].userId").description("최신 리뷰 작성자 ID"),
-						fieldWithPath("data.reviews.recentReviewInfos[].imageUrl").description("최신 리뷰 작성자 프로필 이미지 URL"),
-						fieldWithPath("data.reviews.recentReviewInfos[].nickName").description("최신 리뷰 작성자 닉네임"),
-						fieldWithPath("data.reviews.recentReviewInfos[].reviewId").description("최신 리뷰 ID"),
-						fieldWithPath("data.reviews.recentReviewInfos[].reviewContent").description("최신 리뷰 내용"),
-						fieldWithPath("data.reviews.recentReviewInfos[].rating").description("최신 리뷰 평점"),
-						fieldWithPath("data.reviews.recentReviewInfos[].sizeType").optional().description("최신 리뷰 사이즈 타입"),
-						fieldWithPath("data.reviews.recentReviewInfos[].price").description("최신 리뷰 가격"),
-						fieldWithPath("data.reviews.recentReviewInfos[].viewCount").description("최신 리뷰 조회수"),
-						fieldWithPath("data.reviews.recentReviewInfos[].likeCount").description("최신 리뷰 좋아요 수"),
-						fieldWithPath("data.reviews.recentReviewInfos[].isLikedByMe").description("최신 리뷰 내가 좋아요를 눌렀는지 여부"),
-						fieldWithPath("data.reviews.recentReviewInfos[].replyCount").description("최신 리뷰 댓글 수"),
-						fieldWithPath("data.reviews.recentReviewInfos[].hasReplyByMe").description("최신 리뷰 내가 댓글을 달았는지 여부"),
-						fieldWithPath("data.reviews.recentReviewInfos[].status").description("리뷰 공개 비공개 여부 (PUBLIC/PRIVATE)"),
-						fieldWithPath("data.reviews.recentReviewInfos[].reviewImageUrl").description("최신 리뷰 이미지 URL"),
-						fieldWithPath("data.reviews.recentReviewInfos[].createAt").description("최신 리뷰 작성 날짜"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].userId").description("최신 리뷰 작성자 ID"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].imageUrl").description("최신 리뷰 작성자 프로필 이미지 URL"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].nickName").description("최신 리뷰 작성자 닉네임"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].reviewId").description("최신 리뷰 ID"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].reviewContent").description("최신 리뷰 내용"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].rating").description("최신 리뷰 평점"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].sizeType").optional().description("최신 리뷰 사이즈 타입"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].price").description("최신 리뷰 가격"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].viewCount").description("최신 리뷰 조회수"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].likeCount").description("최신 리뷰 좋아요 수"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].isLikedByMe").description("최신 리뷰 내가 좋아요를 눌렀는지 여부"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].replyCount").description("최신 리뷰 댓글 수"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].hasReplyByMe").description("최신 리뷰 내가 댓글을 달았는지 여부"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].status").description("리뷰 공개 비공개 여부 (PUBLIC/PRIVATE)"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].reviewImageUrl").description("최신 리뷰 이미지 URL"),
+						fieldWithPath("data.reviewList.recentReviewInfos[].createAt").description("최신 리뷰 작성 날짜"),
 
 						fieldWithPath("errors").ignored(),
 						fieldWithPath("meta.serverVersion").ignored(),


### PR DESCRIPTION
Resolves #{이슈-번호}

#219 

# 해결하려는 문제가 무엇인가요?
- 아래 두 API의 필드명이 다르게 설정되어 있어서 reviewList로 통일했습니다.
GET /api/v1/reviews/{alcoholId}, GET /api/v1/reviews/me/{alcoholId}의 data.reviewList
GET /api/v1/alcohols/{alcoholsId}의 data.reviews

- 리뷰 목록 조회, 내가 작성한 리뷰 API 응답에 베스트리뷰 여부 필드를 추가했고, 로직이 수정되었습니다.
- 베스트 리뷰를 조회하는 쿼리가 여러 API에서 중복되어 추후 Redis나 DB에 저장해서 쓰는 것이 더 좋아보입니다.


# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
