### PR TITLE
hotfix : fix wrong dynamic query

### DIFF
--- a/src/main/java/app/bottlenote/history/repository/CustomUserHistoryRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/history/repository/CustomUserHistoryRepositoryImpl.java
@@ -13,13 +13,18 @@ import static app.bottlenote.user.domain.QUser.user;
 
 import app.bottlenote.global.service.cursor.CursorPageable;
 import app.bottlenote.global.service.cursor.PageResponse;
+import app.bottlenote.history.domain.constant.EventType;
 import app.bottlenote.history.dto.request.UserHistorySearchRequest;
 import app.bottlenote.history.dto.response.UserHistoryDetail;
 import app.bottlenote.history.dto.response.UserHistorySearchResponse;
 import app.bottlenote.picks.domain.PicksStatus;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,6 +39,56 @@ public class CustomUserHistoryRepositoryImpl implements CustomUserHistoryReposit
 
 	@Override
 	public PageResponse<UserHistorySearchResponse> findUserHistoryListByUserId(Long userId, UserHistorySearchRequest request) {
+
+		// 요청에 따른 eventType 필터 구성
+		final List<EventType> eventTypeFilters = new ArrayList<>();
+		if (request.ratingPoint() != null) {
+			eventTypeFilters.addAll(Arrays.asList(START_RATING, RATING_MODIFY, RATING_DELETE));
+		}
+		if (request.picksStatus() != null) {
+			eventTypeFilters.addAll(
+				request.picksStatus()
+					.stream()
+					.map(status -> status == PicksStatus.PICK ? IS_PICK : UNPICK)
+					.toList()
+			);
+		}
+		if (request.historyReviewFilterType() != null) {
+			eventTypeFilters.addAll(request.toEventTypeList());
+		}
+
+		// ratingPoint가 있을 경우 dynamicMessage의 currentValue 조건 생성
+		BooleanExpression ratingDynamicCondition = null;
+		if (request.ratingPoint() != null && !request.ratingPoint().isEmpty()) {
+			ratingDynamicCondition = request.ratingPoint().stream()
+				.map(point -> Expressions.stringTemplate(
+					"JSON_UNQUOTE(JSON_EXTRACT({0}, '$.currentValue'))", userHistory.dynamicMessage
+				).eq(point.toString()))
+				.reduce(BooleanExpression::or)
+				.orElse(null);
+		}
+
+		// rating 이벤트(평점 이벤트)는 반드시 dynamicMessage 조건을 만족해야 함
+		BooleanExpression ratingEventCondition = null;
+		if (ratingDynamicCondition != null) {
+			ratingEventCondition = userHistory.eventType.in(START_RATING, RATING_MODIFY, RATING_DELETE)
+				.and(ratingDynamicCondition);
+		}
+
+		// rating 이벤트가 아닌 경우(예: PICK 등)는 dynamic 조건 없이 조회
+		BooleanExpression nonRatingEventCondition = userHistory.eventType.notIn(START_RATING, RATING_MODIFY, RATING_DELETE);
+
+		// 두 조건을 OR로 결합 – rating 이벤트인 경우에는 dynamic 조건을 적용하고, 그 외는 그대로 통과
+		BooleanExpression combinedEventCondition = ratingEventCondition != null
+			? ratingEventCondition.or(nonRatingEventCondition)
+			: null;
+
+		// 기본 userId 조건에 이벤트 조건을 추가
+		BooleanExpression condition = userHistory.userId.eq(userId);
+		if (combinedEventCondition != null) {
+			condition = condition.and(combinedEventCondition);
+		}
+
 		final List<UserHistoryDetail> fetch = queryFactory
 			.select(
 				Projections.constructor(
@@ -58,21 +113,11 @@ public class CustomUserHistoryRepositoryImpl implements CustomUserHistoryReposit
 			.leftJoin(picks).on(userHistory.alcoholId.eq(picks.alcoholId)
 				.and(picks.userId.eq(userId)))
 			.where(
-				userHistory.userId.eq(userId),
+				condition,
 				isValidKeyword(request.keyword()) ? alcohol.korName.like("%" + request.keyword() + "%") : null,
-				request.ratingPoint() == null ? null
-					: rating.ratingPoint.in(request.ratingPoint())
-						.andAnyOf(userHistory.eventType.in(START_RATING, RATING_MODIFY, RATING_DELETE)),
-				request.picksStatus() == null ? null
-					: userHistory.eventType.in(
-						request.picksStatus()
-							.stream()
-							.map(status -> status == PicksStatus.PICK ? IS_PICK : UNPICK)
-							.toList()
-					),
 				request.startDate() == null ? null : userHistory.createAt.goe(request.startDate()),
 				request.endDate() == null ? null : userHistory.createAt.loe(request.endDate()),
-				request.historyReviewFilterType() == null ? null : userHistory.eventType.in(request.toEventTypeList())
+				eventTypeFilters.isEmpty() ? null : userHistory.eventType.in(eventTypeFilters)
 			)
 			.orderBy(request.sortOrder().resolve(userHistory.createAt))
 			.offset(request.cursor())


### PR DESCRIPTION

# 해결하려는 문제가 무엇인가요?

- 필터링 조건의 별점이 기존에는 rating 테이블을 바라보고 있음
- rating 테이블이 아닌 userHistory 테이블의 json 형태의 dynamicMessage 컬럼의 currentValue를 기준으로 조회하도록 수정
- 필터링 조건을 여러개 선택했을때 where절 오류 수정 

**postman 테스트 완료**
---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
