### PR TITLE
Fix 'isPicked' subquery in alcohol search API

### DIFF
--- a/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
+++ b/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
@@ -1,5 +1,13 @@
 package app.bottlenote.alcohols.repository;
 
+import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
+import static app.bottlenote.alcohols.domain.QAlcoholsTastingTags.alcoholsTastingTags;
+import static app.bottlenote.alcohols.domain.QTastingTag.tastingTag;
+import static app.bottlenote.picks.domain.PicksStatus.PICK;
+import static app.bottlenote.picks.domain.QPicks.picks;
+import static app.bottlenote.rating.domain.QRating.rating;
+import static app.bottlenote.review.domain.QReview.review;
+
 import app.bottlenote.alcohols.domain.constant.AlcoholCategoryGroup;
 import app.bottlenote.alcohols.domain.constant.SearchSortType;
 import app.bottlenote.alcohols.dto.dsl.AlcoholSearchCriteria;
@@ -14,19 +22,12 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.JPAExpressions;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
-import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
-import static app.bottlenote.alcohols.domain.QAlcoholsTastingTags.alcoholsTastingTags;
-import static app.bottlenote.alcohols.domain.QTastingTag.tastingTag;
-import static app.bottlenote.picks.domain.PicksStatus.PICK;
-import static app.bottlenote.picks.domain.QPicks.picks;
-import static app.bottlenote.rating.domain.QRating.rating;
-import static app.bottlenote.review.domain.QReview.review;
-
+@Slf4j
 @Component
 public class AlcoholQuerySupporter {
 
@@ -46,14 +47,17 @@ public class AlcoholQuerySupporter {
 	 * 토큰값이 유효한 경우 좋아요 상태를 나타내는 서브쿼리
 	 */
 	public BooleanExpression pickedSubQuery(Long userId) {
-		if (userId == null)
+		if (userId == -1)
 			return Expressions.asBoolean(false);
 
 		return JPAExpressions
 			.selectOne()
 			.from(picks)
-			.where(picks.alcoholId.eq(alcohol.id),
-				picks.userId.eq(userId))
+			.where(
+				picks.alcoholId.eq(alcohol.id),
+				picks.userId.eq(userId),
+				picks.status.eq(PICK)
+			)
 			.exists();
 	}
 


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- 메인 화면에서 알콜 목록 조회 시 isPicked 서브쿼리가 로그인을 해도 false로 온다는 QC가 등록됨

# 어떻게 해결했나요?

- 기존 잘못 작성된 서브 쿼리 수정 
- 개발 DB에 붙어서 로컬 테스트 결과 정상 조회되는 것 확인함
- FE에 API 요청 시 토큰이 헤더에 정상적으로 들어가는지 확인 요청함
<img width="987" alt="image" src="https://github.com/user-attachments/assets/279c8ed1-bd69-4ed6-b7cd-412e5b8a371c" />

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
