### PR TITLE
Fix incorrect ratingCount returns in whisky search API

### DIFF
--- a/src/main/java/app/bottlenote/alcohols/repository/CustomAlcoholQueryRepositoryImpl.java
+++ b/src/main/java/app/bottlenote/alcohols/repository/CustomAlcoholQueryRepositoryImpl.java
@@ -148,7 +148,7 @@ public class CustomAlcoholQueryRepositoryImpl implements CustomAlcoholQueryRepos
 				alcohol.engCategory.as("engCategoryName"),
 				alcohol.imageUrl.as("imageUrl"),
 				rating.ratingPoint.rating.avg().multiply(2).castToNum(Double.class).round().divide(2).coalesce(0.0).as("rating"),
-				rating.id.alcoholId.countDistinct().as("ratingCount"),
+					rating.id.countDistinct().as("ratingCount"),
 				review.id.countDistinct().as("reviewCount"),
 				picks.id.countDistinct().as("pickCount"),
 				supporter.pickedSubQuery(userId).as("isPicked")


### PR DESCRIPTION

# 해결하려는 문제가 무엇인가요?

- 로그인 후 Alcohol 검색 API 호출시 ratingCount가 1로 반환된다는 QC가 등록됨

# 어떻게 해결했나요?
- rating.alcohol.id를 discinct로 조회하고 있어 항상 1이 나옴 -> alcohol을 기준으로 조회하기 때문에 조인하는 테이블의 rating.alcohol.id는 항상 1임
- rating.id를 조회해야 올바르게 조회 됨

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refined the method for calculating ratings in search results, leading to a more accurate display of rating counts on alcohol entries. Users will benefit from clearer insights into product popularity, as rating information now aligns more closely with user interactions without altering the overall search experience. This update enhances transparency in rating presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->