### PR TITLE
fix  : 한 이메일로 여러 소셜타입에 가입했을 때 로그인이 되지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/app/bottlenote/global/security/customPrincipal/CustomUserDetailsService.java
+++ b/src/main/java/app/bottlenote/global/security/customPrincipal/CustomUserDetailsService.java
@@ -1,7 +1,12 @@
 package app.bottlenote.global.security.customPrincipal;
 
 import app.bottlenote.user.domain.User;
+import app.bottlenote.user.domain.constant.SocialType;
+import app.bottlenote.user.exception.UserException;
+import app.bottlenote.user.exception.UserExceptionCode;
 import app.bottlenote.user.repository.OauthRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -9,9 +14,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +24,19 @@ public class CustomUserDetailsService implements UserDetailsService {
 	@Override
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-		User customUser = oauthRepository.findByEmail(email).get();
+		User customUser = oauthRepository.findByEmail(email)
+			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new SimpleGrantedAuthority(customUser.getRole().toString()));
+
+		return new CustomUserContext(customUser, authorities);
+	}
+
+	public UserDetails loadUserByUsernameAndSocialType(String email, SocialType socialType) throws UsernameNotFoundException {
+
+		User customUser = oauthRepository.findByEmailAndSocialType(email, socialType)
+			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 
 		List<GrantedAuthority> authorities = new ArrayList<>();
 		authorities.add(new SimpleGrantedAuthority(customUser.getRole().toString()));

--- a/src/main/java/app/bottlenote/global/security/jwt/JwtAuthenticationManager.java
+++ b/src/main/java/app/bottlenote/global/security/jwt/JwtAuthenticationManager.java
@@ -5,6 +5,7 @@ import static app.bottlenote.user.exception.UserExceptionCode.INVALID_TOKEN;
 import static java.util.stream.Collectors.toList;
 
 import app.bottlenote.global.security.customPrincipal.CustomUserDetailsService;
+import app.bottlenote.user.domain.constant.SocialType;
 import app.bottlenote.user.exception.UserException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -58,8 +59,10 @@ public class JwtAuthenticationManager {
 			.map(String::trim)
 			.map(SimpleGrantedAuthority::new)
 			.collect(toList());
-
-		UserDetails userDetails = customUserDetailsService.loadUserByUsername(claims.getSubject());
+		
+		UserDetails userDetails = customUserDetailsService.loadUserByUsernameAndSocialType(
+			claims.getSubject(),
+			SocialType.parsing((String) claims.get("socialType")));
 
 		return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);
 	}

--- a/src/main/java/app/bottlenote/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/app/bottlenote/global/security/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package app.bottlenote.global.security.jwt;
 
+import app.bottlenote.user.domain.constant.SocialType;
 import app.bottlenote.user.domain.constant.UserType;
 import app.bottlenote.user.dto.response.TokenDto;
 import io.jsonwebtoken.Claims;
@@ -43,9 +44,9 @@ public class JwtTokenProvider {
 	 * @param userId    유저 고유 아이디
 	 * @return OauthResponse ( 엑세스 토큰과 리프레시 토큰을 담은 객체 )
 	 */
-	public TokenDto generateToken(String userEmail, UserType role, Long userId) {
-		String accessToken = createAccessToken(userEmail, role, userId);
-		String refreshToken = createRefreshToken(userEmail, role, userId);
+	public TokenDto generateToken(String userEmail, SocialType socialType, UserType role, Long userId) {
+		String accessToken = createAccessToken(userEmail, socialType, role, userId);
+		String refreshToken = createRefreshToken(userEmail, socialType, role, userId);
 		return TokenDto.builder()
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)
@@ -60,8 +61,8 @@ public class JwtTokenProvider {
 	 * @param userId    유저 고유 아이디
 	 * @return access token ( 엑세스 토큰 )
 	 */
-	public String createAccessToken(String userEmail, UserType role, Long userId) {
-		Claims claims = createClaims(userEmail, role, userId);
+	public String createAccessToken(String userEmail, SocialType socialType, UserType role, Long userId) {
+		Claims claims = createClaims(userEmail, socialType, role, userId);
 		Date now = new Date();
 		return Jwts.builder()
 			.setClaims(claims)
@@ -79,8 +80,8 @@ public class JwtTokenProvider {
 	 * @param userId    유저 고유 아이디
 	 * @return refresh token ( 리프레시 토큰 )
 	 */
-	public String createRefreshToken(String userEmail, UserType role, Long userId) {
-		Claims claims = createClaims(userEmail, role, userId);
+	public String createRefreshToken(String userEmail, SocialType socialType, UserType role, Long userId) {
+		Claims claims = createClaims(userEmail, socialType, role, userId);
 		Date now = new Date();
 		return Jwts.builder()
 			.setClaims(claims)
@@ -98,9 +99,11 @@ public class JwtTokenProvider {
 	 * @param userId    유저 고유 아이디
 	 * @return 클레임 객체 ( 토큰에 담을 정보 )
 	 */
-	private Claims createClaims(String userEmail, UserType role, Long userId) {
-		Claims claims = Jwts.claims().setSubject(userEmail);
+	private Claims createClaims(String userEmail, SocialType socialType, UserType role, Long userId) {
+		Claims claims = Jwts.claims()
+			.setSubject(userEmail);
 		claims.put(KEY_ROLES, role.name());
+		claims.put("socialType", socialType.name());
 		claims.put("userId", userId);
 		return claims;
 	}

--- a/src/main/java/app/bottlenote/user/domain/User.java
+++ b/src/main/java/app/bottlenote/user/domain/User.java
@@ -10,6 +10,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,13 +20,14 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.Comment;
 
-import java.util.Objects;
-
 @ToString(of = {"id", "email", "nickName", "age"})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Comment("사용자 정보 테이블")
 @Entity(name = "users")
+@Table(name = "users", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"email", "social_type"})
+})
 public class User {
 
 	@Id
@@ -32,7 +36,7 @@ public class User {
 	private Long id;
 
 	@Comment("사용자 이메일")
-	@Column(name = "email", nullable = false, unique = true)
+	@Column(name = "email", nullable = false)
 	private String email;
 
 	@Comment("사용자 닉네임")

--- a/src/main/java/app/bottlenote/user/service/OauthService.java
+++ b/src/main/java/app/bottlenote/user/service/OauthService.java
@@ -1,5 +1,7 @@
 package app.bottlenote.user.service;
 
+import static app.bottlenote.user.exception.UserExceptionCode.INVALID_REFRESH_TOKEN;
+
 import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
 import app.bottlenote.global.security.jwt.JwtTokenProvider;
 import app.bottlenote.global.security.jwt.JwtTokenValidator;
@@ -16,8 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static app.bottlenote.user.exception.UserExceptionCode.INVALID_REFRESH_TOKEN;
 
 
 @Slf4j
@@ -52,7 +52,7 @@ public class OauthService {
 			user = optionalUser;
 		}
 
-		TokenDto token = jwtTokenProvider.generateToken(user.getEmail(), user.getRole(), user.getId());
+		TokenDto token = jwtTokenProvider.generateToken(user.getEmail(), user.getSocialType(), user.getRole(), user.getId());
 
 		//재 로그인시 발급된 refresh token 업데이트
 		user.updateRefreshToken(token.getRefreshToken());
@@ -98,8 +98,11 @@ public class OauthService {
 		User user = oauthRepository.findByRefreshToken(refreshToken).orElseThrow(
 			() -> new UserException(INVALID_REFRESH_TOKEN)
 		);
-		TokenDto reissuedToken = jwtTokenProvider.generateToken(user.getEmail(),
-			user.getRole(), user.getId());
+		TokenDto reissuedToken = jwtTokenProvider.generateToken(
+			user.getEmail(),
+			user.getSocialType(),
+			user.getRole(),
+			user.getId());
 
 		// DB에 저장된 refresh 토큰을 재발급한 refresh 토큰으로 업데이트
 		user.updateRefreshToken(reissuedToken.getRefreshToken());


### PR DESCRIPTION
Resolves #{이슈-번호}
#234 

# 해결하려는 문제가 무엇인가요?

- 하나의 이메일로 여러 소셜타입에 가입한 경우 첫번째 소셜타입으로는 회원가입이 되지만, 해당 이메일을 사용하는 다른 소셜타입으로는 회원가입이 불가능합니다.
- Email 컬럼에 Unique 제약조건이 걸려있어서 발생한 문제입니다.

# 어떻게 해결했나요?
- Email 컬럼의 유니크 제약조건을 해제하고, Email과 SocialType을 복합 유니크 제약조건으로 설정했습니다.
- Email 컬럼의 유니크 제약조건을 해제하는 것 뿐 아니라, 복합 유니크 키를 설정해서 DB에서 확실하게 Email + SocialType의 조합으로 유일성을 만족시켜야 할 필요가 있다고 판단했습니다.

- 토큰 생성 로직에서 에서 SocialType을 추가하도록 로직을 변경했습니다.
- 토큰 파싱 로직에서도 SocialType을 추출하도록 수정했습니다.
- 토큰의 길이가 길어져 refresh_token의 컬럼 길이를 255에서 512로 수정해야 합니다.
- 현재 POSTMAN으로 같은 이메일에서 다른 소셜타입으로 로그인 후, 리뷰 등록 및 내가 작성한 리뷰 정상적으로 조회되는 것을 확인했고, 통합 테스트 작성중입니다.


# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
