### PR TITLE
hotfix : fix retrieve follower api query

### DIFF
--- a/src/main/java/app/bottlenote/user/dto/response/RelationUserInfo.java
+++ b/src/main/java/app/bottlenote/user/dto/response/RelationUserInfo.java
@@ -13,4 +13,10 @@ public record RelationUserInfo(
 	Long reviewCount,
 	Long ratingCount
 ) {
+
+	public RelationUserInfo(Long userId, Long followUserId, String followUserNickname, String userProfileImage,
+		String status, Long reviewCount, Long ratingCount) {
+		this(userId, followUserId, followUserNickname, userProfileImage,
+			FollowStatus.parsing(status), reviewCount, ratingCount);
+	}
 }


### PR DESCRIPTION
- status 값을 유저 기준 상대방을 팔로우하고 있는지 수정


# 해결하려는 문제가 무엇인가요?

- 나를 팔로우하는 유저 조회 API에서 status 값이 잘못 설정되는 오류
- status 값은 나 기준으로 내가 상대방을 팔로우하는 지 여부임.

# 어떻게 해결했나요?

- Select 절 서브쿼리로 status값 별도로 조회

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
