### PR TITLE
Hotfix : fix wrong query in user history api

### DIFF
--- a/src/main/java/app/bottlenote/history/dto/request/HistoryReviewFilterType.java
+++ b/src/main/java/app/bottlenote/history/dto/request/HistoryReviewFilterType.java
@@ -3,6 +3,7 @@ package app.bottlenote.history.dto.request;
 public enum HistoryReviewFilterType {
 	ALL,
 	BEST_REVIEW,
+	REVIEW_CREATE,
 	REVIEW_LIKE,
 	REVIEW_REPLY
 }

--- a/src/main/java/app/bottlenote/history/dto/request/UserHistorySearchRequest.java
+++ b/src/main/java/app/bottlenote/history/dto/request/UserHistorySearchRequest.java
@@ -9,7 +9,6 @@ import app.bottlenote.rating.domain.RatingPoint;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,25 +46,18 @@ public record UserHistorySearchRequest(
 		List<EventType> eventTypes = new ArrayList<>();
 		for (HistoryReviewFilterType filterType : historyReviewFilterType) {
 			switch (filterType) {
-				case ALL:
-					eventTypes.addAll(Arrays.asList(
-						EventType.REVIEW_LIKES,
+				case ALL -> eventTypes.addAll(
+					List.of(
 						EventType.REVIEW_CREATE,
 						EventType.BEST_REVIEW_SELECTED,
+						EventType.REVIEW_CREATE,
+						EventType.REVIEW_LIKES,
 						EventType.REVIEW_REPLY_CREATE
 					));
-					break;
-				case BEST_REVIEW:
-					eventTypes.add(EventType.BEST_REVIEW_SELECTED);
-					break;
-				case REVIEW_LIKE:
-					eventTypes.add(EventType.REVIEW_LIKES);
-					break;
-				case REVIEW_REPLY:
-					eventTypes.add(EventType.REVIEW_REPLY_CREATE);
-					break;
-				default:
-					break;
+				case BEST_REVIEW -> eventTypes.add(EventType.BEST_REVIEW_SELECTED);
+				case REVIEW_CREATE -> eventTypes.add(EventType.REVIEW_CREATE);
+				case REVIEW_LIKE -> eventTypes.add(EventType.REVIEW_LIKES);
+				case REVIEW_REPLY -> eventTypes.add(EventType.REVIEW_REPLY_CREATE);
 			}
 		}
 		return eventTypes;

--- a/src/main/java/app/bottlenote/history/repository/CustomUserHistoryRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/history/repository/CustomUserHistoryRepositoryImpl.java
@@ -2,13 +2,17 @@ package app.bottlenote.history.repository;
 
 import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
 import static app.bottlenote.history.domain.QUserHistory.userHistory;
+import static app.bottlenote.history.domain.constant.EventType.IS_PICK;
+import static app.bottlenote.history.domain.constant.EventType.RATING_DELETE;
+import static app.bottlenote.history.domain.constant.EventType.RATING_MODIFY;
+import static app.bottlenote.history.domain.constant.EventType.START_RATING;
+import static app.bottlenote.history.domain.constant.EventType.UNPICK;
 import static app.bottlenote.picks.domain.QPicks.picks;
 import static app.bottlenote.rating.domain.QRating.rating;
 import static app.bottlenote.user.domain.QUser.user;
 
 import app.bottlenote.global.service.cursor.CursorPageable;
 import app.bottlenote.global.service.cursor.PageResponse;
-import app.bottlenote.history.domain.constant.EventType;
 import app.bottlenote.history.dto.request.UserHistorySearchRequest;
 import app.bottlenote.history.dto.response.UserHistoryDetail;
 import app.bottlenote.history.dto.response.UserHistorySearchResponse;
@@ -56,11 +60,14 @@ public class CustomUserHistoryRepositoryImpl implements CustomUserHistoryReposit
 			.where(
 				userHistory.userId.eq(userId),
 				isValidKeyword(request.keyword()) ? alcohol.korName.like("%" + request.keyword() + "%") : null,
-				request.ratingPoint() == null ? null : rating.ratingPoint.in(request.ratingPoint()),
-				request.picksStatus() == null ? null :
-					userHistory.eventType.in(
-						request.picksStatus().stream()
-							.map(status -> status == PicksStatus.PICK ? EventType.IS_PICK : EventType.UNPICK)
+				request.ratingPoint() == null ? null
+					: rating.ratingPoint.in(request.ratingPoint())
+						.andAnyOf(userHistory.eventType.in(START_RATING, RATING_MODIFY, RATING_DELETE)),
+				request.picksStatus() == null ? null
+					: userHistory.eventType.in(
+						request.picksStatus()
+							.stream()
+							.map(status -> status == PicksStatus.PICK ? IS_PICK : UNPICK)
 							.toList()
 					),
 				request.startDate() == null ? null : userHistory.createAt.goe(request.startDate()),


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- History 조회 API 호출 시 RATING 조건으로만 검색했을때, REVIEW_CREATE 등 이벤트타입도 함께 조회되는 이슈
- reviewFilterType에 REVIEW_CREATE가 누락되어 있어 추가
# 어떻게 해결했나요?

- userSearchReqeust객체의 rating이 null이 아닐때 eventType.in(RATING...) 등으로 조건절에 eventType이 RATING과 관련된 타입인 것들만 조회하도록 AND절 추가 

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
