### PR TITLE
Fix retrieve my-page api

### DIFF
--- a/src/main/java/app/bottlenote/user/domain/User.java
+++ b/src/main/java/app/bottlenote/user/domain/User.java
@@ -22,14 +22,21 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.Comment;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 
 @Getter
 @ToString(of = {"id", "email", "nickName", "age", "socialType"})
 @Comment("사용자 정보 테이블")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "users")
-@Where(clause = "status = 'ACTIVE'")
+@FilterDef(
+	name = "statusFilter",
+	parameters = @ParamDef(name = "userStatus", type = String.class),
+	defaultCondition = "status = :userStatus"
+)
+@Filter(name = "statusFilter")
 public class User extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/app/bottlenote/user/domain/User.java
+++ b/src/main/java/app/bottlenote/user/domain/User.java
@@ -13,22 +13,23 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.Comment;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import org.hibernate.annotations.Where;
 
 @Getter
 @ToString(of = {"id", "email", "nickName", "age", "socialType"})
 @Comment("사용자 정보 테이블")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "users")
+@Where(clause = "status = 'ACTIVE'")
 public class User extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/app/bottlenote/user/dto/response/MyPageResponse.java
+++ b/src/main/java/app/bottlenote/user/dto/response/MyPageResponse.java
@@ -2,9 +2,8 @@ package app.bottlenote.user.dto.response;
 
 import lombok.Builder;
 
-
+@Builder
 public record MyPageResponse(
-
 	Long userId,
 	String nickName,
 	String imageUrl,
@@ -15,10 +14,5 @@ public record MyPageResponse(
 	Long followingCount,
 	Boolean isFollow,
 	Boolean isMyPage
-
-
 ) {
-	@Builder
-	public MyPageResponse {
-	}
 }

--- a/src/main/java/app/bottlenote/user/repository/CustomUserRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/user/repository/CustomUserRepositoryImpl.java
@@ -1,23 +1,21 @@
 package app.bottlenote.user.repository;
 
+import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
 import app.bottlenote.global.service.cursor.CursorPageable;
+import static app.bottlenote.picks.domain.PicksStatus.PICK;
+import static app.bottlenote.picks.domain.QPicks.picks;
+import static app.bottlenote.rating.domain.QRating.rating;
+import static app.bottlenote.review.domain.QReview.review;
 import app.bottlenote.review.domain.constant.ReviewActiveStatus;
+import static app.bottlenote.user.domain.QUser.user;
 import app.bottlenote.user.dto.dsl.MyBottlePageableCriteria;
 import app.bottlenote.user.dto.response.MyBottleResponse;
 import app.bottlenote.user.dto.response.MyPageResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.List;
-
-import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
-import static app.bottlenote.picks.domain.PicksStatus.PICK;
-import static app.bottlenote.picks.domain.QPicks.picks;
-import static app.bottlenote.rating.domain.QRating.rating;
-import static app.bottlenote.review.domain.QReview.review;
-import static app.bottlenote.user.domain.QUser.user;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -45,10 +43,10 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
 				supporter.reviewCountSubQuery(user.id),     // 마이 페이지 사용자의 리뷰 개수
 				supporter.ratingCountSubQuery(user.id),     // 마이 페이지 사용자의 평점 개수
 				supporter.picksCountSubQuery(user.id),      // 마이 페이지 사용자의 찜하기 개수
-				supporter.followCountSubQuery(user.id),     // 마이 페이지 사용자가 팔로우 하는 유저 수
+				supporter.followingCountSubQuery(user.id),     // 마이 페이지 사용자가 팔로우 하는 유저 수
 				supporter.followerCountSubQuery(user.id),   //  마이 페이지 사용자를 팔로우 하는 유저 수
 				supporter.isFollowSubQuery(user.id, currentUserId), // 로그인 사용자가 마이 페이지 사용자를 팔로우 하고 있는지 여부
-				supporter.isMyPageSubQuery(user.id, currentUserId) // 로그인 사용자가 마이 페이지 사용자인지 여부(나의 마이페이지인지 여부)
+				supporter.isMyPageSubQuery(userId, currentUserId) // 로그인 사용자가 마이 페이지 사용자인지 여부(나의 마이페이지인지 여부)
 			))
 			.from(user)
 			.where(user.id.eq(userId))

--- a/src/main/java/app/bottlenote/user/repository/OauthRepository.java
+++ b/src/main/java/app/bottlenote/user/repository/OauthRepository.java
@@ -22,9 +22,6 @@ public interface OauthRepository extends CrudRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
 
-	@Query(value = "SELECT * FROM users WHERE email = :email", nativeQuery = true)
-	Optional<User> findByEmailIncludingWithdrawn(@Param("email") String email);
-
 	Optional<User> findByRefreshToken(String refreshToken);
 
 	@Query("select u from users  u order by u.id limit 1")

--- a/src/main/java/app/bottlenote/user/repository/OauthRepository.java
+++ b/src/main/java/app/bottlenote/user/repository/OauthRepository.java
@@ -2,10 +2,9 @@ package app.bottlenote.user.repository;
 
 import app.bottlenote.user.domain.User;
 import feign.Param;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
-
-import java.util.Optional;
 
 public interface OauthRepository extends CrudRepository<User, Long> {
 
@@ -22,6 +21,9 @@ public interface OauthRepository extends CrudRepository<User, Long> {
 	Optional<User> findByNickName(String nickName);
 
 	Optional<User> findByEmail(String email);
+
+	@Query(value = "SELECT * FROM users WHERE email = :email", nativeQuery = true)
+	Optional<User> findByEmailIncludingWithdrawn(@Param("email") String email);
 
 	Optional<User> findByRefreshToken(String refreshToken);
 

--- a/src/main/java/app/bottlenote/user/service/OauthService.java
+++ b/src/main/java/app/bottlenote/user/service/OauthService.java
@@ -1,8 +1,10 @@
 package app.bottlenote.user.service;
 
+import static app.bottlenote.global.security.jwt.JwtTokenValidator.validateToken;
+import static app.bottlenote.user.exception.UserExceptionCode.INVALID_REFRESH_TOKEN;
+
 import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
 import app.bottlenote.global.security.jwt.JwtTokenProvider;
-import static app.bottlenote.global.security.jwt.JwtTokenValidator.validateToken;
 import app.bottlenote.user.domain.User;
 import app.bottlenote.user.domain.constant.GenderType;
 import app.bottlenote.user.domain.constant.SocialType;
@@ -12,7 +14,6 @@ import app.bottlenote.user.dto.response.BasicAccountResponse;
 import app.bottlenote.user.dto.response.TokenDto;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
-import static app.bottlenote.user.exception.UserExceptionCode.INVALID_REFRESH_TOKEN;
 import app.bottlenote.user.repository.OauthRepository;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -43,7 +44,7 @@ public class OauthService {
 		final GenderType genderType = oauthReq.gender();
 		final Integer age = oauthReq.age();
 
-		User user = oauthRepository.findByEmailIncludingWithdrawn(email).orElseGet(() -> oauthSignUp(email, socialType, genderType, age, UserType.ROLE_USER));
+		User user = oauthRepository.findByEmail(email).orElseGet(() -> oauthSignUp(email, socialType, genderType, age, UserType.ROLE_USER));
 
 		if (Boolean.FALSE.equals(user.isAlive()))
 			throw new UserException(UserExceptionCode.USER_DELETED);
@@ -136,7 +137,7 @@ public class OauthService {
 
 	@Transactional
 	public BasicAccountResponse basicSignup(String email, String password, Integer age, String gender) {
-		oauthRepository.findByEmailIncludingWithdrawn(email).ifPresent(user -> {
+		oauthRepository.findByEmail(email).ifPresent(user -> {
 			throw new UserException(UserExceptionCode.USER_ALREADY_EXISTS);
 		});
 

--- a/src/main/java/app/bottlenote/user/service/UserBasicService.java
+++ b/src/main/java/app/bottlenote/user/service/UserBasicService.java
@@ -1,5 +1,11 @@
 package app.bottlenote.user.service;
 
+import static app.bottlenote.user.domain.constant.UserStatus.ACTIVE;
+import static app.bottlenote.user.dto.response.constant.WithdrawUserResultMessage.USER_WITHDRAW_SUCCESS;
+import static app.bottlenote.user.exception.UserExceptionCode.MYBOTTLE_NOT_ACCESSIBLE;
+import static app.bottlenote.user.exception.UserExceptionCode.MYPAGE_NOT_ACCESSIBLE;
+import static app.bottlenote.user.exception.UserExceptionCode.USER_NOT_FOUND;
+
 import app.bottlenote.user.domain.User;
 import app.bottlenote.user.domain.UserRepository;
 import app.bottlenote.user.dto.dsl.MyBottlePageableCriteria;
@@ -10,12 +16,8 @@ import app.bottlenote.user.dto.response.MyPageResponse;
 import app.bottlenote.user.dto.response.NicknameChangeResponse;
 import app.bottlenote.user.dto.response.ProfileImageChangeResponse;
 import app.bottlenote.user.dto.response.WithdrawUserResultResponse;
-import static app.bottlenote.user.dto.response.constant.WithdrawUserResultMessage.USER_WITHDRAW_SUCCESS;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
-import static app.bottlenote.user.exception.UserExceptionCode.MYBOTTLE_NOT_ACCESSIBLE;
-import static app.bottlenote.user.exception.UserExceptionCode.MYPAGE_NOT_ACCESSIBLE;
-import static app.bottlenote.user.exception.UserExceptionCode.USER_NOT_FOUND;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,79 +29,98 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserBasicService {
 
 	private final UserRepository userRepository;
+	private final UserFilterManager userFilterManager;
 
 	@Transactional
 	public NicknameChangeResponse nicknameChange(Long userId, NicknameChangeRequest request) {
-		String name = request.nickName();
-		String beforeNickname;
 
-		if (userRepository.existsByNickName(name)) {
-			throw new UserException(UserExceptionCode.USER_NICKNAME_NOT_VALID);
-		}
+		return userFilterManager.withActiveUserFilter(ACTIVE,
+			() -> {
+				String name = request.nickName();
+				String beforeNickname;
 
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new UserException(USER_NOT_FOUND));
+				if (userRepository.existsByNickName(name)) {
+					throw new UserException(UserExceptionCode.USER_NICKNAME_NOT_VALID);
+				}
 
-		beforeNickname = user.getNickName();
+				User user = userRepository.findById(userId)
+					.orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
-		user.changeNickName(name);
-		Long updatedUser = user.getId();
-		String newUserNickName = user.getNickName();
+				beforeNickname = user.getNickName();
 
-		return NicknameChangeResponse.builder()
-			.message(NicknameChangeResponse.Message.SUCCESS)
-			.userId(updatedUser)
-			.beforeNickname(beforeNickname)
-			.changedNickname(newUserNickName)
-			.build();
+				user.changeNickName(name);
+				Long updatedUser = user.getId();
+				String newUserNickName = user.getNickName();
+
+				return NicknameChangeResponse.builder()
+					.message(NicknameChangeResponse.Message.SUCCESS)
+					.userId(updatedUser)
+					.beforeNickname(beforeNickname)
+					.changedNickname(newUserNickName)
+					.build();
+			});
 	}
 
 	@Transactional
 	public ProfileImageChangeResponse profileImageChange(Long userId, String viewUrl) {
 
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new UserException(USER_NOT_FOUND));
+		return userFilterManager.withActiveUserFilter(ACTIVE,
+			() -> {
+				User user = userRepository.findById(userId)
+					.orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
-		user.changeProfileImage(viewUrl);
+				user.changeProfileImage(viewUrl);
 
-		return new ProfileImageChangeResponse(user.getId(), user.getImageUrl());
+				return new ProfileImageChangeResponse(user.getId(), user.getImageUrl());
+			});
 	}
 
 	@Transactional
 	public WithdrawUserResultResponse withdrawUser(Long userId) {
 
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new UserException(USER_NOT_FOUND));
+		return userFilterManager.withActiveUserFilter(ACTIVE,
+			() -> {
+				User user = userRepository.findById(userId)
+					.orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
-		user.withdrawUser();
+				user.withdrawUser();
 
-		return WithdrawUserResultResponse.response(USER_WITHDRAW_SUCCESS, userId);
+				return WithdrawUserResultResponse.response(USER_WITHDRAW_SUCCESS, userId);
+			});
 	}
 
 	@Transactional(readOnly = true)
 	public MyPageResponse getMyPage(Long userId, Long currentUserId) {
-		boolean isUserNotAccessible = !userRepository.existsByUserId(userId);
 
-		if (isUserNotAccessible) {
-			throw new UserException(MYPAGE_NOT_ACCESSIBLE);
-		}
-		return userRepository.getMyPage(userId, currentUserId);
+		return userFilterManager.withActiveUserFilter(ACTIVE,
+			() -> {
+				boolean isUserNotAccessible = !userRepository.existsByUserId(userId);
+
+				if (isUserNotAccessible) {
+					throw new UserException(MYPAGE_NOT_ACCESSIBLE);
+				}
+				return userRepository.getMyPage(userId, currentUserId);
+			});
 	}
 
 	@Transactional(readOnly = true)
 	public MyBottleResponse getMyBottle(Long userId, Long currentUserId, MyBottleRequest myBottleRequest) {
-		boolean isUserNotAccessible = !userRepository.existsByUserId(userId);
 
-		if (isUserNotAccessible) {
-			throw new UserException(MYBOTTLE_NOT_ACCESSIBLE);
-		}
+		return userFilterManager.withActiveUserFilter(ACTIVE,
+			() -> {
+				boolean isUserNotAccessible = !userRepository.existsByUserId(userId);
 
-		MyBottlePageableCriteria criteria = MyBottlePageableCriteria.of(
-			myBottleRequest,
-			userId,
-			currentUserId
-		);
+				if (isUserNotAccessible) {
+					throw new UserException(MYBOTTLE_NOT_ACCESSIBLE);
+				}
 
-		return userRepository.getMyBottle(criteria);
+				MyBottlePageableCriteria criteria = MyBottlePageableCriteria.of(
+					myBottleRequest,
+					userId,
+					currentUserId
+				);
+
+				return userRepository.getMyBottle(criteria);
+			});
 	}
 }

--- a/src/main/java/app/bottlenote/user/service/UserBasicService.java
+++ b/src/main/java/app/bottlenote/user/service/UserBasicService.java
@@ -1,10 +1,5 @@
 package app.bottlenote.user.service;
 
-import static app.bottlenote.user.dto.response.constant.WithdrawUserResultMessage.USER_WITHDRAW_SUCCESS;
-import static app.bottlenote.user.exception.UserExceptionCode.MYBOTTLE_NOT_ACCESSIBLE;
-import static app.bottlenote.user.exception.UserExceptionCode.MYPAGE_NOT_ACCESSIBLE;
-import static app.bottlenote.user.exception.UserExceptionCode.USER_NOT_FOUND;
-
 import app.bottlenote.user.domain.User;
 import app.bottlenote.user.domain.UserRepository;
 import app.bottlenote.user.dto.dsl.MyBottlePageableCriteria;
@@ -15,8 +10,12 @@ import app.bottlenote.user.dto.response.MyPageResponse;
 import app.bottlenote.user.dto.response.NicknameChangeResponse;
 import app.bottlenote.user.dto.response.ProfileImageChangeResponse;
 import app.bottlenote.user.dto.response.WithdrawUserResultResponse;
+import static app.bottlenote.user.dto.response.constant.WithdrawUserResultMessage.USER_WITHDRAW_SUCCESS;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
+import static app.bottlenote.user.exception.UserExceptionCode.MYBOTTLE_NOT_ACCESSIBLE;
+import static app.bottlenote.user.exception.UserExceptionCode.MYPAGE_NOT_ACCESSIBLE;
+import static app.bottlenote.user.exception.UserExceptionCode.USER_NOT_FOUND;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -79,15 +78,12 @@ public class UserBasicService {
 
 	@Transactional(readOnly = true)
 	public MyPageResponse getMyPage(Long userId, Long currentUserId) {
-
 		boolean isUserNotAccessible = !userRepository.existsByUserId(userId);
 
 		if (isUserNotAccessible) {
 			throw new UserException(MYPAGE_NOT_ACCESSIBLE);
 		}
-
 		return userRepository.getMyPage(userId, currentUserId);
-
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/app/bottlenote/user/service/UserFilterManager.java
+++ b/src/main/java/app/bottlenote/user/service/UserFilterManager.java
@@ -1,0 +1,44 @@
+package app.bottlenote.user.service;
+
+import app.bottlenote.user.domain.constant.UserStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.Filter;
+import org.hibernate.Session;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserFilterManager {
+
+	private final EntityManager entityManager;
+
+	/**
+	 * 필터를 활성화하고 작업을 수행한 후 이후에 필터를 비활성화
+	 */
+	public <T> T withActiveUserFilter(UserStatus status, java.util.function.Supplier<T> action) {
+		enableStatusFilter(status);
+		try {
+			return action.get();
+		} finally {
+			disableStatusFilter();
+		}
+	}
+
+	/**
+	 * 특정 상태의 유저만 조회하도록 필터를 활성화
+	 */
+	private void enableStatusFilter(UserStatus status) {
+		Session session = entityManager.unwrap(Session.class);
+		Filter filter = session.enableFilter("statusFilter");
+		filter.setParameter("userStatus", status.name());
+	}
+
+	/**
+	 * 필터를 비활성화해서 모든 유저 조회 가능
+	 */
+	private void disableStatusFilter() {
+		Session session = entityManager.unwrap(Session.class);
+		session.disableFilter("statusFilter");
+	}
+}


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

 마이페이지 API의 오류를 수정합니다.

- 팔로잉/팔로워 수 조회 시 FOLLOWING 상태만 카운트하도록 수정했습니다.
- 찜 개수 조회시PICK 상태만 카운트하도록 수정
- 팔로워 팔로잉이 구현이 반대로 되어 있어서 수정
- 탈퇴한 회원의 마이페이지가 조회되지 않도록 UserStatus가 ACTIVE인 조건절 추가

---
- 이 외 다른 닉네임변경, 프사변경 API가 모두 탈퇴한 회원에게도 적용되어 User엔티티에 `@Where(clause = "status = 'ACTIVE'")`를 적용하여 기본적으로 ACTIVE인 유저만 조회하도록 수정 

### @Where 어노테이션을 삭제하고 @Filter 적용

```java
Session session = entityManager.unwrap(Session.class);
		Filter filter = session.enableFilter("statusFilter");
		filter.setParameter("userStatus", status.name());
```
- 필터를 적용하기 위해서 위 코드를 반드시 사용해야하는데, 보일러 플레이트 코드를 피하기 위해서 UserFilterManager를 구현
- 함수형 인터페이스를 사용해서 아래와 같이 파라미터로 필터를 적용할 status를 넘기고, 람다식으로 로직을 수행하도록 구현함
```java
@Transactional(readOnly = true)
	public MyPageResponse getMyPage(Long userId, Long currentUserId) {

		return userFilterManager.withActiveUserFilter(ACTIVE,
			() -> {
				boolean isUserNotAccessible = !userRepository.existsByUserId(userId);

				if (isUserNotAccessible) {
					throw new UserException(MYPAGE_NOT_ACCESSIBLE);
				}
				return userRepository.getMyPage(userId, currentUserId);
			});
	}
```

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
