### PR TITLE
Change of login api specification according to application of apple login

### DIFF
--- a/database/mysql/init/01-init-table.sql
+++ b/database/mysql/init/01-init-table.sql
@@ -52,6 +52,7 @@ CREATE TABLE `alcohol`
 CREATE TABLE `users`
 (
     `id`             bigint       NOT NULL AUTO_INCREMENT COMMENT '사용자',
+	`social_unique_id` VARCHAR(255) NULL COMMENT '소셜 로그인 제공자의 고유 식별자',
     `email`          varchar(255) NOT NULL COMMENT '사용자 소셜 이메일',
     `password`       varchar(255) NULL COMMENT '사용자 비밀번호',
     `nick_name`      varchar(255) NOT NULL COMMENT '사용자 소셜 닉네임 ( 수정 가능 )',
@@ -66,7 +67,8 @@ CREATE TABLE `users`
     `last_modify_at` timestamp    NULL COMMENT '최종 생성일',
     PRIMARY KEY (`id`),
     UNIQUE KEY `email` (`email`),
-    UNIQUE KEY `nick_name` (`nick_name`)
+	UNIQUE KEY `nick_name` (`nick_name`),
+	UNIQUE KEY `social_unique_id` (`social_unique_id`)
 ) COMMENT = '사용자';
 
 CREATE TABLE `picks`

--- a/src/main/java/app/bottlenote/user/domain/User.java
+++ b/src/main/java/app/bottlenote/user/domain/User.java
@@ -49,6 +49,10 @@ public class User extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Comment("소셜 로그인 제공자의 고유 식별자")
+	@Column(name = "social_unique_id", unique = true)
+	private String socialUniqueId;
+
 	@Comment("사용자 이메일")
 	@Column(name = "email", nullable = false, unique = true)
 	private String email;

--- a/src/main/java/app/bottlenote/user/dto/request/OauthRequest.java
+++ b/src/main/java/app/bottlenote/user/dto/request/OauthRequest.java
@@ -4,20 +4,22 @@ import app.bottlenote.user.constant.GenderType;
 import app.bottlenote.user.constant.SocialType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record OauthRequest
-	(@NotBlank(message = "EMAIL_NOT_BLANK")
-	 @Email(message = "EMAIL_PATTERN_NOT_VALID")
-	 String email,
+public record OauthRequest(
 
-	 @NotNull(message = "SOCIAL_TYPE_REQUIRED")
-	 SocialType socialType,
+		@Email(message = "EMAIL_PATTERN_NOT_VALID")
+		String email,
 
-	 GenderType gender,
-	 @Min(value = 0, message = "AGE_MINIMUM")
-	 Integer age
-	) {
+		String socialUniqueId,
+
+		@NotNull(message = "SOCIAL_TYPE_REQUIRED")
+		SocialType socialType,
+
+		GenderType gender,
+
+		@Min(value = 0, message = "AGE_MINIMUM")
+		Integer age
+) {
 
 }

--- a/src/main/java/app/bottlenote/user/exception/UserExceptionCode.java
+++ b/src/main/java/app/bottlenote/user/exception/UserExceptionCode.java
@@ -27,7 +27,8 @@ public enum UserExceptionCode implements ExceptionCode {
 	USER_NICKNAME_NOT_VALID(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
 	JSON_PARSING_EXCEPTION(HttpStatus.BAD_REQUEST, "JSON 처리 중 오류가 발생했습니다"),
 	NOT_MATCH_GUEST_CODE(HttpStatus.BAD_REQUEST, "게스트 코드가 일치하지 않습니다."),
-	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+	TEMPORARY_LOGIN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 로그인 오류입니다.");
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/src/main/java/app/bottlenote/user/repository/OauthRepository.java
+++ b/src/main/java/app/bottlenote/user/repository/OauthRepository.java
@@ -2,9 +2,10 @@ package app.bottlenote.user.repository;
 
 import app.bottlenote.user.domain.User;
 import feign.Param;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
 
 public interface OauthRepository extends CrudRepository<User, Long> {
 
@@ -17,6 +18,8 @@ public interface OauthRepository extends CrudRepository<User, Long> {
 			""",
 		nativeQuery = true)
 	Optional<User> findByEmailAndSocialType(@Param("email") String email, @Param("socialType") String socialType);
+
+	Optional<User> findBySocialUniqueId(String socialUniqueId);
 
 	Optional<User> findByNickName(String nickName);
 

--- a/src/main/java/app/bottlenote/user/service/OauthService.java
+++ b/src/main/java/app/bottlenote/user/service/OauthService.java
@@ -41,16 +41,46 @@ public class OauthService {
 	@Transactional
 	public TokenItem login(OauthRequest oauthReq) {
 		final String email = oauthReq.email();
+		final String socialUniqueId = oauthReq.socialUniqueId();
 		final SocialType socialType = oauthReq.socialType();
 		final GenderType genderType = oauthReq.gender();
 		final Integer age = oauthReq.age();
 
-		User user = oauthRepository.findByEmail(email).orElseGet(() -> oauthSignUp(email, socialType, genderType, age, UserType.ROLE_USER));
+		User user;
 
+		switch (socialType) {
+			case APPLE -> {
+				//최초 로그인 (email과 socialUniqueId 모두 존재하는 경우)
+				if (socialUniqueId != null && !socialUniqueId.isBlank() && email != null && !email.isBlank()) {
+					user = oauthSignUp(oauthReq, UserType.ROLE_USER);
+					checkActiveUser(user);
+					return getTokenItem(user, socialType);
+				} else {
+					if (socialUniqueId == null) {
+						throw new UserException(UserExceptionCode.TEMPORARY_LOGIN_ERROR);
+					}
+					user = oauthRepository.findBySocialUniqueId(socialUniqueId).orElseThrow(
+							() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+					checkActiveUser(user);
+					return getTokenItem(user, socialType);
+				}
+			}
+			default -> {
+				user = oauthRepository.findByEmail(email)
+						.orElseGet(() -> oauthSignUp(oauthReq, UserType.ROLE_USER));
+				checkActiveUser(user);
+				return getTokenItem(user, socialType);
+			}
+		}
+	}
+
+	private void checkActiveUser(User user) {
 		if (Boolean.FALSE.equals(user.isAlive()))
 			throw new UserException(UserExceptionCode.USER_DELETED);
+	}
 
-		user.addSocialType(oauthReq.socialType());
+	private TokenItem getTokenItem(User user, SocialType socialType) {
+		user.addSocialType(socialType);
 		TokenItem token = tokenProvider.generateToken(user.getEmail(), user.getRole(), user.getId());
 		user.updateRefreshToken(token.refreshToken());
 		return token;
@@ -59,7 +89,7 @@ public class OauthService {
 	@Transactional
 	public void restoreUser(String email, String password) {
 		User user = oauthRepository.findByEmail(email)
-			.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
+				.orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 
 		if (Boolean.TRUE.equals(user.isAlive()))
 			throw new UserException(UserExceptionCode.USER_ALREADY_EXISTS);
@@ -78,37 +108,31 @@ public class OauthService {
 	@Transactional
 	public String guestLogin() {
 		final int expireTime = 1000 * 60 * 60 * 24;
+		OauthRequest oauthRequest = new OauthRequest(
+				"guest" + UUID.randomUUID() + "@bottlenote.com",
+				"socialUniqueId" + UUID.randomUUID(),
+				SocialType.APPLE,
+				GenderType.MALE,
+				30);
 		User guest = oauthRepository.loadGuestUser()
-			.orElseGet(() ->
-				oauthSignUp("guest" + UUID.randomUUID() + "@bottlenote.com",
-					SocialType.APPLE,
-					GenderType.MALE,
-					30,
-					UserType.ROLE_GUEST
-				)
-			);
+				.orElseGet(() -> oauthSignUp(oauthRequest, UserType.ROLE_GUEST));
 		return tokenProvider.createGuestToken(
-			guest.getId(),
-			expireTime
+				guest.getId(),
+				expireTime
 		);
 	}
 
 	@Transactional
-	public User oauthSignUp(
-		String email,
-		SocialType socialType,
-		GenderType genderType,
-		Integer age,
-		UserType userType
-	) {
+	public User oauthSignUp(OauthRequest oauthRequest, UserType userType) {
 		User user = User.builder()
-			.email(email)
-			.socialType(List.of(socialType))
-			.role(userType)
-			.gender(genderType)
-			.age(age)
-			.nickName(generateNickname())
-			.build();
+				.email(oauthRequest.email())
+				.socialUniqueId(oauthRequest.socialUniqueId())
+				.socialType(List.of(oauthRequest.socialType()))
+				.role(userType)
+				.gender(oauthRequest.gender())
+				.age(oauthRequest.age())
+				.nickName(generateNickname())
+				.build();
 
 		return oauthRepository.save(user);
 	}
@@ -125,11 +149,11 @@ public class OauthService {
 
 		//refresh Token DB에 존재하는지 검사
 		User user = oauthRepository.findByRefreshToken(refreshToken).orElseThrow(
-			() -> new UserException(INVALID_REFRESH_TOKEN)
+				() -> new UserException(INVALID_REFRESH_TOKEN)
 		);
 
 		TokenItem reissuedToken = tokenProvider.generateToken(user.getEmail(),
-			user.getRole(), user.getId());
+				user.getRole(), user.getId());
 
 		// DB에 저장된 refresh 토큰을 재발급한 refresh 토큰으로 업데이트
 		user.updateRefreshToken(reissuedToken.refreshToken());
@@ -145,25 +169,25 @@ public class OauthService {
 
 		String encodePassword = passwordEncoder.encode(password);
 		User user = oauthRepository.save(User.builder()
-			.email(email)
-			.password(encodePassword)
-			.role(UserType.ROLE_USER)
-			.socialType(List.of(SocialType.BASIC))
-			.nickName(generateNickname())
-			.age(age)
-			.gender(gender)
-			.build());
+				.email(email)
+				.password(encodePassword)
+				.role(UserType.ROLE_USER)
+				.socialType(List.of(SocialType.BASIC))
+				.nickName(generateNickname())
+				.age(age)
+				.gender(gender)
+				.build());
 
 		TokenItem token = tokenProvider.generateToken(user.getEmail(), user.getRole(), user.getId());
 		user.updateRefreshToken(token.refreshToken());
 
 		return BasicAccountResponse.builder()
-			.message(user.getNickName() + "님 환영합니다!")
-			.email(user.getEmail())
-			.nickname(user.getNickName())
-			.accessToken(token.accessToken())
-			.refreshToken(token.refreshToken())
-			.build();
+				.message(user.getNickName() + "님 환영합니다!")
+				.email(user.getEmail())
+				.nickname(user.getNickName())
+				.accessToken(token.accessToken())
+				.refreshToken(token.refreshToken())
+				.build();
 	}
 
 	@Transactional
@@ -173,8 +197,7 @@ public class OauthService {
 			throw new UserException(UserExceptionCode.INVALID_PASSWORD);
 		}
 
-		if (Boolean.FALSE.equals(user.isAlive()))
-			throw new UserException(UserExceptionCode.USER_DELETED);
+		checkActiveUser(user);
 
 		TokenItem token = tokenProvider.generateToken(user.getEmail(), user.getRole(), user.getId());
 		user.updateRefreshToken(token.refreshToken());

--- a/src/test/java/app/bottlenote/alcohols/integration/AlcoholQueryIntegrationTest.java
+++ b/src/test/java/app/bottlenote/alcohols/integration/AlcoholQueryIntegrationTest.java
@@ -43,20 +43,20 @@ class AlcoholQueryIntegrationTest extends IntegrationTestSupport {
 	RatingTestFactory ratingTestFactory;
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-alcohol.sql"
+			"/init-script/init-user.sql",
+			"/init-script/init-alcohol.sql"
 	})
 	@DisplayName("알코올 목록조회를 할 수 있다.")
 	@Test
 	void test_1() throws Exception {
 
 		MvcResult result = mockMvc.perform(get("/api/v1/alcohols/search")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andReturn();
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
 		AlcoholSearchResponse alcoholSearchResponse = mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
@@ -67,9 +67,9 @@ class AlcoholQueryIntegrationTest extends IntegrationTestSupport {
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-alcohol.sql",
-		"/init-script/init-review.sql"
+			"/init-script/init-user.sql",
+			"/init-script/init-alcohol.sql",
+			"/init-script/init-review.sql"
 	})
 	@DisplayName("알코올 상세 조회를 할 수 있다.")
 	@Test
@@ -77,12 +77,12 @@ class AlcoholQueryIntegrationTest extends IntegrationTestSupport {
 		final Long alcoholId = 1L;
 
 		MvcResult result = mockMvc.perform(get("/api/v1/alcohols/{alcoholId}", alcoholId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andReturn();
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
 		AlcoholDetailResponse alcoholDetail = mapper.convertValue(response.getData(), AlcoholDetailResponse.class);
@@ -107,24 +107,24 @@ class AlcoholQueryIntegrationTest extends IntegrationTestSupport {
 		ratingTestFactory.createRating(user2, alcohol, 3);
 
 		MvcResult authResult = mockMvc.perform(post("/api/v1/oauth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(new OauthRequest(userEmail, userSocialType.get(0), null, null)))
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new OauthRequest(userEmail, null, userSocialType.get(0), null, null)))
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andReturn();
 		String contentAsString = authResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse tokenResponse = mapper.readValue(contentAsString, GlobalResponse.class);
 		JsonNode dataNode = mapper.convertValue(tokenResponse.getData(), JsonNode.class);
 		String accessToken = dataNode.get("accessToken").asText();
 
 		MvcResult result = mockMvc.perform(get("/api/v1/alcohols/{alcoholId}", alcoholId)
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + accessToken)
-				.with(csrf())
-			)
-			.andDo(print())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + accessToken)
+						.with(csrf())
+				)
+				.andDo(print())
+				.andReturn();
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
 		AlcoholDetailResponse alcoholDetail = mapper.convertValue(response.getData(), AlcoholDetailResponse.class);

--- a/src/test/java/app/bottlenote/docs/user/RestOauthControllerTest.java
+++ b/src/test/java/app/bottlenote/docs/user/RestOauthControllerTest.java
@@ -43,10 +43,10 @@ class RestOauthControllerTest extends AbstractRestDocs {
 
 	public RestOauthControllerTest() {
 		this.config = OauthConfigProperties.builder()
-			.guestCode("TEST_GUEST_CODE")
-			.cookieExpireTime(123456)
-			.refreshTokenHeaderPrefix("refresh-token")
-			.build();
+				.guestCode("TEST_GUEST_CODE")
+				.cookieExpireTime(123456)
+				.refreshTokenHeaderPrefix("refresh-token")
+				.build();
 	}
 
 	@Override
@@ -60,53 +60,54 @@ class RestOauthControllerTest extends AbstractRestDocs {
 	void login_test() throws Exception {
 
 		//given
-		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", SocialType.KAKAO, GenderType.MALE, 27);
+		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", "", SocialType.KAKAO, GenderType.MALE, 27);
 		TokenItem tokenItem = TokenItem.builder()
-			.accessToken("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJn44WB44WBZ2dAbmF2ZXIuY29tIiwicm9sZXMiOiJST0xFX1VTRVIiLCJ1c2VySWQiOjE2LCJpYXQiOjE3MTQ5NzU2MjMsImV4cCI6MTcxNDk3NjUyM30.41SuOBgmX-sd8nrMbC-xm0kH6rbny_SMYCKWE4rNQEZgSrRPS0HvYv0X7E-weo6sHlWWm1OmiQgHl4-uy6-9ig")
-			.refreshToken("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJn44WB44WBZ2dAbmF2ZXIuY29tIiwicm9sZXMiOiJST0xFX1VTRVIiLCJ1c2VySWQiOjE2LCJpYXQiOjE3MTQ5NzU2MjMsImV4cCI6MTcxNjE4NTIyM30.lvmPueUcOb1erv5Llo4qhEUQ_gtWrpFGbBHDw-Pi94qj8MGojoEI3ugdMo8PwoKgrVQZ_gBwBbytwjxh8XktUg")
-			.build();
+				.accessToken("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJn44WB44WBZ2dAbmF2ZXIuY29tIiwicm9sZXMiOiJST0xFX1VTRVIiLCJ1c2VySWQiOjE2LCJpYXQiOjE3MTQ5NzU2MjMsImV4cCI6MTcxNDk3NjUyM30.41SuOBgmX-sd8nrMbC-xm0kH6rbny_SMYCKWE4rNQEZgSrRPS0HvYv0X7E-weo6sHlWWm1OmiQgHl4-uy6-9ig")
+				.refreshToken("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJn44WB44WBZ2dAbmF2ZXIuY29tIiwicm9sZXMiOiJST0xFX1VTRVIiLCJ1c2VySWQiOjE2LCJpYXQiOjE3MTQ5NzU2MjMsImV4cCI6MTcxNjE4NTIyM30.lvmPueUcOb1erv5Llo4qhEUQ_gtWrpFGbBHDw-Pi94qj8MGojoEI3ugdMo8PwoKgrVQZ_gBwBbytwjxh8XktUg")
+				.build();
 
 		//when
 		when(oauthService.login(oauthRequest)).thenReturn(tokenItem);
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.with(csrf())
-				.content(objectMapper.writeValueAsString(oauthRequest)))
-			.andExpect(status().isOk())
-			.andExpect(cookie().exists("refresh-token"))
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf())
+						.content(objectMapper.writeValueAsString(oauthRequest)))
+				.andExpect(status().isOk())
+				.andExpect(cookie().exists("refresh-token"))
 
-			.andDo(
-				document("user/user-login",
-					requestFields(
-						fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-						fieldWithPath("gender").type(JsonFieldType.STRING).description("성별")
-							.optional(),
-						fieldWithPath("age").type(JsonFieldType.NUMBER).description("나이")
-							.optional(),
-						fieldWithPath("socialType").type(JsonFieldType.STRING)
-							.description("소셜 로그인 타입")
-					),
-					responseFields(
-						fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-							.description("응답 성공 여부"),
-						fieldWithPath("code").type(JsonFieldType.NUMBER)
-							.description("응답 코드(http status code)"),
-						fieldWithPath("data.accessToken").type(JsonFieldType.STRING)
-							.description("액세스 토큰"),
-						fieldWithPath("errors").type(JsonFieldType.ARRAY)
-							.description("응답 성공 여부가 false일 경우 에러 메시지(없을 경우 null)"),
-						fieldWithPath("meta.serverEncoding").description("서버 인코딩 정도"),
-						fieldWithPath("meta.serverVersion").description("서버 버전"),
-						fieldWithPath("meta.serverPathVersion").description("서버 경로 버전"),
-						fieldWithPath("meta.serverResponseTime").description("서버 응답 시간")
-					),
-					responseHeaders(
-						headerWithName("Set-Cookie").description("리프레쉬 토큰")
-					)
-				)
-			);
+				.andDo(
+						document("user/user-login",
+								requestFields(
+										fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+										fieldWithPath("socialUniqueId").type(JsonFieldType.STRING).description("소셜 로그인 제공자의 고유 식별자"),
+										fieldWithPath("gender").type(JsonFieldType.STRING).description("성별")
+												.optional(),
+										fieldWithPath("age").type(JsonFieldType.NUMBER).description("나이")
+												.optional(),
+										fieldWithPath("socialType").type(JsonFieldType.STRING)
+												.description("소셜 로그인 타입")
+								),
+								responseFields(
+										fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+												.description("응답 성공 여부"),
+										fieldWithPath("code").type(JsonFieldType.NUMBER)
+												.description("응답 코드(http status code)"),
+										fieldWithPath("data.accessToken").type(JsonFieldType.STRING)
+												.description("액세스 토큰"),
+										fieldWithPath("errors").type(JsonFieldType.ARRAY)
+												.description("응답 성공 여부가 false일 경우 에러 메시지(없을 경우 null)"),
+										fieldWithPath("meta.serverEncoding").description("서버 인코딩 정도"),
+										fieldWithPath("meta.serverVersion").description("서버 버전"),
+										fieldWithPath("meta.serverPathVersion").description("서버 경로 버전"),
+										fieldWithPath("meta.serverResponseTime").description("서버 응답 시간")
+								),
+								responseHeaders(
+										headerWithName("Set-Cookie").description("리프레쉬 토큰")
+								)
+						)
+				);
 	}
 
 	@Test
@@ -117,42 +118,42 @@ class RestOauthControllerTest extends AbstractRestDocs {
 		String request = "refresh-token";
 
 		TokenItem newTokenItem = TokenItem.builder()
-			.accessToken("new-access-token")
-			.refreshToken("new-refresh-token")
-			.build();
+				.accessToken("new-access-token")
+				.refreshToken("new-refresh-token")
+				.build();
 
 		//when
 		when(oauthService.refresh(request)).thenReturn(newTokenItem);
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/reissue")
-				.header("refresh-token", request)
-				.contentType(MediaType.APPLICATION_JSON)
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andExpect(cookie().exists("refresh-token"))
+						.header("refresh-token", request)
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf()))
+				.andExpect(status().isOk())
+				.andExpect(cookie().exists("refresh-token"))
 
-			.andDo(
-				document("user/user-reissue",
-					responseFields(
-						fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-							.description("응답 성공 여부"),
-						fieldWithPath("code").type(JsonFieldType.NUMBER)
-							.description("응답 코드(http status code)"),
-						fieldWithPath("data.accessToken").type(JsonFieldType.STRING)
-							.description("액세스 토큰"),
-						fieldWithPath("errors").type(JsonFieldType.ARRAY)
-							.description("응답 성공 여부가 false일 경우 에러 메시지(없을 경우 null)"),
-						fieldWithPath("meta.serverEncoding").description("서버 인코딩 정도"),
-						fieldWithPath("meta.serverVersion").description("서버 버전"),
-						fieldWithPath("meta.serverPathVersion").description("서버 경로 버전"),
-						fieldWithPath("meta.serverResponseTime").description("서버 응답 시간")
-					),
-					responseHeaders(
-						headerWithName("Set-Cookie").description("리프레쉬 토큰")
-					)
-				)
-			);
+				.andDo(
+						document("user/user-reissue",
+								responseFields(
+										fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+												.description("응답 성공 여부"),
+										fieldWithPath("code").type(JsonFieldType.NUMBER)
+												.description("응답 코드(http status code)"),
+										fieldWithPath("data.accessToken").type(JsonFieldType.STRING)
+												.description("액세스 토큰"),
+										fieldWithPath("errors").type(JsonFieldType.ARRAY)
+												.description("응답 성공 여부가 false일 경우 에러 메시지(없을 경우 null)"),
+										fieldWithPath("meta.serverEncoding").description("서버 인코딩 정도"),
+										fieldWithPath("meta.serverVersion").description("서버 버전"),
+										fieldWithPath("meta.serverPathVersion").description("서버 경로 버전"),
+										fieldWithPath("meta.serverResponseTime").description("서버 응답 시간")
+								),
+								responseHeaders(
+										headerWithName("Set-Cookie").description("리프레쉬 토큰")
+								)
+						)
+				);
 
 
 	}
@@ -170,27 +171,27 @@ class RestOauthControllerTest extends AbstractRestDocs {
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/guest-login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(
-				document("user/guest-login",
-					requestFields(
-						fieldWithPath("code").description("게스트 코드")
-					),
-					responseFields(
-						fieldWithPath("success").ignored(),
-						fieldWithPath("code").ignored(),
-						fieldWithPath("errors").ignored(),
-						fieldWithPath("data.accessToken").description("액세스 토큰"),
-						fieldWithPath("meta.serverEncoding").description("서버 인코딩 정도"),
-						fieldWithPath("meta.serverVersion").description("서버 버전"),
-						fieldWithPath("meta.serverPathVersion").description("서버 경로 버전"),
-						fieldWithPath("meta.serverResponseTime").description("서버 응답 시간")
-					)
-				)
-			);
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request))
+						.with(csrf()))
+				.andExpect(status().isOk())
+				.andDo(
+						document("user/guest-login",
+								requestFields(
+										fieldWithPath("code").description("게스트 코드")
+								),
+								responseFields(
+										fieldWithPath("success").ignored(),
+										fieldWithPath("code").ignored(),
+										fieldWithPath("errors").ignored(),
+										fieldWithPath("data.accessToken").description("액세스 토큰"),
+										fieldWithPath("meta.serverEncoding").description("서버 인코딩 정도"),
+										fieldWithPath("meta.serverVersion").description("서버 버전"),
+										fieldWithPath("meta.serverPathVersion").description("서버 경로 버전"),
+										fieldWithPath("meta.serverResponseTime").description("서버 응답 시간")
+								)
+						)
+				);
 
 
 	}
@@ -207,27 +208,27 @@ class RestOauthControllerTest extends AbstractRestDocs {
 
 		//then
 		mockMvc.perform(put("/api/v1/oauth/token/verify")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(
-				document("user/token-verify",
-					requestFields(
-						fieldWithPath("token").description("검사할 토큰")
-					),
-					responseFields(
-						fieldWithPath("success").ignored(),
-						fieldWithPath("code").ignored(),
-						fieldWithPath("errors").ignored(),
-						fieldWithPath("data").description("결과"),
-						fieldWithPath("meta.serverEncoding").ignored(),
-						fieldWithPath("meta.serverVersion").ignored(),
-						fieldWithPath("meta.serverPathVersion").ignored(),
-						fieldWithPath("meta.serverResponseTime").ignored()
-					)
-				)
-			);
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request))
+						.with(csrf()))
+				.andExpect(status().isOk())
+				.andDo(
+						document("user/token-verify",
+								requestFields(
+										fieldWithPath("token").description("검사할 토큰")
+								),
+								responseFields(
+										fieldWithPath("success").ignored(),
+										fieldWithPath("code").ignored(),
+										fieldWithPath("errors").ignored(),
+										fieldWithPath("data").description("결과"),
+										fieldWithPath("meta.serverEncoding").ignored(),
+										fieldWithPath("meta.serverVersion").ignored(),
+										fieldWithPath("meta.serverPathVersion").ignored(),
+										fieldWithPath("meta.serverResponseTime").ignored()
+								)
+						)
+				);
 	}
 
 	@Test
@@ -236,55 +237,55 @@ class RestOauthControllerTest extends AbstractRestDocs {
 		//given
 		final String nickName = "부드러운몰트";
 		final BasicAccountRequest request = BasicAccountRequest.builder()
-			.email("test@email.com")
-			.password("test-password")
-			.age(27)
-			.gender(null)
-			.build();
+				.email("test@email.com")
+				.password("test-password")
+				.age(27)
+				.gender(null)
+				.build();
 
 		final BasicAccountResponse response = BasicAccountResponse.builder()
-			.message(nickName + "님 환영합니다!")
-			.email(request.getEmail())
-			.nickname(nickName)
-			.accessToken("access-token")
-			.refreshToken("refresh-token")
-			.build();
+				.message(nickName + "님 환영합니다!")
+				.email(request.getEmail())
+				.nickname(nickName)
+				.accessToken("access-token")
+				.refreshToken("refresh-token")
+				.build();
 
 		//when
 		when(oauthService.basicSignup(request.getEmail(), request.getPassword(),
-			request.getAge(), request.getGender())).thenReturn(response);
+				request.getAge(), request.getGender())).thenReturn(response);
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/basic/signup")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(
-				document("user/basic-signup",
-					requestFields(
-						fieldWithPath("email").description("이메일"),
-						fieldWithPath("password").description("비밀번호"),
-						fieldWithPath("age").description("나이"),
-						fieldWithPath("gender").description("성별")
-					),
-					responseFields(
-						fieldWithPath("success").ignored(),
-						fieldWithPath("code").ignored(),
-						fieldWithPath("errors").ignored(),
-						fieldWithPath("data").description("결과"),
-						fieldWithPath("data.message").description("결과 메시지"),
-						fieldWithPath("data.email").description("이메일"),
-						fieldWithPath("data.nickname").description("닉네임"),
-						fieldWithPath("data.accessToken").description("accessToken"),
-						fieldWithPath("data.refreshToken").description("refreshToken"),
-						fieldWithPath("meta.serverEncoding").ignored(),
-						fieldWithPath("meta.serverVersion").ignored(),
-						fieldWithPath("meta.serverPathVersion").ignored(),
-						fieldWithPath("meta.serverResponseTime").ignored()
-					)
-				)
-			);
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request))
+						.with(csrf()))
+				.andExpect(status().isOk())
+				.andDo(
+						document("user/basic-signup",
+								requestFields(
+										fieldWithPath("email").description("이메일"),
+										fieldWithPath("password").description("비밀번호"),
+										fieldWithPath("age").description("나이"),
+										fieldWithPath("gender").description("성별")
+								),
+								responseFields(
+										fieldWithPath("success").ignored(),
+										fieldWithPath("code").ignored(),
+										fieldWithPath("errors").ignored(),
+										fieldWithPath("data").description("결과"),
+										fieldWithPath("data.message").description("결과 메시지"),
+										fieldWithPath("data.email").description("이메일"),
+										fieldWithPath("data.nickname").description("닉네임"),
+										fieldWithPath("data.accessToken").description("accessToken"),
+										fieldWithPath("data.refreshToken").description("refreshToken"),
+										fieldWithPath("meta.serverEncoding").ignored(),
+										fieldWithPath("meta.serverVersion").ignored(),
+										fieldWithPath("meta.serverPathVersion").ignored(),
+										fieldWithPath("meta.serverResponseTime").ignored()
+								)
+						)
+				);
 	}
 
 	@Test
@@ -293,9 +294,9 @@ class RestOauthControllerTest extends AbstractRestDocs {
 		//given
 		final String nickName = "부드러운몰트";
 		final BasicLoginRequest request = BasicLoginRequest.builder()
-			.email("test@email.com")
-			.password("test-password")
-			.build();
+				.email("test@email.com")
+				.password("test-password")
+				.build();
 
 		final TokenItem response = TokenItem.of("access-token", "refresh-token");
 		//when
@@ -303,29 +304,29 @@ class RestOauthControllerTest extends AbstractRestDocs {
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/basic/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(
-				document("user/basic-login",
-					requestFields(
-						fieldWithPath("email").description("이메일"),
-						fieldWithPath("password").description("비밀번호")
-					),
-					responseFields(
-						fieldWithPath("success").ignored(),
-						fieldWithPath("code").ignored(),
-						fieldWithPath("errors").ignored(),
-						fieldWithPath("data").description("결과"),
-						fieldWithPath("data.accessToken").description("accessToken"),
-						fieldWithPath("meta.serverEncoding").ignored(),
-						fieldWithPath("meta.serverVersion").ignored(),
-						fieldWithPath("meta.serverPathVersion").ignored(),
-						fieldWithPath("meta.serverResponseTime").ignored()
-					)
-				)
-			);
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request))
+						.with(csrf()))
+				.andExpect(status().isOk())
+				.andDo(
+						document("user/basic-login",
+								requestFields(
+										fieldWithPath("email").description("이메일"),
+										fieldWithPath("password").description("비밀번호")
+								),
+								responseFields(
+										fieldWithPath("success").ignored(),
+										fieldWithPath("code").ignored(),
+										fieldWithPath("errors").ignored(),
+										fieldWithPath("data").description("결과"),
+										fieldWithPath("data.accessToken").description("accessToken"),
+										fieldWithPath("meta.serverEncoding").ignored(),
+										fieldWithPath("meta.serverVersion").ignored(),
+										fieldWithPath("meta.serverPathVersion").ignored(),
+										fieldWithPath("meta.serverResponseTime").ignored()
+								)
+						)
+				);
 	}
 
 	@Test
@@ -335,33 +336,33 @@ class RestOauthControllerTest extends AbstractRestDocs {
 		final String email = "test-email";
 		final String password = "test-password";
 		var request = BasicLoginRequest.builder()
-			.email(email)
-			.password(password)
-			.build();
+				.email(email)
+				.password(password)
+				.build();
 
 		doNothing().when(oauthService).restoreUser(email, password);
 
 		mockMvc.perform(post("/api/v1/oauth/restore")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request))
-				.with(csrf()))
-			.andExpect(status().isOk())
-			.andDo(
-				document("user/restore",
-					requestFields(
-						fieldWithPath("email").description("이메일"),
-						fieldWithPath("password").description("비밀번호")
-					),
-					responseFields(
-						fieldWithPath("success").ignored(),
-						fieldWithPath("code").ignored(),
-						fieldWithPath("errors").ignored(),
-						fieldWithPath("data").description("결과 메시지"),
-						fieldWithPath("meta.serverEncoding").ignored(),
-						fieldWithPath("meta.serverVersion").ignored(),
-						fieldWithPath("meta.serverPathVersion").ignored(),
-						fieldWithPath("meta.serverResponseTime").ignored()
-					)
-				));
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request))
+						.with(csrf()))
+				.andExpect(status().isOk())
+				.andDo(
+						document("user/restore",
+								requestFields(
+										fieldWithPath("email").description("이메일"),
+										fieldWithPath("password").description("비밀번호")
+								),
+								responseFields(
+										fieldWithPath("success").ignored(),
+										fieldWithPath("code").ignored(),
+										fieldWithPath("errors").ignored(),
+										fieldWithPath("data").description("결과 메시지"),
+										fieldWithPath("meta.serverEncoding").ignored(),
+										fieldWithPath("meta.serverVersion").ignored(),
+										fieldWithPath("meta.serverPathVersion").ignored(),
+										fieldWithPath("meta.serverResponseTime").ignored()
+								)
+						));
 	}
 }

--- a/src/test/java/app/bottlenote/global/config/JpaAuditingIntegrationTest.java
+++ b/src/test/java/app/bottlenote/global/config/JpaAuditingIntegrationTest.java
@@ -39,16 +39,16 @@ class JpaAuditingIntegrationTest extends IntegrationTestSupport {
 
 	@BeforeEach
 	void setUp() {
-		oauthRequest = new OauthRequest("chadongmin@naver.com", SocialType.KAKAO, null, null);
+		oauthRequest = new OauthRequest("chadongmin@naver.com", null, SocialType.KAKAO, null, null);
 		reviewCreateRequest = ReviewObjectFixture.getReviewCreateRequest();
 	}
 
 	@DisplayName("DB 저장 시 생성자와 수정자가 기록된다.")
 	@Sql(scripts = {
-		"/init-script/init-alcohol.sql",
-		"/init-script/init-user.sql",
-		"/init-script/init-review.sql",
-		"/init-script/init-review-reply.sql"}
+			"/init-script/init-alcohol.sql",
+			"/init-script/init-user.sql",
+			"/init-script/init-review.sql",
+			"/init-script/init-review-reply.sql"}
 	)
 	@Test
 	void test_1() throws Exception {
@@ -56,16 +56,16 @@ class JpaAuditingIntegrationTest extends IntegrationTestSupport {
 
 		// when
 		MvcResult result = mockMvc.perform(post("/api/v1/reviews")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(reviewCreateRequest))
-				.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(reviewCreateRequest))
+						.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);

--- a/src/test/java/app/bottlenote/support/help/integration/HelpIntegrationTest.java
+++ b/src/test/java/app/bottlenote/support/help/integration/HelpIntegrationTest.java
@@ -58,7 +58,7 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 
 	@BeforeEach
 	void setUp() {
-		oauthRequest = new OauthRequest("chadongmin@naver.com", SocialType.KAKAO, null, null);
+		oauthRequest = new OauthRequest("chadongmin@naver.com", null, SocialType.KAKAO, null, null);
 		helpUpsertRequest = HelpObjectFixture.getHelpUpsertRequest();
 
 	}
@@ -72,15 +72,15 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 		helpUpsertRequest = new HelpUpsertRequest("로그인이 안돼요", null, List.of(new HelpImageItem(1L, "https://test.com")));
 		// given when
 		mockMvc.perform(post("/api/v1/help")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsBytes(helpUpsertRequest))
-				.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.errors[?(@.code == 'REQUIRED_HELP_TYPE')].status").value(error.status().name()))
-			.andExpect(jsonPath("$.errors[?(@.code == 'REQUIRED_HELP_TYPE')].message").value(error.message()));
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsBytes(helpUpsertRequest))
+						.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.errors[?(@.code == 'REQUIRED_HELP_TYPE')].status").value(error.status().name()))
+				.andExpect(jsonPath("$.errors[?(@.code == 'REQUIRED_HELP_TYPE')].message").value(error.message()));
 	}
 
 	@Nested
@@ -92,16 +92,16 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 		void test_1() throws Exception {
 			// given when
 			MvcResult result = mockMvc.perform(post("/api/v1/help")
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(mapper.writeValueAsBytes(helpUpsertRequest))
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.code").value(200))
-				.andExpect(jsonPath("$.data").exists())
-				.andReturn();
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(mapper.writeValueAsBytes(helpUpsertRequest))
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.code").value(200))
+					.andExpect(jsonPath("$.data").exists())
+					.andReturn();
 
 			String contentAsString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 			GlobalResponse response = mapper.readValue(contentAsString, GlobalResponse.class);
@@ -113,8 +113,8 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-help.sql"})
+			"/init-script/init-user.sql",
+			"/init-script/init-help.sql"})
 	@Nested
 	@DisplayName("[Integration] 문의글 조회 통합테스트")
 	class HelpReadIntegrationTest extends IntegrationTestSupport {
@@ -125,15 +125,15 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 			// given
 
 			MvcResult result = mockMvc.perform(get("/api/v1/help")
-					.contentType(MediaType.APPLICATION_JSON)
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.code").value(200))
-				.andExpect(jsonPath("$.data").exists())
-				.andReturn();
+							.contentType(MediaType.APPLICATION_JSON)
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.code").value(200))
+					.andExpect(jsonPath("$.data").exists())
+					.andReturn();
 
 			String contentAsString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 			GlobalResponse response = mapper.readValue(contentAsString, GlobalResponse.class);
@@ -148,15 +148,15 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 			// given
 
 			MvcResult result = mockMvc.perform(get("/api/v1/help/{helpId}", 1L)
-					.contentType(MediaType.APPLICATION_JSON)
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.code").value(200))
-				.andExpect(jsonPath("$.data").exists())
-				.andReturn();
+							.contentType(MediaType.APPLICATION_JSON)
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.code").value(200))
+					.andExpect(jsonPath("$.data").exists())
+					.andReturn();
 
 			String contentAsString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 			GlobalResponse response = mapper.readValue(contentAsString, GlobalResponse.class);
@@ -167,8 +167,8 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-help.sql"})
+			"/init-script/init-user.sql",
+			"/init-script/init-help.sql"})
 	@Nested
 	@DisplayName("[Integration] 문의글 수정 통합테스트")
 	class HelpModifyIntegrationTest extends IntegrationTestSupport {
@@ -179,16 +179,16 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 			// given when
 			long helpId = 1L;
 			MvcResult result = mockMvc.perform(patch("/api/v1/help/{helpId}", helpId)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(mapper.writeValueAsBytes(helpUpsertRequest))
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.code").value(200))
-				.andExpect(jsonPath("$.data").exists())
-				.andReturn();
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(mapper.writeValueAsBytes(helpUpsertRequest))
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.code").value(200))
+					.andExpect(jsonPath("$.data").exists())
+					.andReturn();
 
 			String contentAsString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 			GlobalResponse response = mapper.readValue(contentAsString, GlobalResponse.class);
@@ -203,19 +203,19 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 		void test_2() throws Exception {
 			// given when
 			long helpId = 1L;
-			oauthRequest = new OauthRequest("test@naver.com", SocialType.KAKAO, null, null);
+			oauthRequest = new OauthRequest("test@naver.com", null, SocialType.KAKAO, null, null);
 			Error error = Error.of(HELP_NOT_AUTHORIZED);
 
 			mockMvc.perform(patch("/api/v1/help/{helpId}", helpId)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(mapper.writeValueAsBytes(helpUpsertRequest))
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isUnauthorized())
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].status").value(error.status().name()))
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].message").value(error.message()));
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(mapper.writeValueAsBytes(helpUpsertRequest))
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isUnauthorized())
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].status").value(error.status().name()))
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].message").value(error.message()));
 		}
 
 		@DisplayName("존재하지 않는 문의글을 수정할 수 없다.")
@@ -223,19 +223,19 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 		void test_3() throws Exception {
 			// given when
 			long helpId = -1L;
-			oauthRequest = new OauthRequest("test@naver.com", SocialType.KAKAO, null, null);
+			oauthRequest = new OauthRequest("test@naver.com", null, SocialType.KAKAO, null, null);
 			Error error = Error.of(HELP_NOT_FOUND);
 
 			mockMvc.perform(patch("/api/v1/help/{helpId}", helpId)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(mapper.writeValueAsBytes(helpUpsertRequest))
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].status").value(error.status().name()))
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].message").value(error.message()));
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(mapper.writeValueAsBytes(helpUpsertRequest))
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].status").value(error.status().name()))
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].message").value(error.message()));
 		}
 
 		@DisplayName("Not null 필드에 null이 할당되면 예외를 반환한다.")
@@ -248,21 +248,21 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 			helpUpsertRequest = new HelpUpsertRequest(null, HelpType.USER, List.of(new HelpImageItem(1L, "https://test.com")));
 			// given when
 			mockMvc.perform(patch("/api/v1/help/{helpId}", helpId)
-					.contentType(MediaType.APPLICATION_JSON)
-					.content(mapper.writeValueAsBytes(helpUpsertRequest))
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.errors[?(@.code == 'CONTENT_NOT_EMPTY')].status").value(error.status().name()))
-				.andExpect(jsonPath("$.errors[?(@.code == 'CONTENT_NOT_EMPTY')].message").value(error.message()));
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(mapper.writeValueAsBytes(helpUpsertRequest))
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.errors[?(@.code == 'CONTENT_NOT_EMPTY')].status").value(error.status().name()))
+					.andExpect(jsonPath("$.errors[?(@.code == 'CONTENT_NOT_EMPTY')].message").value(error.message()));
 		}
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-help.sql"})
+			"/init-script/init-user.sql",
+			"/init-script/init-help.sql"})
 	@Nested
 	@DisplayName("[Integration] 문의글 수정 통합테스트")
 	class HelpDeleteIntegrationTest extends IntegrationTestSupport {
@@ -273,15 +273,15 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 			// given when
 			long helpId = 1L;
 			MvcResult result = mockMvc.perform(delete("/api/v1/help/{helpId}", helpId)
-					.contentType(MediaType.APPLICATION_JSON)
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.code").value(200))
-				.andExpect(jsonPath("$.data").exists())
-				.andReturn();
+							.contentType(MediaType.APPLICATION_JSON)
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.code").value(200))
+					.andExpect(jsonPath("$.data").exists())
+					.andReturn();
 
 			String contentAsString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 			GlobalResponse response = mapper.readValue(contentAsString, GlobalResponse.class);
@@ -296,18 +296,18 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 		void test_2() throws Exception {
 			// given when
 			long helpId = -1L;
-			oauthRequest = new OauthRequest("test@naver.com", SocialType.KAKAO, null, null);
+			oauthRequest = new OauthRequest("test@naver.com", null, SocialType.KAKAO, null, null);
 			Error error = Error.of(HELP_NOT_FOUND);
 
 			mockMvc.perform(delete("/api/v1/help/{helpId}", helpId)
-					.contentType(MediaType.APPLICATION_JSON)
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].status").value(error.status().name()))
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].message").value(error.message()));
+							.contentType(MediaType.APPLICATION_JSON)
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].status").value(error.status().name()))
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_FOUND')].message").value(error.message()));
 		}
 
 		@DisplayName("유저 본인이 작성한 글이 아니면 문의글을 삭제할 수 없다.")
@@ -315,18 +315,18 @@ class HelpIntegrationTest extends IntegrationTestSupport {
 		void test_3() throws Exception {
 			// given when
 			long helpId = 1L;
-			oauthRequest = new OauthRequest("test@naver.com", SocialType.KAKAO, null, null);
+			oauthRequest = new OauthRequest("test@naver.com", null, SocialType.KAKAO, null, null);
 			Error error = Error.of(HELP_NOT_AUTHORIZED);
 
 			mockMvc.perform(delete("/api/v1/help/{helpId}", helpId)
-					.contentType(MediaType.APPLICATION_JSON)
-					.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
-					.with(csrf())
-				)
-				.andDo(print())
-				.andExpect(status().isUnauthorized())
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].status").value(error.status().name()))
-				.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].message").value(error.message()));
+							.contentType(MediaType.APPLICATION_JSON)
+							.header("Authorization", "Bearer " + getToken(oauthRequest).accessToken())
+							.with(csrf())
+					)
+					.andDo(print())
+					.andExpect(status().isUnauthorized())
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].status").value(error.status().name()))
+					.andExpect(jsonPath("$.errors[?(@.code == 'HELP_NOT_AUTHORIZED')].message").value(error.message()));
 		}
 	}
 }

--- a/src/test/java/app/bottlenote/support/report/integration/ReportIntegrationTest.java
+++ b/src/test/java/app/bottlenote/support/report/integration/ReportIntegrationTest.java
@@ -52,9 +52,9 @@ class ReportIntegrationTest extends IntegrationTestSupport {
 	@DisplayName("리뷰를 신고할 수 있다.")
 	@Test
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-alcohol.sql",
-		"/init-script/init-review.sql"
+			"/init-script/init-user.sql",
+			"/init-script/init-alcohol.sql",
+			"/init-script/init-review.sql"
 	})
 	void test_1() throws Exception {
 		// given
@@ -62,16 +62,16 @@ class ReportIntegrationTest extends IntegrationTestSupport {
 
 		final Long reviewReportId = 1L;
 		MvcResult result = mockMvc.perform(post("/api/v1/reports/review")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(reviewReportRequest))
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(reviewReportRequest))
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		ReviewReport saved = reviewReportRepository.findById(reviewReportId).orElse(null);
 		assertNotNull(saved);
@@ -86,25 +86,25 @@ class ReportIntegrationTest extends IntegrationTestSupport {
 	@DisplayName("유저는 하나의 리뷰에 대해 한번만 신고할 수 있다.")
 	@Test
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-alcohol.sql",
-		"/init-script/init-review.sql"
+			"/init-script/init-user.sql",
+			"/init-script/init-alcohol.sql",
+			"/init-script/init-review.sql"
 	})
 	void test_2() throws Exception {
 		// given
 		ReviewReportRequest reviewReportRequest = new ReviewReportRequest(1L, ADVERTISEMENT, "이 리뷰는 광고 리뷰입니다.");
 
 		MvcResult result = mockMvc.perform(post("/api/v1/reports/review")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(reviewReportRequest))
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(reviewReportRequest))
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		ReviewReport saved = reviewReportRepository.findById(reviewReportRequest.reportReviewId()).orElse(null);
 		assertNotNull(saved);
@@ -118,24 +118,24 @@ class ReportIntegrationTest extends IntegrationTestSupport {
 		Error error = Error.of(ALREADY_REPORTED_REVIEW);
 
 		mockMvc.perform(post("/api/v1/reports/review")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(reviewReportRequest))
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(400))
-			.andExpect(jsonPath("$.errors[?(@.code == 'ALREADY_REPORTED_REVIEW')].status").value(error.status().name()))
-			.andExpect(jsonPath("$.errors[?(@.code == 'ALREADY_REPORTED_REVIEW')].message").value(error.message()));
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(reviewReportRequest))
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value(400))
+				.andExpect(jsonPath("$.errors[?(@.code == 'ALREADY_REPORTED_REVIEW')].status").value(error.status().name()))
+				.andExpect(jsonPath("$.errors[?(@.code == 'ALREADY_REPORTED_REVIEW')].message").value(error.message()));
 	}
 
 	@DisplayName("서로 다른 IP로 5개의 신고가 누적되면 리뷰가 비활성화 된다.")
 	@Test
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-alcohol.sql",
-		"/init-script/init-review.sql"
+			"/init-script/init-user.sql",
+			"/init-script/init-alcohol.sql",
+			"/init-script/init-review.sql"
 	})
 	void test_3() throws Exception {
 		// given
@@ -143,27 +143,27 @@ class ReportIntegrationTest extends IntegrationTestSupport {
 
 		IntStream.range(1, 5).forEach((int i) -> {
 			ReviewReport reviewReport = ReviewReport.builder()
-				.reviewId(reviewReportRequest.reportReviewId())
-				.ipAddress(String.valueOf(i))
-				.type(ADVERTISEMENT)
-				.userId((long) i)
-				.reportContent("이 리뷰는 광고 리뷰입니다.")
-				.build();
+					.reviewId(reviewReportRequest.reportReviewId())
+					.ipAddress(String.valueOf(i))
+					.type(ADVERTISEMENT)
+					.userId((long) i)
+					.reportContent("이 리뷰는 광고 리뷰입니다.")
+					.build();
 			reviewReportRepository.save(reviewReport);
 		});
 		Review beforeReview = reviewRepository.findById(reviewReportRequest.reportReviewId()).orElse(null);
 
 		MvcResult authResult = mockMvc.perform(post("/api/v1/oauth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(new OauthRequest("test@test.com", SocialType.KAKAO, null, null)))
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new OauthRequest("test@test.com", null, SocialType.KAKAO, null, null)))
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		String contentAsString = authResult.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(contentAsString, GlobalResponse.class);
@@ -171,16 +171,16 @@ class ReportIntegrationTest extends IntegrationTestSupport {
 		String accessToken = dataNode.get("accessToken").asText();
 
 		MvcResult result = mockMvc.perform(post("/api/v1/reports/review")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(reviewReportRequest))
-				.header("Authorization", "Bearer " + accessToken)
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(reviewReportRequest))
+						.header("Authorization", "Bearer " + accessToken)
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		ReviewReport savedReport = reviewReportRepository.findById(reviewReportRequest.reportReviewId()).orElse(null);
 		assertNotNull(savedReport);
@@ -204,24 +204,24 @@ class ReportIntegrationTest extends IntegrationTestSupport {
 	@DisplayName("유저를 신고할 수 있다.")
 	@Test
 	@Sql(scripts = {
-		"/init-script/init-user.sql",
-		"/init-script/init-alcohol.sql",
-		"/init-script/init-review.sql"
+			"/init-script/init-user.sql",
+			"/init-script/init-alcohol.sql",
+			"/init-script/init-review.sql"
 	})
 	void test_4() throws Exception {
 		UserReportRequest userReportRequest = new UserReportRequest(2L, UserReportType.FRAUD, "아주 나쁜놈이에요 신고합니다.");
 
 		MvcResult result = mockMvc.perform(post("/api/v1/reports/user")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(userReportRequest))
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(userReportRequest))
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		String contentAsString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(contentAsString, GlobalResponse.class);

--- a/src/test/java/app/bottlenote/user/controller/OauthControllerTest.java
+++ b/src/test/java/app/bottlenote/user/controller/OauthControllerTest.java
@@ -52,9 +52,9 @@ class OauthControllerTest {
 	@BeforeEach
 	void setUp() {
 		tokenItem = TokenItem.builder()
-			.accessToken("access-token")
-			.refreshToken("refresh-token")
-			.build();
+				.accessToken("access-token")
+				.refreshToken("refresh-token")
+				.build();
 		oauthConfigProperties.printConfigs();
 	}
 
@@ -64,30 +64,30 @@ class OauthControllerTest {
 	void user_login_test() throws Exception {
 
 		//given
-		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", SocialType.KAKAO,
-			GenderType.MALE,
-			27);
+		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", null, SocialType.KAKAO,
+				GenderType.MALE,
+				27);
 
 		TokenItem tokenItem = TokenItem.builder()
-			.accessToken("accessToken")
-			.refreshToken("refreshToken")
-			.build();
+				.accessToken("accessToken")
+				.refreshToken("refreshToken")
+				.build();
 
 		//when
 		when(oauthService.login(oauthRequest)).thenReturn(tokenItem);
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.with(csrf())
-				.content(mapper.writeValueAsString(oauthRequest)))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("200"))
-			.andExpect(jsonPath("$.data.accessToken").value("accessToken"))
-			.andExpect(cookie().value("refresh-token", "refreshToken"))
-			.andExpect(cookie().httpOnly("refresh-token", true))
-			.andExpect(cookie().secure("refresh-token", true))
-			.andDo(print());
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf())
+						.content(mapper.writeValueAsString(oauthRequest)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("200"))
+				.andExpect(jsonPath("$.data.accessToken").value("accessToken"))
+				.andExpect(cookie().value("refresh-token", "refreshToken"))
+				.andExpect(cookie().httpOnly("refresh-token", true))
+				.andExpect(cookie().secure("refresh-token", true))
+				.andDo(print());
 	}
 
 	@Test
@@ -97,8 +97,8 @@ class OauthControllerTest {
 		Error error = Error.of(ValidExceptionCode.SOCIAL_TYPE_REQUIRED);
 
 		//given
-		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", null,
-			GenderType.MALE, 27);
+		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", null, null,
+				GenderType.MALE, 27);
 
 
 		//when
@@ -106,13 +106,13 @@ class OauthControllerTest {
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.with(csrf())
-				.content(mapper.writeValueAsString(oauthRequest)))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.errors[0].code").value(String.valueOf(error.code())))
-			.andExpect(jsonPath("$.errors[0].status").value(error.status().name()))
-			.andExpect(jsonPath("$.errors[0].message").value(error.message()));
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf())
+						.content(mapper.writeValueAsString(oauthRequest)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.errors[0].code").value(String.valueOf(error.code())))
+				.andExpect(jsonPath("$.errors[0].status").value(error.status().name()))
+				.andExpect(jsonPath("$.errors[0].message").value(error.message()));
 	}
 
 	@Test
@@ -121,21 +121,21 @@ class OauthControllerTest {
 		Error error = Error.of(ValidExceptionCode.AGE_MINIMUM);
 
 		//given
-		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", SocialType.KAKAO,
-			GenderType.MALE, -10);
+		OauthRequest oauthRequest = new OauthRequest("cdm2883@naver.com", null, SocialType.KAKAO,
+				GenderType.MALE, -10);
 
 		//when
 		when(oauthService.login(oauthRequest)).thenReturn(tokenItem);
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.with(csrf())
-				.content(mapper.writeValueAsString(oauthRequest)))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.errors[0].code").value(String.valueOf(error.code())))
-			.andExpect(jsonPath("$.errors[0].status").value(error.status().name()))
-			.andExpect(jsonPath("$.errors[0].message").value(error.message()));
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf())
+						.content(mapper.writeValueAsString(oauthRequest)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.errors[0].code").value(String.valueOf(error.code())))
+				.andExpect(jsonPath("$.errors[0].status").value(error.status().name()))
+				.andExpect(jsonPath("$.errors[0].message").value(error.message()));
 	}
 
 	@Test
@@ -146,26 +146,26 @@ class OauthControllerTest {
 		String reissueRefreshToken = "refresh-token";
 
 		TokenItem newTokenItem = TokenItem.builder()
-			.accessToken("new-access-token")
-			.refreshToken("new-refresh-token")
-			.build();
+				.accessToken("new-access-token")
+				.refreshToken("new-refresh-token")
+				.build();
 
 		//when
 		when(oauthService.refresh(reissueRefreshToken)).thenReturn(newTokenItem);
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/reissue")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("refresh-token", reissueRefreshToken)
-				.with(csrf())
-				.content(mapper.writeValueAsString(reissueRefreshToken)))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("200"))
-			.andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
-			.andExpect(cookie().value("refresh-token", "new-refresh-token"))
-			.andExpect(cookie().httpOnly("refresh-token", true))
-			.andExpect(cookie().secure("refresh-token", true))
-			.andDo(print());
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("refresh-token", reissueRefreshToken)
+						.with(csrf())
+						.content(mapper.writeValueAsString(reissueRefreshToken)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("200"))
+				.andExpect(jsonPath("$.data.accessToken").value("new-access-token"))
+				.andExpect(cookie().value("refresh-token", "new-refresh-token"))
+				.andExpect(cookie().httpOnly("refresh-token", true))
+				.andExpect(cookie().secure("refresh-token", true))
+				.andDo(print());
 	}
 
 	@Test
@@ -183,22 +183,22 @@ class OauthControllerTest {
 		String reissueRefreshToken = "refresh-tokenxzz";
 
 		TokenItem newTokenItem = TokenItem.builder()
-			.accessToken("new-access-token")
-			.refreshToken("new-refresh-token")
-			.build();
+				.accessToken("new-access-token")
+				.refreshToken("new-refresh-token")
+				.build();
 		//when
 		when(oauthService.refresh(reissueRefreshToken)).thenThrow(
-			new UserException(UserExceptionCode.INVALID_REFRESH_TOKEN));
+				new UserException(UserExceptionCode.INVALID_REFRESH_TOKEN));
 
 		//then
 		mockMvc.perform(post("/api/v1/oauth/reissue")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("refresh-token", reissueRefreshToken)
-				.with(csrf()))
-			.andExpect(status().isUnauthorized()).andDo(print())
-			.andExpect(jsonPath("$.errors[0].code").value(String.valueOf(error.code())))
-			.andExpect(jsonPath("$.errors[0].status").value(error.status().name()))
-			.andExpect(jsonPath("$.errors[0].message").value(error.message()));
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("refresh-token", reissueRefreshToken)
+						.with(csrf()))
+				.andExpect(status().isUnauthorized()).andDo(print())
+				.andExpect(jsonPath("$.errors[0].code").value(String.valueOf(error.code())))
+				.andExpect(jsonPath("$.errors[0].status").value(error.status().name()))
+				.andExpect(jsonPath("$.errors[0].message").value(error.message()));
 
 	}
 
@@ -209,16 +209,16 @@ class OauthControllerTest {
 
 		// when
 		when(oauthService.refresh(reissueRefreshToken)).thenThrow(
-			new IllegalArgumentException("Refresh token is missing"));
+				new IllegalArgumentException("Refresh token is missing"));
 
 		// then
 		mockMvc.perform(post("/api/v1/oauth/reissue")
-				.contentType(MediaType.APPLICATION_JSON)
-				.with(csrf()))
-			.andExpect(status().isUnauthorized())
-			.andExpect(result -> assertTrue(
-				result.getResolvedException() instanceof IllegalArgumentException))
-			.andExpect(jsonPath("$.errors").exists());
+						.contentType(MediaType.APPLICATION_JSON)
+						.with(csrf()))
+				.andExpect(status().isUnauthorized())
+				.andExpect(result -> assertTrue(
+						result.getResolvedException() instanceof IllegalArgumentException))
+				.andExpect(jsonPath("$.errors").exists());
 	}
 
 

--- a/src/test/java/app/bottlenote/user/integration/UserCommandIntegrationTest.java
+++ b/src/test/java/app/bottlenote/user/integration/UserCommandIntegrationTest.java
@@ -47,33 +47,33 @@ class UserCommandIntegrationTest extends IntegrationTestSupport {
 	private UserRepository userRepository;
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql"}
+			"/init-script/init-user.sql"}
 	)
 	@DisplayName("회원탈퇴에 성공한다.")
 	@Test
 	void test_1() throws Exception {
 		// given
 		MvcResult result = mockMvc.perform(delete("/api/v1/users")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
 		WithdrawUserResultResponse withdrawUserResultResponse = mapper.convertValue(response.getData(), WithdrawUserResultResponse.class);
 
 		userRepository.findById(withdrawUserResultResponse.userId())
-			.ifPresent(withdraw -> assertEquals(DELETED, withdraw.getStatus()));
+				.ifPresent(withdraw -> assertEquals(DELETED, withdraw.getStatus()));
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql"}
+			"/init-script/init-user.sql"}
 	)
 	@DisplayName("탈퇴한 회원이 다시 탈퇴하는 경우 성공")
 	@Test
@@ -85,18 +85,18 @@ class UserCommandIntegrationTest extends IntegrationTestSupport {
 		statusField.set(firstUser, UserStatus.DELETED);
 
 		mockMvc.perform(delete("/api/v1/users")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists());
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists());
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql"}
+			"/init-script/init-user.sql"}
 	)
 	@DisplayName("탈퇴한 회원이 재로그인 하는 경우 예외가 발생한다.")
 	@Test
@@ -105,47 +105,47 @@ class UserCommandIntegrationTest extends IntegrationTestSupport {
 		final User firstUser = oauthRepository.getFirstUser().get();
 
 		mockMvc.perform(delete("/api/v1/users")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists());
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists());
 
 		mockMvc.perform(post("/api/v1/oauth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(mapper.writeValueAsString(new OauthRequest(firstUser.getEmail(), SocialType.KAKAO, null, null)))
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(400))
-			.andExpect(jsonPath("$.errors").isArray())
-			.andExpect(jsonPath("$.errors[0].code").value(UserExceptionCode.USER_DELETED.name()))
-			.andExpect(jsonPath("$.errors[0].message").value(UserExceptionCode.USER_DELETED.getMessage()));
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(mapper.writeValueAsString(new OauthRequest(firstUser.getEmail(), null, SocialType.KAKAO, null, null)))
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value(400))
+				.andExpect(jsonPath("$.errors").isArray())
+				.andExpect(jsonPath("$.errors[0].code").value(UserExceptionCode.USER_DELETED.name()))
+				.andExpect(jsonPath("$.errors[0].message").value(UserExceptionCode.USER_DELETED.getMessage()));
 	}
 
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql"}
+			"/init-script/init-user.sql"}
 	)
 	@DisplayName("닉네임 변경에 성공한다.")
 	@Test
 	void test_4() throws Exception {
 
 		MvcResult result = mockMvc.perform(patch("/api/v1/users/nickname")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.content(mapper.writeValueAsString(new NicknameChangeRequest("newNickname")))
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.content(mapper.writeValueAsString(new NicknameChangeRequest("newNickname")))
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
@@ -161,45 +161,45 @@ class UserCommandIntegrationTest extends IntegrationTestSupport {
 
 		// 중복 닉네임 생성
 		userRepository.save(User.builder()
-			.email("test@email.com")
-			.password("password")
-			.nickName("fail")
-			.role(UserType.ROLE_USER)
-			.socialType(List.of(SocialType.KAKAO))
-			.build());
+				.email("test@email.com")
+				.password("password")
+				.nickName("fail")
+				.role(UserType.ROLE_USER)
+				.socialType(List.of(SocialType.KAKAO))
+				.build());
 
 		mockMvc.perform(patch("/api/v1/users/nickname")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.content(mapper.writeValueAsString(new NicknameChangeRequest("fail")))
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(400))
-			.andExpect(jsonPath("$.errors").isArray())
-			.andExpect(jsonPath("$.errors[0].code").value(UserExceptionCode.USER_NICKNAME_NOT_VALID.name()))
-			.andExpect(jsonPath("$.errors[0].message").value(UserExceptionCode.USER_NICKNAME_NOT_VALID.getMessage()));
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.content(mapper.writeValueAsString(new NicknameChangeRequest("fail")))
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value(400))
+				.andExpect(jsonPath("$.errors").isArray())
+				.andExpect(jsonPath("$.errors[0].code").value(UserExceptionCode.USER_NICKNAME_NOT_VALID.name()))
+				.andExpect(jsonPath("$.errors[0].message").value(UserExceptionCode.USER_NICKNAME_NOT_VALID.getMessage()));
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql"}
+			"/init-script/init-user.sql"}
 	)
 	@DisplayName("프로필 이미지 변경에 성공한다.")
 	@Test
 	void test_6() throws Exception {
 
 		MvcResult result = mockMvc.perform(patch("/api/v1/users/profile-image")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.content(mapper.writeValueAsString(new ProfileImageChangeRequest("newProfileImageUrl")))
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.content(mapper.writeValueAsString(new ProfileImageChangeRequest("newProfileImageUrl")))
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
@@ -209,23 +209,23 @@ class UserCommandIntegrationTest extends IntegrationTestSupport {
 	}
 
 	@Sql(scripts = {
-		"/init-script/init-user.sql"}
+			"/init-script/init-user.sql"}
 	)
 	@DisplayName("프로필 이미지에 null을 넣는 경우 변경에 성공한다.(삭제)")
 	@Test
 	void test_7() throws Exception {
 
 		MvcResult result = mockMvc.perform(patch("/api/v1/users/profile-image")
-				.contentType(MediaType.APPLICATION_JSON)
-				.header("Authorization", "Bearer " + getToken())
-				.content(mapper.writeValueAsString(new ProfileImageChangeRequest(null)))
-				.with(csrf())
-			)
-			.andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
-			.andExpect(jsonPath("$.data").exists())
-			.andReturn();
+						.contentType(MediaType.APPLICATION_JSON)
+						.header("Authorization", "Bearer " + getToken())
+						.content(mapper.writeValueAsString(new ProfileImageChangeRequest(null)))
+						.with(csrf())
+				)
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value(200))
+				.andExpect(jsonPath("$.data").exists())
+				.andReturn();
 
 		String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
 		GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);

--- a/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
+++ b/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
@@ -68,25 +68,25 @@ class OauthServiceTest {
 	@BeforeEach
 	void setUp() {
 
-		request = new OauthRequest("cdm2883@naver.com", SocialType.KAKAO,
-			null, 26);
+		request = new OauthRequest("cdm2883@naver.com", null, SocialType.KAKAO,
+				null, 26);
 
 		String nickName = "mockNickname";
 
 		user = User.builder()
-			.id(1L)
-			.email("cdm2883@naver.com")
-			.gender(GenderType.MALE)
-			.socialType(new ArrayList<>(List.of(SocialType.KAKAO)))
-			.age(26)
-			.nickName(nickName)
-			.role(UserType.ROLE_USER)
-			.build();
+				.id(1L)
+				.email("cdm2883@naver.com")
+				.gender(GenderType.MALE)
+				.socialType(new ArrayList<>(List.of(SocialType.KAKAO)))
+				.age(26)
+				.nickName(nickName)
+				.role(UserType.ROLE_USER)
+				.build();
 
 		tokenItem = TokenItem.builder()
-			.accessToken("mock-accessToken")
-			.refreshToken("mock-refreshToken")
-			.build();
+				.accessToken("mock-accessToken")
+				.refreshToken("mock-refreshToken")
+				.build();
 
 		reissueRefreshToken = "mock-refreshToken";
 	}
@@ -100,7 +100,7 @@ class OauthServiceTest {
 		//when
 		when(oauthRepository.save(any(User.class))).thenReturn(user);
 		//then
-		User resultUser = oauthService.oauthSignUp(request.email(), request.socialType(), request.gender(), request.age(), UserType.ROLE_USER);
+		User resultUser = oauthService.oauthSignUp(request, UserType.ROLE_USER);
 
 		assertThat(resultUser.getAge()).isEqualTo(request.age());
 	}
@@ -115,7 +115,7 @@ class OauthServiceTest {
 		when(oauthRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
 
 		when(jwtTokenProvider.generateToken(user.getEmail(), user.getRole(),
-			user.getId())).thenReturn(tokenItem);
+				user.getId())).thenReturn(tokenItem);
 
 		TokenItem result = oauthService.login(request);
 		System.out.println(result.accessToken() + " " + result.refreshToken());
@@ -134,7 +134,7 @@ class OauthServiceTest {
 		when(oauthRepository.save(any(User.class))).thenReturn(user);
 
 		when(jwtTokenProvider.generateToken(user.getEmail(), user.getRole(),
-			user.getId())).thenReturn(tokenItem);
+				user.getId())).thenReturn(tokenItem);
 
 		oauthService.login(request);
 
@@ -153,7 +153,7 @@ class OauthServiceTest {
 		when(oauthRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
 
 		when(jwtTokenProvider.generateToken(user.getEmail(), user.getRole(),
-			user.getId())).thenReturn(tokenItem);
+				user.getId())).thenReturn(tokenItem);
 
 		oauthService.login(request);
 
@@ -170,23 +170,23 @@ class OauthServiceTest {
 	@DisplayName("토큰 재발급을 할 수 있다.")
 	void reissue_token() {
 		try (MockedStatic<JwtTokenValidator> mockedValidator = mockStatic(
-			JwtTokenValidator.class)) {
+				JwtTokenValidator.class)) {
 
 			//when
 			mockedValidator.when(() -> JwtTokenValidator.validateToken(reissueRefreshToken))
-				.thenReturn(true);
+					.thenReturn(true);
 
 			when(jwtAuthenticationManager.getAuthentication(reissueRefreshToken)).thenReturn(
-				mock(Authentication.class));
+					mock(Authentication.class));
 
 			when(oauthRepository.findByRefreshToken(reissueRefreshToken)).thenReturn(
-				Optional.of(user));
+					Optional.of(user));
 
 			when(jwtTokenProvider.generateToken(anyString(), any(UserType.class), anyLong()))
-				.thenReturn(TokenItem.builder()
-					.accessToken("newAccessToken")
-					.refreshToken("newRefreshToken")
-					.build());
+					.thenReturn(TokenItem.builder()
+							.accessToken("newAccessToken")
+							.refreshToken("newRefreshToken")
+							.build());
 
 			// then
 			TokenItem response = oauthService.refresh(reissueRefreshToken);
@@ -204,11 +204,11 @@ class OauthServiceTest {
 	@DisplayName("토큰 검증에 통과하지 못하면 토큰 재발급에 실패한다")
 	void reissue_token_fail() {
 		try (MockedStatic<JwtTokenValidator> mockedValidator = mockStatic(
-			JwtTokenValidator.class)) {
+				JwtTokenValidator.class)) {
 
 			//when
 			mockedValidator.when(() -> JwtTokenValidator.validateToken(reissueRefreshToken))
-				.thenReturn(false);
+					.thenReturn(false);
 
 			// then
 			assertThrows(UserException.class, () -> oauthService.refresh(reissueRefreshToken));

--- a/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
+++ b/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
@@ -92,20 +92,6 @@ class OauthServiceTest {
 	}
 
 	@Test
-	@DisplayName("회원가입을 할 수 있다.")
-	void signup_test() {
-
-		//given
-
-		//when
-		when(oauthRepository.save(any(User.class))).thenReturn(user);
-		//then
-		User resultUser = oauthService.oauthSignUp(request, UserType.ROLE_USER);
-
-		assertThat(resultUser.getAge()).isEqualTo(request.age());
-	}
-
-	@Test
 	@DisplayName("로그인을 할 수 있다.")
 	void signin_test() {
 


### PR DESCRIPTION
Resolves #{이슈-번호}
#359 

# 해결하려는 문제가 무엇인가요?

- 애플 로그인의 요구사항을 적용합니다. 
> 최초 로그인시, email 과 id를 둘 다 받습니다.
이후 로그인시, 유저 id 만을 받습니다.
아이디는 001856.64db7e4847bc4e3895847ab884862ac4.0554 와 같은 형식의 string 입니다.
이에 따라, 최초 로그인시 id 와 email 을 BE 로 전달하고,
이후 로그인 시 id 를 전송하여 서버에 저장된 id, email 값과 매칭시켜 토큰 발급을 해주시면 될 것 같습니다



# 어떻게 해결했나요?

- switch case문을 사용해서 분기
- 중복된 로직을 추출

# 어떤 부분에 집중하여 리뷰해야 할까요?
**- 애플 로그인 시 최초에만 email, socialUniqueId를 주고, 이후부터는 email을 주지않아서 RequestDto의 email에 Validation 어노테이션을 제거해야함**
**- 애플이 아닌 다른 로그인에는 email이 필수값이기 때문에 어떻게 validation을 수행해야할지 고민중......**

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced social login functionality by using a unique identifier for improved security and streamlined authentication.
	- Improved error feedback during login, with clearer messaging for temporary login issues.
	- Added a new field for social unique ID in user records to support social login identification.
	- Introduced a method to retrieve users by their social unique ID.

- **Bug Fixes**
	- Resolved issues related to user login handling when social unique ID is missing.

- **Chores**
	- Adjusted test formatting for improved readability and consistency without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->