### PR TITLE
Fix redirectUrl that is issued when commenting on the review

### DIFF
--- a/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
+++ b/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
@@ -88,7 +88,7 @@ public class ReviewReplyService {
 		final Long alcoholId = reviewRepository.findById(reviewId)
 			.orElseThrow(() -> new ReviewException(REVIEW_NOT_FOUND)).getAlcoholId();
 
-		ReviewRegistryEvent event = ReviewRegistryEvent.of(reply.getId(), alcoholId, reply.getUserId(), reply.getContent());
+		ReviewRegistryEvent event = ReviewRegistryEvent.of(reply.getReviewId(), alcoholId, reply.getUserId(), reply.getContent());
 		reviewReplyEventPublisher.publishHistoryEvent(event);
 
 		return ReviewReplyResponse.of(


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- 리뷰 댓글 작성시 발행하는 이벤트의 redirectUrl 값 오류 수정

# 어떻게 해결했나요?

- redirectUrl의 pathVariable 값이 reviewId가 아닌 reviewReplyId로 들어가고 있어 수정했습니다.



---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of review reply processing by ensuring that replies are correctly associated with their respective reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->