### PR TITLE
hotfix : 도로명주소 not null 조건 삭제

### DIFF
--- a/src/main/java/app/bottlenote/review/dto/request/LocationInfo.java
+++ b/src/main/java/app/bottlenote/review/dto/request/LocationInfo.java
@@ -1,15 +1,11 @@
 package app.bottlenote.review.dto.request;
 
-import jakarta.validation.constraints.NotNull;
-
 public record LocationInfo(
 
 	String locationName,
 
-	@NotNull(message = "STREET_ADDRESS_REQUIRED")
 	String streetAddress,
 
-	//TODO : Enum으로 관리 필요
 	String category,
 
 	String mapUrl,


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- 프론트의 요청으로 리뷰 등록 시 입력하는 주소 값들 중 도로명 주소를 nullable하게 수정합니다.
---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
