### PR TITLE
hotfix : 알코올 서포터에서 alcohos info 에서 pick 여부가 unpick이여도 true로 나오는 문제 발생 수정 

### DIFF
--- a/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
+++ b/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
@@ -1,5 +1,11 @@
 package app.bottlenote.alcohols.repository;
 
+import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
+import static app.bottlenote.picks.domain.PicksStatus.PICK;
+import static app.bottlenote.picks.domain.QPicks.picks;
+import static app.bottlenote.rating.domain.QRating.rating;
+import static app.bottlenote.review.domain.QReview.review;
+
 import app.bottlenote.alcohols.domain.constant.AlcoholCategoryGroup;
 import app.bottlenote.alcohols.domain.constant.SearchSortType;
 import app.bottlenote.alcohols.dto.dsl.AlcoholSearchCriteria;
@@ -15,15 +21,9 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.JPAExpressions;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.Objects;
-
-import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
-import static app.bottlenote.picks.domain.QPicks.picks;
-import static app.bottlenote.rating.domain.QRating.rating;
-import static app.bottlenote.review.domain.QReview.review;
+import org.springframework.stereotype.Component;
 
 @Component
 public class AlcoholQuerySupporter {
@@ -49,15 +49,14 @@ public class AlcoholQuerySupporter {
 	}
 
 	public BooleanExpression isPickedSubquery(Long alcoholId, Long userId) {
-
-		BooleanExpression eqUserId = userId == null ?
-			picks.user.id.isNull() : picks.user.id.eq(userId);
-
+		if (userId == -1) {
+			return Expressions.asBoolean(false);
+		}
 		return Expressions.asBoolean(
 			JPAExpressions
 				.selectOne()
 				.from(picks)
-				.where(picks.alcohol.id.eq(alcoholId).and(eqUserId))
+				.where(picks.alcohol.id.eq(alcoholId).and(picks.user.id.eq(userId)).and(picks.status.eq(PICK)))
 				.exists()
 		).as("isPicked");
 	}


### PR DESCRIPTION
…ser.id == PICK)

Resolves #{이슈-번호}
#265 
# 해결하려는 문제가 무엇인가요?

- 알코올 서포터에서 alcohos info 에서 pick 여부가 unpick이여도 true로 나오는 문제 발생 수정 필요.

# 어떻게 해결했나요?

- 미로그인 시 (userid == -1) 일 때 항상 false를 리턴하도록 수정
- 로그인 시 파라미터로 넘어온 alcohol.id == user.id 이외에 status가 PICK인 and 조건을 만족시켜야만 true를 반환하도록 수정

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
