### PR TITLE
Hotfix 내가 작성한 리뷰 total count 오류수정

### DIFF
--- a/src/main/java/app/bottlenote/review/repository/ReviewQuerySupporter.java
+++ b/src/main/java/app/bottlenote/review/repository/ReviewQuerySupporter.java
@@ -129,6 +129,9 @@ public class ReviewQuerySupporter {
 	}
 
 	public BooleanExpression isBestReviewSubquery(Long bestReviewId, NumberExpression<Long> reviewId) {
+		if (bestReviewId == null) {
+			return reviewId.isNull();
+		}
 		return reviewId.eq(bestReviewId);
 	}
 

--- a/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/review/repository/custom/CustomReviewRepositoryImpl.java
@@ -177,7 +177,9 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 		Long totalCount = queryFactory
 			.select(review.id.count())
 			.from(review)
-			.where(review.userId.eq(userId).and(review.activeStatus.eq(ACTIVE)))
+			.where(review.userId.eq(userId)
+				.and(review.alcoholId.eq(alcoholId))
+				.and(review.activeStatus.eq(ACTIVE)))
 			.fetchOne();
 
 		CursorPageable cursorPageable = getCursorPageable(pageableRequest, fetch);


### PR DESCRIPTION

# 해결하려는 문제가 무엇인가요?
- 내가 작성한 리뷰 조회 API에서 totalCount가 정상적으로 출력되지 않은 오류를 해결했습니다.
- 베스트 리뷰 여부를 체크하는 로직에서 `org.springframework.dao.InvalidDataAccessApiUsageException: eq(null) is not allowed. Use isNull() instead` 예외가 발생하여 Null 체크 로직을 추가해서 해결했습니다
## 참고 자료

-

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
