### PR TITLE
apple login v2 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,7 @@ dependencies {
 
 	//apache commons
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
+	implementation 'commons-codec:commons-codec:1.15'
 
 	//test containers
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
+	implementation("com.google.guava:guava:32.1.2-jre") // Nonce 저장을 위한 캐시
+
 	// spring rest docs
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/src/main/java/app/bottlenote/global/security/jwt/AppleTokenValidator.java
+++ b/src/main/java/app/bottlenote/global/security/jwt/AppleTokenValidator.java
@@ -1,0 +1,117 @@
+package app.bottlenote.global.security.jwt;
+
+import app.bottlenote.user.exception.UserException;
+import app.bottlenote.user.exception.UserExceptionCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class AppleTokenValidator {
+
+	private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
+	private static final String APPLE_ISSUER = "https://appleid.apple.com";
+
+	// application.yml 에서 실제 값 주입
+	@Value("${apple.bundle-id}")
+	private String appleAudience;
+
+	// Apple 공개키는 자주 바뀌지 않으므로 캐싱하여 사용
+	private final Cache<String, List<Map<String, String>>> publicKeyCache = CacheBuilder.newBuilder()
+		.expireAfterWrite(1, TimeUnit.DAYS)
+		.build();
+
+	public Claims validateAndGetClaims(String idToken, String expectedNonce) {
+		String headerOfIdToken = idToken.substring(0, idToken.indexOf('.'));
+		Map<String, String> header;
+		try {
+			header = new ObjectMapper().readValue(new String(Base64.getDecoder().decode(headerOfIdToken)), Map.class);
+		} catch (JsonProcessingException e) {
+			throw new UserException(UserExceptionCode.APPLE_ID_TOKEN_HEADER_PARSING_ERROR);
+		}
+
+		PublicKey publicKey = getPublicKey(header);
+
+		Claims claims;
+		try {
+			claims = Jwts.parserBuilder()
+				.setSigningKey(publicKey)
+				.requireIssuer(APPLE_ISSUER)
+				.requireAudience(appleAudience)
+				.build()
+				.parseClaimsJws(idToken)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			throw new UserException(UserExceptionCode.APPLE_ID_TOKEN_EXPIRED);
+		} catch (Exception e) {
+			throw new UserException(UserExceptionCode.INVALID_APPLE_ID_TOKEN);
+		}
+
+
+		String nonceFromToken = claims.get("nonce", String.class);
+		if (nonceFromToken == null || !nonceFromToken.equals(expectedNonce)) {
+			throw new UserException(UserExceptionCode.NONCE_MISMATCH);
+		}
+
+		return claims;
+	}
+
+	private PublicKey getPublicKey(Map<String, String> header) {
+		List<Map<String, String>> publicKeys = getApplePublicKeys();
+		Map<String, String> matchedKey = publicKeys.stream()
+			.filter(key -> key.get("kid").equals(header.get("kid")) && key.get("alg").equals(header.get("alg")))
+			.findFirst()
+			.orElseThrow(() -> new UserException(UserExceptionCode.NO_MATCHING_APPLE_PUBLIC_KEY));
+
+		return createPublicKey(matchedKey);
+	}
+
+	private List<Map<String, String>> getApplePublicKeys() {
+		return publicKeyCache.getIfPresent(APPLE_PUBLIC_KEYS_URL) != null ?
+			publicKeyCache.getIfPresent(APPLE_PUBLIC_KEYS_URL) :
+			fetchApplePublicKeys();
+	}
+
+	private List<Map<String, String>> fetchApplePublicKeys() {
+		RestTemplate restTemplate = new RestTemplate();
+		Map<String, List<Map<String, String>>> keys = restTemplate.getForObject(APPLE_PUBLIC_KEYS_URL, Map.class);
+		publicKeyCache.put(APPLE_PUBLIC_KEYS_URL, keys.get("keys"));
+		return keys.get("keys");
+	}
+
+	private PublicKey createPublicKey(Map<String, String> keyData) {
+		try {
+			BigInteger n = new BigInteger(1, Base64.getUrlDecoder().decode(keyData.get("n")));
+			BigInteger e = new BigInteger(1, Base64.getUrlDecoder().decode(keyData.get("e")));
+			RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+			KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+			return keyFactory.generatePublic(publicKeySpec);
+		} catch (Exception ex) {
+			throw new UserException(UserExceptionCode.APPLE_PUBLIC_KEY_GENERATION_ERROR);
+		}
+	}
+
+	public String getAppleSocialUniqueId(Claims claims) {
+		return claims.getSubject();
+	}
+
+	public String getEmail(Claims claims) {
+		return claims.get("email", String.class);
+	}
+}

--- a/src/main/java/app/bottlenote/global/security/jwt/AppleTokenValidator.java
+++ b/src/main/java/app/bottlenote/global/security/jwt/AppleTokenValidator.java
@@ -9,6 +9,7 @@ import com.google.common.cache.CacheBuilder;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -36,6 +37,7 @@ public class AppleTokenValidator implements TokenValidator {
 	private final Cache<String, List<Map<String, String>>> publicKeyCache = CacheBuilder.newBuilder()
 		.expireAfterWrite(1, TimeUnit.DAYS)
 		.build();
+
 
 	public Claims validateAndGetClaims(String idToken, String expectedNonce) {
 		String headerOfIdToken = idToken.substring(0, idToken.indexOf('.'));
@@ -107,10 +109,16 @@ public class AppleTokenValidator implements TokenValidator {
 		}
 	}
 
-	public String getAppleSocialUniqueId(Claims claims) {
+	@Override
+	public String getSocialUniqueId(Claims claims) {
 		return claims.getSubject();
 	}
 
+	public String getAppleSocialUniqueId(Claims claims) {
+		return getSocialUniqueId(claims);
+	}
+
+	@Override
 	public String getEmail(Claims claims) {
 		return claims.get("email", String.class);
 	}

--- a/src/main/java/app/bottlenote/global/security/jwt/AppleTokenValidator.java
+++ b/src/main/java/app/bottlenote/global/security/jwt/AppleTokenValidator.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Component
-public class AppleTokenValidator {
+public class AppleTokenValidator implements TokenValidator {
 
 	private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
 	private static final String APPLE_ISSUER = "https://appleid.apple.com";

--- a/src/main/java/app/bottlenote/global/security/jwt/TokenValidator.java
+++ b/src/main/java/app/bottlenote/global/security/jwt/TokenValidator.java
@@ -5,6 +5,8 @@ import io.jsonwebtoken.Claims;
 public interface TokenValidator {
 
     Claims validateAndGetClaims(String idToken, String expectedNonce);
+    
+    String getSocialUniqueId(Claims claims);
 
     String getEmail(Claims claims);
 }

--- a/src/main/java/app/bottlenote/global/security/jwt/TokenValidator.java
+++ b/src/main/java/app/bottlenote/global/security/jwt/TokenValidator.java
@@ -1,0 +1,10 @@
+package app.bottlenote.global.security.jwt;
+
+import io.jsonwebtoken.Claims;
+
+public interface TokenValidator {
+
+    Claims validateAndGetClaims(String idToken, String expectedNonce);
+
+    String getEmail(Claims claims);
+}

--- a/src/main/java/app/bottlenote/user/controller/AuthV2Controller.java
+++ b/src/main/java/app/bottlenote/user/controller/AuthV2Controller.java
@@ -2,12 +2,24 @@ package app.bottlenote.user.controller;
 
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
+import app.bottlenote.user.config.OauthConfigProperties;
+import app.bottlenote.user.dto.request.AppleLoginRequest;
+import app.bottlenote.user.dto.response.NonceResponse;
+import app.bottlenote.user.dto.response.OauthResponse;
+import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.service.AuthService;
+import app.bottlenote.user.service.NonceService;
+import app.bottlenote.user.service.OauthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +32,10 @@ import static app.bottlenote.user.exception.UserExceptionCode.REQUIRED_USER_ID;
 @RequestMapping("/api/v2/auth")
 public class AuthV2Controller {
 	private final AuthService authService;
+	private final NonceService nonceService;
+	private final OauthService oauthService;
+	private final OauthConfigProperties configProperties;
+	private static final String REFRESH_TOKEN_HEADER_PREFIX = "refresh-token";
 
 	@GetMapping("/admin/permissions")
 	public ResponseEntity<?> checkAdminStatus() {
@@ -28,5 +44,41 @@ public class AuthV2Controller {
 
 		boolean is = authService.checkAdminStatus(currentUserId);
 		return GlobalResponse.ok(is);
+	}
+
+	/**
+	 * Apple 로그인 전, 클라이언트에게 일회성 Nonce 값을 발급
+	 */
+	@GetMapping("/apple/nonce")
+	public ResponseEntity<NonceResponse> getAppleNonce() {
+		return ResponseEntity.ok(new NonceResponse(nonceService.generateNonce()));
+	}
+
+	/**
+	 * Apple 로그인 v2
+	 */
+	@PostMapping("/apple")
+	public ResponseEntity<?> executeAppleLogin(
+			@RequestBody @Valid AppleLoginRequest appleLoginRequest,
+			HttpServletResponse response
+	) {
+		TokenItem token = oauthService.loginWithApple(
+				appleLoginRequest.idToken(),
+				appleLoginRequest.nonce()
+		);
+		setRefreshTokenInCookie(response, token.refreshToken());
+		return ResponseEntity.ok(OauthResponse.of(token.accessToken()));
+	}
+
+	private void setRefreshTokenInCookie(HttpServletResponse response, String refreshToken) {
+		final int COOKIE_EXPIRE_TIME = 14 * 24 * 60 * 60;
+		final int cookieExpireTime = configProperties.getCookieExpireTime();
+		log.info("cookie basic expire time : {} properties time :{}", COOKIE_EXPIRE_TIME, cookieExpireTime);
+		Cookie cookie = new Cookie(REFRESH_TOKEN_HEADER_PREFIX, refreshToken);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(true);
+		cookie.setPath("/");
+		cookie.setMaxAge(COOKIE_EXPIRE_TIME);
+		response.addCookie(cookie);
 	}
 }

--- a/src/main/java/app/bottlenote/user/controller/OauthController.java
+++ b/src/main/java/app/bottlenote/user/controller/OauthController.java
@@ -2,15 +2,18 @@ package app.bottlenote.user.controller;
 
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.user.config.OauthConfigProperties;
+import app.bottlenote.user.dto.request.AppleLoginRequest;
 import app.bottlenote.user.dto.request.BasicAccountRequest;
 import app.bottlenote.user.dto.request.BasicLoginRequest;
 import app.bottlenote.user.dto.request.GuestCodeRequest;
 import app.bottlenote.user.dto.request.OauthRequest;
 import app.bottlenote.user.dto.response.BasicAccountResponse;
+import app.bottlenote.user.dto.response.NonceResponse;
 import app.bottlenote.user.dto.response.OauthResponse;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
+import app.bottlenote.user.service.NonceService;
 import app.bottlenote.user.service.OauthService;
 import app.external.push.data.request.SingleTokenRequest;
 import jakarta.servlet.http.Cookie;
@@ -20,6 +23,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,7 +40,32 @@ import java.util.Base64;
 public class OauthController {
 	private static final String REFRESH_TOKEN_HEADER_PREFIX = "refresh-token";
 	private final OauthService oauthService;
+	private final NonceService nonceService;
 	private final OauthConfigProperties configProperties;
+
+	/**
+	 * Apple 로그인 전, 클라이언트에게 일회성 Nonce 값을 발급
+	 */
+	@GetMapping("/apple/nonce")
+	public ResponseEntity<NonceResponse> getAppleNonce() {
+		return ResponseEntity.ok(new NonceResponse(nonceService.generateNonce()));
+	}
+
+	/**
+	 * Apple 로그인 v2
+	 */
+	@PostMapping("/apple")
+	public ResponseEntity<?> executeAppleLogin(
+			@RequestBody @Valid AppleLoginRequest appleLoginRequest,
+			HttpServletResponse response
+	) {
+		TokenItem token = oauthService.loginWithApple(
+				appleLoginRequest.idToken(),
+				appleLoginRequest.nonce()
+		);
+		 setRefreshTokenInCookie(response, token.refreshToken());
+		return ResponseEntity.ok(OauthResponse.of(token.accessToken()));
+	}
 
 
 	@PostMapping("/basic/signup")

--- a/src/main/java/app/bottlenote/user/controller/OauthController.java
+++ b/src/main/java/app/bottlenote/user/controller/OauthController.java
@@ -40,32 +40,7 @@ import java.util.Base64;
 public class OauthController {
 	private static final String REFRESH_TOKEN_HEADER_PREFIX = "refresh-token";
 	private final OauthService oauthService;
-	private final NonceService nonceService;
 	private final OauthConfigProperties configProperties;
-
-	/**
-	 * Apple 로그인 전, 클라이언트에게 일회성 Nonce 값을 발급
-	 */
-	@GetMapping("/apple/nonce")
-	public ResponseEntity<NonceResponse> getAppleNonce() {
-		return ResponseEntity.ok(new NonceResponse(nonceService.generateNonce()));
-	}
-
-	/**
-	 * Apple 로그인 v2
-	 */
-	@PostMapping("/apple")
-	public ResponseEntity<?> executeAppleLogin(
-			@RequestBody @Valid AppleLoginRequest appleLoginRequest,
-			HttpServletResponse response
-	) {
-		TokenItem token = oauthService.loginWithApple(
-				appleLoginRequest.idToken(),
-				appleLoginRequest.nonce()
-		);
-		 setRefreshTokenInCookie(response, token.refreshToken());
-		return ResponseEntity.ok(OauthResponse.of(token.accessToken()));
-	}
 
 
 	@PostMapping("/basic/signup")

--- a/src/main/java/app/bottlenote/user/dto/request/AppleLoginRequest.java
+++ b/src/main/java/app/bottlenote/user/dto/request/AppleLoginRequest.java
@@ -1,0 +1,6 @@
+package app.bottlenote.user.dto.request;
+
+public record AppleLoginRequest(
+		String idToken,
+		String nonce
+) {}

--- a/src/main/java/app/bottlenote/user/dto/response/NonceResponse.java
+++ b/src/main/java/app/bottlenote/user/dto/response/NonceResponse.java
@@ -1,0 +1,5 @@
+package app.bottlenote.user.dto.response;
+
+public record NonceResponse(
+		String nonce
+) {}

--- a/src/main/java/app/bottlenote/user/exception/UserExceptionCode.java
+++ b/src/main/java/app/bottlenote/user/exception/UserExceptionCode.java
@@ -28,7 +28,13 @@ public enum UserExceptionCode implements ExceptionCode {
 	JSON_PARSING_EXCEPTION(HttpStatus.BAD_REQUEST, "JSON 처리 중 오류가 발생했습니다"),
 	NOT_MATCH_GUEST_CODE(HttpStatus.BAD_REQUEST, "게스트 코드가 일치하지 않습니다."),
 	INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-	TEMPORARY_LOGIN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 로그인 오류입니다.");
+	TEMPORARY_LOGIN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "일시적인 로그인 오류입니다."),
+	INVALID_APPLE_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Apple ID 토큰입니다."),
+	APPLE_ID_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Apple ID 토큰이 만료되었습니다."),
+	NONCE_MISMATCH(HttpStatus.UNAUTHORIZED, "ID Token의 nonce 값이 일치하지 않습니다."),
+	APPLE_PUBLIC_KEY_GENERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 공개키 생성 오류"),
+	NO_MATCHING_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "일치하는 Apple 공개키 없음"),
+	APPLE_ID_TOKEN_HEADER_PARSING_ERROR(HttpStatus.BAD_REQUEST, "Apple ID Token 헤더 파싱 오류");
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/src/main/java/app/bottlenote/user/exception/UserExceptionCode.java
+++ b/src/main/java/app/bottlenote/user/exception/UserExceptionCode.java
@@ -34,7 +34,10 @@ public enum UserExceptionCode implements ExceptionCode {
 	NONCE_MISMATCH(HttpStatus.UNAUTHORIZED, "ID Token의 nonce 값이 일치하지 않습니다."),
 	APPLE_PUBLIC_KEY_GENERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Apple 공개키 생성 오류"),
 	NO_MATCHING_APPLE_PUBLIC_KEY(HttpStatus.BAD_REQUEST, "일치하는 Apple 공개키 없음"),
-	APPLE_ID_TOKEN_HEADER_PARSING_ERROR(HttpStatus.BAD_REQUEST, "Apple ID Token 헤더 파싱 오류");
+	APPLE_ID_TOKEN_HEADER_PARSING_ERROR(HttpStatus.BAD_REQUEST, "Apple ID Token 헤더 파싱 오류"),
+	INVALID_NONCE(HttpStatus.UNAUTHORIZED, "유효하지 않은 Nonce 값입니다."),
+	NONCE_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 Nonce 값입니다."),
+	NONCE_ALREADY_USED(HttpStatus.UNAUTHORIZED, "이미 사용된 Nonce 값입니다.");
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/src/main/java/app/bottlenote/user/service/NonceService.java
+++ b/src/main/java/app/bottlenote/user/service/NonceService.java
@@ -1,5 +1,6 @@
 package app.bottlenote.user.service;
 
+import app.bottlenote.common.annotation.ThirdPartyService;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
 import lombok.RequiredArgsConstructor;
@@ -16,28 +17,29 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@ThirdPartyService
 public class NonceService {
 
 	private static final String NONCE_PREFIX = "auth:nonce:";
 	private static final Duration NONCE_TTL = Duration.ofMinutes(10);
-	
+
 	private final RedisTemplate<String, Object> redisTemplate;
-	
+
 	@Value("${security.nonce.salt}")
 	private String nonceSalt;
 
 	/**
 	 * 클라이언트에게 전달할 일회성 Nonce 값을 생성하고 Redis에 저장
 	 */
-	@Transactional
+
 	public String generateNonce() {
 		String baseNonce = UUID.randomUUID().toString();
 		String saltedNonce = DigestUtils.sha256Hex(baseNonce + nonceSalt);
 		String key = NONCE_PREFIX + saltedNonce;
-		
+
 		redisTemplate.opsForValue().set(key, saltedNonce, NONCE_TTL);
 		log.debug("Salt 적용된 Nonce 생성 및 저장 완료: {}", saltedNonce);
-		
+
 		return saltedNonce;
 	}
 
@@ -48,15 +50,15 @@ public class NonceService {
 	@Transactional
 	public void validateNonce(String nonce) {
 		String key = NONCE_PREFIX + nonce;
-		
+
 		// getAndDelete를 사용하여 원자적으로 값을 가져오고 삭제
 		Object stored = redisTemplate.opsForValue().getAndDelete(key);
-		
+
 		if (stored == null) {
 			log.warn("유효하지 않은 Nonce 검증 시도: {}", nonce);
 			throw new UserException(UserExceptionCode.INVALID_NONCE);
 		}
-		
+
 		log.debug("Nonce 검증 및 제거 완료: {}", nonce);
 	}
 }

--- a/src/main/java/app/bottlenote/user/service/NonceService.java
+++ b/src/main/java/app/bottlenote/user/service/NonceService.java
@@ -18,6 +18,7 @@ public class NonceService {
 	/**
 	 * 클라이언트에게 전달할 일회성 Nonce 값을 생성하고 캐시에 저장
 	 */
+	@Transactional
 	public String generateNonce() {
 		String nonce = UUID.randomUUID().toString();
 		nonceStore.put(nonce, nonce); // key-value 형태로 저장
@@ -28,6 +29,7 @@ public class NonceService {
 	 * 클라이언트로부터 받은 Nonce가 유효한지 검증
 	 * 유효하다면 캐시에서 즉시 제거하여 재사용 방지
 	 */
+	@Transactional
 	public void validateNonce(String nonce) {
 		if (nonceStore.getIfPresent(nonce) == null) {
 			// 캐시에 nonce가 없으면 유효하지 않거나 만료된 것으로 간주

--- a/src/main/java/app/bottlenote/user/service/NonceService.java
+++ b/src/main/java/app/bottlenote/user/service/NonceService.java
@@ -1,0 +1,39 @@
+package app.bottlenote.user.service;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class NonceService {
+
+	// Nonce를 10분 동안만 저장하는 캐시
+	private final Cache<String, String> nonceStore = CacheBuilder.newBuilder()
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.build();
+
+	/**
+	 * 클라이언트에게 전달할 일회성 Nonce 값을 생성하고 캐시에 저장
+	 */
+	public String generateNonce() {
+		String nonce = UUID.randomUUID().toString();
+		nonceStore.put(nonce, nonce); // key-value 형태로 저장
+		return nonce;
+	}
+
+	/**
+	 * 클라이언트로부터 받은 Nonce가 유효한지 검증
+	 * 유효하다면 캐시에서 즉시 제거하여 재사용 방지
+	 */
+	public void validateNonce(String nonce) {
+		if (nonceStore.getIfPresent(nonce) == null) {
+			// 캐시에 nonce가 없으면 유효하지 않거나 만료된 것으로 간주
+			throw new IllegalArgumentException("유효하지 않은 Nonce 값입니다.");
+		}
+		// 한번 사용한 Nonce는 즉시 무효화
+		nonceStore.invalidate(nonce);
+	}
+}

--- a/src/main/java/app/bottlenote/user/service/NonceService.java
+++ b/src/main/java/app/bottlenote/user/service/NonceService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.transaction.annotation.Transactional;
+
 @Service
 public class NonceService {
 

--- a/src/main/java/app/bottlenote/user/service/NonceService.java
+++ b/src/main/java/app/bottlenote/user/service/NonceService.java
@@ -1,5 +1,7 @@
 package app.bottlenote.user.service;
 
+import app.bottlenote.user.exception.UserException;
+import app.bottlenote.user.exception.UserExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -46,7 +48,7 @@ public class NonceService {
 		
 		if (stored == null) {
 			log.warn("유효하지 않은 Nonce 검증 시도: {}", nonce);
-			throw new IllegalArgumentException("유효하지 않은 Nonce 값입니다.");
+			throw new UserException(UserExceptionCode.INVALID_NONCE);
 		}
 		
 		log.debug("Nonce 검증 및 제거 완료: {}", nonce);

--- a/src/main/java/app/bottlenote/user/service/OauthService.java
+++ b/src/main/java/app/bottlenote/user/service/OauthService.java
@@ -199,7 +199,12 @@ public class OauthService {
 	@Transactional
 	public TokenItem refresh(String refreshToken) {
 		//refresh Token 검증
-		if (!validateToken(refreshToken)) {
+		try {
+			if (!validateToken(refreshToken)) {
+				throw new UserException(INVALID_REFRESH_TOKEN);
+			}
+		} catch (Exception e) {
+			// JWT 관련 예외들을 UserException으로 변환
 			throw new UserException(INVALID_REFRESH_TOKEN);
 		}
 

--- a/src/main/java/app/bottlenote/user/service/OauthService.java
+++ b/src/main/java/app/bottlenote/user/service/OauthService.java
@@ -1,6 +1,6 @@
 package app.bottlenote.user.service;
 
-import app.bottlenote.global.security.jwt.AppleTokenValidator;
+import app.bottlenote.global.security.jwt.TokenValidator;
 import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
 import app.bottlenote.global.security.jwt.JwtTokenProvider;
 import app.bottlenote.user.constant.GenderType;
@@ -39,7 +39,7 @@ public class OauthService {
 	private final JwtTokenProvider tokenProvider;
 	private final JwtAuthenticationManager authenticationManager;
 	private final BCryptPasswordEncoder passwordEncoder;
-	private final AppleTokenValidator appleTokenValidator;
+	private final TokenValidator tokenValidator;
 	private final NonceService nonceService;
 	private final SecureRandom randomValue = new SecureRandom();
 
@@ -293,10 +293,10 @@ public class OauthService {
 		nonceService.validateNonce(nonce);
 
 		// 2. id_token 검증 및 Claims 추출 (nonce 포함)
-		Claims claims = appleTokenValidator.validateAndGetClaims(idToken, nonce);
+		Claims claims = tokenValidator.validateAndGetClaims(idToken, nonce);
 
-		String socialUniqueId = appleTokenValidator.getAppleSocialUniqueId(claims);
-		String email = appleTokenValidator.getEmail(claims);
+		String socialUniqueId = tokenValidator.getSocialUniqueId(claims);
+		String email = tokenValidator.getEmail(claims);
 
 		User user = oauthRepository.findBySocialUniqueId(socialUniqueId)
 				.orElseGet(() -> findByEmailOrCreateUser(email, socialUniqueId));

--- a/src/main/java/app/bottlenote/user/service/OauthService.java
+++ b/src/main/java/app/bottlenote/user/service/OauthService.java
@@ -1,5 +1,6 @@
 package app.bottlenote.user.service;
 
+import app.bottlenote.global.security.jwt.AppleTokenValidator;
 import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
 import app.bottlenote.global.security.jwt.JwtTokenProvider;
 import app.bottlenote.user.constant.GenderType;
@@ -12,6 +13,7 @@ import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
 import app.bottlenote.user.repository.OauthRepository;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -37,6 +39,8 @@ public class OauthService {
 	private final JwtTokenProvider tokenProvider;
 	private final JwtAuthenticationManager authenticationManager;
 	private final BCryptPasswordEncoder passwordEncoder;
+	private final AppleTokenValidator appleTokenValidator;
+	private final NonceService nonceService;
 	private final SecureRandom randomValue = new SecureRandom();
 
 	@Transactional
@@ -281,5 +285,47 @@ public class OauthService {
 			log.error("Token is invalid : {}", e.getMessage());
 			return String.format("Token is invalid {%s}", e.getMessage());
 		}
+	}
+
+	@Transactional
+	public TokenItem loginWithApple(String idToken, String nonce) {
+		// 1. Nonce 검증 (가장 먼저 수행하여 재전송 공격 방어)
+		nonceService.validateNonce(nonce);
+
+		// 2. id_token 검증 및 Claims 추출 (nonce 포함)
+		Claims claims = appleTokenValidator.validateAndGetClaims(idToken, nonce);
+
+		String socialUniqueId = appleTokenValidator.getAppleSocialUniqueId(claims);
+		String email = appleTokenValidator.getEmail(claims);
+
+		User user = oauthRepository.findBySocialUniqueId(socialUniqueId)
+				.orElseGet(() -> findByEmailOrCreateUser(email, socialUniqueId));
+
+		checkActiveUser(user);
+		return getTokenItem(user, SocialType.APPLE);
+	}
+
+	private User findByEmailOrCreateUser(String email, String socialUniqueId) {
+		return oauthRepository.findByEmail(email)
+				.map(existingUser -> {
+					log.info("기존 계정({})에 Apple 계정 연동: socialUniqueId={}", email, socialUniqueId);
+					existingUser.updateSocialUniqueId(socialUniqueId); // 👈 socialUniqueId 업데이트 로직 필요
+					return existingUser;
+				})
+				.orElseGet(() -> {
+					log.info("Apple 신규 회원가입: email={}, socialUniqueId={}", email, socialUniqueId);
+					return signupWithApple(email, socialUniqueId);
+				});
+	}
+
+	private User signupWithApple(String email, String socialUniqueId) {
+		User user = User.builder()
+				.email(email)
+				.socialUniqueId(socialUniqueId)
+				.socialType(List.of(SocialType.APPLE))
+				.role(UserType.ROLE_USER)
+				.nickName(generateNickname())
+				.build();
+		return oauthRepository.save(user);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,3 +74,6 @@ management:
   endpoint:
     health:
       show-details: always
+
+apple:
+  bundle-id: "com.bottlenote.official.app"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,8 @@ security:
     secret-key: ${JWT_SECRET_KEY:c2VjdXJlU2VjcmV0S2V5MTIzNDU2Nzg5MGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QWJDRGVGR2hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlrSg==}
     access-token-expiration: 86400 # 하루 (24시간)
     refresh-token-expiration: 2592000 # 한 달 (30일)
+  nonce:
+    salt: ${NONCE_SALT:bottle-note-secure-salt-2024}
 
 
 # Actuator 설정

--- a/src/test/java/app/bottlenote/user/controller/OauthControllerTest.java
+++ b/src/test/java/app/bottlenote/user/controller/OauthControllerTest.java
@@ -5,7 +5,6 @@ import app.bottlenote.global.exception.custom.code.ValidExceptionCode;
 import app.bottlenote.user.config.OauthConfigProperties;
 import app.bottlenote.user.constant.GenderType;
 import app.bottlenote.user.constant.SocialType;
-import app.bottlenote.user.dto.request.AppleLoginRequest;
 import app.bottlenote.user.dto.request.OauthRequest;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.exception.UserException;
@@ -26,9 +25,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -229,63 +225,4 @@ class OauthControllerTest {
 						result.getResolvedException() instanceof IllegalArgumentException))
 				.andExpect(jsonPath("$.errors").exists());
 	}
-
-
-	@Test
-	@DisplayName("유저는 Apple 로그인을 할 수 있다.")
-	void user_apple_login_success() throws Exception {
-		// Given
-		String idToken = "mockIdToken";
-		String nonce = "mockNonce";
-		TokenItem expectedTokenItem = TokenItem.builder()
-				.accessToken("apple-access-token")
-				.refreshToken("apple-refresh-token")
-				.build();
-
-		when(oauthService.loginWithApple(idToken, nonce)).thenReturn(expectedTokenItem);
-
-		// When & Then
-		mockMvc.perform(post("/api/v1/oauth/apple")
-						.contentType(MediaType.APPLICATION_JSON)
-						.with(csrf())
-						.content(mapper.writeValueAsString(new AppleLoginRequest(idToken, nonce))))
-				.andDo(print())
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.accessToken").value("apple-access-token"))
-				.andExpect(cookie().value("refresh-token", "apple-refresh-token"))
-				.andExpect(cookie().httpOnly("refresh-token", true))
-				.andExpect(cookie().secure("refresh-token", true))
-				.andExpect(cookie().maxAge("refresh-token", 1209600))
-				.andExpect(cookie().path("refresh-token", "/"));
-
-		verify(oauthService, times(1)).loginWithApple(idToken, nonce);
-	}
-
-	@Test
-	@DisplayName("유저는 Apple 로그인 시 Nonce 검증 실패로 로그인 할 수 없다.")
-	void user_apple_login_invalid_nonce_failure() throws Exception {
-		Error error = Error.of(UserExceptionCode.NONCE_MISMATCH);
-
-		// Given
-		String idToken = "mockIdToken";
-		String invalidNonce = "invalidNonce";
-
-		doThrow(new UserException(UserExceptionCode.NONCE_MISMATCH))
-				.when(oauthService).loginWithApple(idToken, invalidNonce);
-
-		// When & Then
-		mockMvc.perform(post("/api/v1/oauth/apple")
-						.contentType(MediaType.APPLICATION_JSON)
-						.with(csrf())
-						.content(mapper.writeValueAsString(new AppleLoginRequest(idToken, invalidNonce))))
-				.andDo(print())
-				.andExpect(status().isUnauthorized())
-				.andExpect(jsonPath("$.errors[0].code").value(String.valueOf(error.code())))
-				.andExpect(jsonPath("$.errors[0].status").value(error.status().name()))
-				.andExpect(jsonPath("$.errors[0].message").value(error.message()));
-
-		verify(oauthService, times(1)).loginWithApple(idToken, invalidNonce);
-	}
-
-
 }

--- a/src/test/java/app/bottlenote/user/fake/FakeAppleTokenValidator.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeAppleTokenValidator.java
@@ -1,0 +1,194 @@
+package app.bottlenote.user.fake;
+
+import app.bottlenote.global.security.jwt.AppleTokenValidator;
+import app.bottlenote.global.security.jwt.TokenValidator;
+import io.jsonwebtoken.Claims;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class FakeAppleTokenValidator extends AppleTokenValidator implements TokenValidator {
+
+	@Override
+	public Claims validateAndGetClaims(String idToken, String expectedNonce) {
+		return new FakeClaims(expectedNonce);
+	}
+	
+	@Override
+	public String getSocialUniqueId(Claims claims) {
+		return claims.getSubject();
+	}
+
+	@Override
+	public String getAppleSocialUniqueId(Claims claims) {
+		return getSocialUniqueId(claims);
+	}
+	
+	@Override
+	public String getEmail(Claims claims) {
+		return claims.get("email", String.class);
+	}
+
+	private static class FakeClaims implements Claims {
+		private final Map<String, Object> claims = new HashMap<>();
+
+		public FakeClaims(String nonce) {
+			claims.put("sub", "fake-apple-user-id");
+			claims.put("email", "apple.user@example.com");
+			claims.put("nonce", nonce);
+			claims.put("iss", "https://appleid.apple.com");
+			claims.put("aud", "com.bottlenote.official.app");
+			claims.put("exp", new Date(System.currentTimeMillis() + 3600000));
+			claims.put("iat", new Date());
+		}
+
+		@Override
+		public String getIssuer() {
+			return (String) claims.get("iss");
+		}
+
+		@Override
+		public Claims setIssuer(String iss) {
+			claims.put("iss", iss);
+			return this;
+		}
+
+		@Override
+		public String getSubject() {
+			return (String) claims.get("sub");
+		}
+
+		@Override
+		public Claims setSubject(String sub) {
+			claims.put("sub", sub);
+			return this;
+		}
+
+		@Override
+		public String getAudience() {
+			return (String) claims.get("aud");
+		}
+
+		@Override
+		public Claims setAudience(String aud) {
+			claims.put("aud", aud);
+			return this;
+		}
+
+		@Override
+		public Date getExpiration() {
+			return (Date) claims.get("exp");
+		}
+
+		@Override
+		public Claims setExpiration(Date exp) {
+			claims.put("exp", exp);
+			return this;
+		}
+
+		@Override
+		public Date getNotBefore() {
+			return (Date) claims.get("nbf");
+		}
+
+		@Override
+		public Claims setNotBefore(Date nbf) {
+			claims.put("nbf", nbf);
+			return this;
+		}
+
+		@Override
+		public Date getIssuedAt() {
+			return (Date) claims.get("iat");
+		}
+
+		@Override
+		public Claims setIssuedAt(Date iat) {
+			claims.put("iat", iat);
+			return this;
+		}
+
+		@Override
+		public String getId() {
+			return (String) claims.get("jti");
+		}
+
+		@Override
+		public Claims setId(String jti) {
+			claims.put("jti", jti);
+			return this;
+		}
+
+		@Override
+		public <T> T get(String claimName, Class<T> requiredType) {
+			Object value = claims.get(claimName);
+			if (value != null && requiredType.isAssignableFrom(value.getClass())) {
+				return requiredType.cast(value);
+			}
+			return null;
+		}
+
+		@Override
+		public int size() {
+			return claims.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return claims.isEmpty();
+		}
+
+		@Override
+		public boolean containsKey(Object key) {
+			return claims.containsKey(key);
+		}
+
+		@Override
+		public boolean containsValue(Object value) {
+			return claims.containsValue(value);
+		}
+
+		@Override
+		public Object get(Object key) {
+			return claims.get(key);
+		}
+
+		@Override
+		public Object put(String key, Object value) {
+			return claims.put(key, value);
+		}
+
+		@Override
+		public Object remove(Object key) {
+			return claims.remove(key);
+		}
+
+		@Override
+		public void putAll(Map<? extends String, ?> m) {
+			claims.putAll(m);
+		}
+
+		@Override
+		public void clear() {
+			claims.clear();
+		}
+
+		@Override
+		public Set<String> keySet() {
+			return claims.keySet();
+		}
+
+		@Override
+		public Collection<Object> values() {
+			return claims.values();
+		}
+
+		@Override
+		public Set<Entry<String, Object>> entrySet() {
+			return claims.entrySet();
+		}
+	}
+}

--- a/src/test/java/app/bottlenote/user/fake/FakeBCryptPasswordEncoder.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeBCryptPasswordEncoder.java
@@ -1,0 +1,16 @@
+package app.bottlenote.user.fake;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class FakeBCryptPasswordEncoder extends BCryptPasswordEncoder {
+
+	@Override
+	public String encode(CharSequence rawPassword) {
+		return "fake-encoded-" + rawPassword;
+	}
+
+	@Override
+	public boolean matches(CharSequence rawPassword, String encodedPassword) {
+		return ("fake-encoded-" + rawPassword).equals(encodedPassword);
+	}
+}

--- a/src/test/java/app/bottlenote/user/fake/FakeJsonArrayConverter.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeJsonArrayConverter.java
@@ -1,0 +1,36 @@
+package app.bottlenote.user.fake;
+
+import app.bottlenote.global.service.converter.JsonArrayConverter;
+import app.bottlenote.user.constant.SocialType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+public class FakeJsonArrayConverter extends JsonArrayConverter {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public String convertToDatabaseColumn(List<SocialType> attribute) {
+		if (attribute == null || attribute.isEmpty()) {
+			return "[]";
+		}
+		try {
+			return objectMapper.writeValueAsString(attribute);
+		} catch (Exception e) {
+			return "[]";
+		}
+	}
+
+	@Override
+	public List<SocialType> convertToEntityAttribute(String dbData) {
+		if (dbData == null || dbData.trim().isEmpty()) {
+			return List.of();
+		}
+		try {
+			return objectMapper.readValue(dbData, List.class);
+		} catch (Exception e) {
+			return List.of();
+		}
+	}
+}

--- a/src/test/java/app/bottlenote/user/fake/FakeJwtAuthenticationManager.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeJwtAuthenticationManager.java
@@ -1,0 +1,25 @@
+package app.bottlenote.user.fake;
+
+import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+public class FakeJwtAuthenticationManager extends JwtAuthenticationManager {
+
+	public FakeJwtAuthenticationManager() {
+		// 더 긴 Base64 인코딩된 시크릿 키 (512비트)
+		super("dGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tZ2VuZXJhdGlvbi10ZXN0aW5nLXB1cnBvc2UtbG9uZy1lbm91Z2gtZm9yLWhtYWMtc2hhLTUxMi12ZXJzaW9uLWFuZC1pbXBvcnRhbnQtc2VjdXJpdHktaW4tbW9kZXJuLWphdmEtYXBwbGljYXRpb25z", null);
+	}
+
+	@Override
+	public Authentication getAuthentication(String token) {
+		// Fake 토큰에서 사용자 정보를 추출하는 로직
+		String email = "test@example.com";
+		List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+		return new UsernamePasswordAuthenticationToken(email, null, authorities);
+	}
+}

--- a/src/test/java/app/bottlenote/user/fake/FakeJwtTokenProvider.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeJwtTokenProvider.java
@@ -1,0 +1,16 @@
+package app.bottlenote.user.fake;
+
+import app.bottlenote.global.security.jwt.JwtTokenProvider;
+import app.bottlenote.user.constant.UserType;
+import app.bottlenote.user.dto.response.TokenItem;
+
+public class FakeJwtTokenProvider extends JwtTokenProvider {
+
+	public FakeJwtTokenProvider() {
+		// 더 긴 Base64 인코딩된 시크릿 키 (512비트)
+		super("dGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tZ2VuZXJhdGlvbi10ZXN0aW5nLXB1cnBvc2UtbG9uZy1lbm91Z2gtZm9yLWhtYWMtc2hhLTUxMi12ZXJzaW9uLWFuZC1pbXBvcnRhbnQtc2VjdXJpdHktaW4tbW9kZXJuLWphdmEtYXBwbGljYXRpb25z");
+	}
+
+	// 실제 JWT 토큰을 생성하도록 부모 클래스의 메서드를 그대로 사용
+	// 이렇게 하면 JwtTokenValidator.validateToken()에서 검증 가능한 실제 JWT가 생성됩니다
+}

--- a/src/test/java/app/bottlenote/user/fake/FakeJwtTokenValidator.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeJwtTokenValidator.java
@@ -1,0 +1,53 @@
+package app.bottlenote.user.fake;
+
+import app.bottlenote.global.security.jwt.CustomJwtException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.Key;
+
+@Slf4j
+public class FakeJwtTokenValidator {
+
+	private final Key secretKey;
+
+	public FakeJwtTokenValidator() {
+		// 테스트용 시크릿 키로 초기화
+		String secret = "dGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tZ2VuZXJhdGlvbi10ZXN0aW5nLXB1cnBvc2UtbG9uZy1lbm91Z2gtZm9yLWhtYWMtc2hhLTUxMi12ZXJzaW9uLWFuZC1pbXBvcnRhbnQtc2VjdXJpdHktaW4tbW9kZXJuLWphdmEtYXBwbGljYXRpb25z";
+		byte[] keyBytes = Decoders.BASE64.decode(secret);
+		this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	/**
+	 * 토큰의 유효성을 검사하는 메소드
+	 */
+	public boolean validateToken(String token) throws
+			io.jsonwebtoken.security.SecurityException, MalformedJwtException,
+			ExpiredJwtException, UnsupportedJwtException, IllegalArgumentException,
+			CustomJwtException {
+
+		if (token == null || token.trim().isEmpty()) {
+			return false;
+		}
+
+		// invalid 토큰은 항상 검증 실패
+		if ("invalid-refresh-token".equals(token)) {
+			return false;
+		}
+
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(secretKey)
+				.build()
+				.parseClaimsJws(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/src/test/java/app/bottlenote/user/fake/FakeNonceService.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeNonceService.java
@@ -1,0 +1,42 @@
+package app.bottlenote.user.fake;
+
+import app.bottlenote.user.exception.UserException;
+import app.bottlenote.user.exception.UserExceptionCode;
+import app.bottlenote.user.service.NonceService;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class FakeNonceService extends NonceService {
+
+	private final Set<String> validNonces = new HashSet<>();
+
+	public FakeNonceService() {
+		super(null);
+	}
+	@Override
+	public String generateNonce() {
+		String nonce = "fake-nonce-" + UUID.randomUUID();
+		validNonces.add(nonce);
+		return nonce;
+	}
+
+	@Override
+	public void validateNonce(String nonce) {
+		if (!validNonces.contains(nonce)) {
+			throw new UserException(UserExceptionCode.INVALID_NONCE);
+		}
+		// 사용 후 제거 (일회성)
+		validNonces.remove(nonce);
+	}
+
+	// 테스트 유틸리티 메서드
+	public void addValidNonce(String nonce) {
+		validNonces.add(nonce);
+	}
+
+	public void clearNonces() {
+		validNonces.clear();
+	}
+}

--- a/src/test/java/app/bottlenote/user/fake/FakeOauthRepository.java
+++ b/src/test/java/app/bottlenote/user/fake/FakeOauthRepository.java
@@ -1,0 +1,165 @@
+package app.bottlenote.user.fake;
+
+import app.bottlenote.user.constant.SocialType;
+import app.bottlenote.user.domain.User;
+import app.bottlenote.user.repository.OauthRepository;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeOauthRepository implements OauthRepository {
+
+	private final Map<Long, User> userDatabase = new HashMap<>();
+	private final Map<String, User> emailDatabase = new HashMap<>();
+	private final Map<String, User> refreshTokenDatabase = new HashMap<>();
+	private final Map<String, User> socialUniqueIdDatabase = new HashMap<>();
+	private final Map<String, User> nickNameDatabase = new HashMap<>();
+	private Long autoIncrementId = 1L;
+	private Long nicknameSequence = 1L;
+
+	@Override
+	public Optional<User> findByEmail(String email) {
+		return Optional.ofNullable(emailDatabase.get(email));
+	}
+
+	@Override
+	public Optional<User> findByRefreshToken(String refreshToken) {
+		return Optional.ofNullable(refreshTokenDatabase.get(refreshToken));
+	}
+
+	@Override
+	public Optional<User> getFirstUser() {
+		return Optional.empty();
+	}
+
+	@Override
+	public Optional<User> loadGuestUser() {
+		return Optional.empty();
+	}
+
+	@Override
+	public String getNextNicknameSequence() {
+		return "User" + (nicknameSequence++);
+	}
+
+	@Override
+	public Optional<User> findByEmailAndSocialType(String email, String socialType) {
+		return emailDatabase.values().stream()
+			.filter(user -> user.getEmail().equals(email))
+			.filter(user -> user.getSocialType() != null && 
+				user.getSocialType().contains(SocialType.valueOf(socialType)))
+			.findFirst();
+	}
+
+	@Override
+	public Optional<User> findBySocialUniqueId(String socialUniqueId) {
+		return Optional.ofNullable(socialUniqueIdDatabase.get(socialUniqueId));
+	}
+
+	@Override
+	public Optional<User> findByNickName(String nickName) {
+		return Optional.ofNullable(nickNameDatabase.get(nickName));
+	}
+
+	@Override
+	public User save(User user) {
+		if (user.getId() == null) {
+			ReflectionTestUtils.setField(user, "id", autoIncrementId++);
+		}
+
+		Long id = user.getId();
+		userDatabase.put(id, user);
+		emailDatabase.put(user.getEmail(), user);
+
+		if (user.getRefreshToken() != null) {
+			refreshTokenDatabase.put(user.getRefreshToken(), user);
+		}
+
+		if (user.getSocialUniqueId() != null) {
+			socialUniqueIdDatabase.put(user.getSocialUniqueId(), user);
+		}
+
+		if (user.getNickName() != null) {
+			nickNameDatabase.put(user.getNickName(), user);
+		}
+
+		return user;
+	}
+
+	@Override
+	public <S extends User> Iterable<S> saveAll(Iterable<S> entities) {
+		return null;
+	}
+
+	@Override
+	public Optional<User> findById(Long id) {
+		return Optional.ofNullable(userDatabase.get(id));
+	}
+
+	@Override
+	public void delete(User user) {
+		userDatabase.remove(user.getId());
+		emailDatabase.remove(user.getEmail());
+		if (user.getRefreshToken() != null) {
+			refreshTokenDatabase.remove(user.getRefreshToken());
+		}
+		if (user.getSocialUniqueId() != null) {
+			socialUniqueIdDatabase.remove(user.getSocialUniqueId());
+		}
+		if (user.getNickName() != null) {
+			nickNameDatabase.remove(user.getNickName());
+		}
+	}
+
+	@Override
+	public void deleteAllById(Iterable<? extends Long> longs) {
+
+	}
+
+	@Override
+	public void deleteAll(Iterable<? extends User> entities) {
+
+	}
+
+	@Override
+	public void deleteAll() {
+
+	}
+
+	@Override
+	public boolean existsById(Long id) {
+		return userDatabase.containsKey(id);
+	}
+
+	@Override
+	public Iterable<User> findAll() {
+		return null;
+	}
+
+	@Override
+	public Iterable<User> findAllById(Iterable<Long> longs) {
+		return null;
+	}
+
+	@Override
+	public long count() {
+		return userDatabase.size();
+	}
+
+	@Override
+	public void deleteById(Long aLong) {
+
+	}
+
+	public void clear() {
+		userDatabase.clear();
+		emailDatabase.clear();
+		refreshTokenDatabase.clear();
+		socialUniqueIdDatabase.clear();
+		nickNameDatabase.clear();
+		autoIncrementId = 1L;
+		nicknameSequence = 1L;
+	}
+}

--- a/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
+++ b/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
@@ -1,5 +1,6 @@
 package app.bottlenote.user.service;
 
+import app.bottlenote.global.security.jwt.AppleTokenValidator;
 import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
 import app.bottlenote.global.security.jwt.JwtTokenProvider;
 import app.bottlenote.global.security.jwt.JwtTokenValidator;
@@ -12,6 +13,7 @@ import app.bottlenote.user.dto.request.OauthRequest;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.repository.OauthRepository;
+import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -33,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -55,6 +58,10 @@ class OauthServiceTest {
 	private JwtTokenProvider jwtTokenProvider;
 	@Mock
 	private JsonArrayConverter converter;
+	@Mock
+	private AppleTokenValidator appleTokenValidator; // 추가
+	@Mock
+	private NonceService nonceService; // 추가
 
 	private String reissueRefreshToken;
 	private OauthRequest request;
@@ -197,5 +204,115 @@ class OauthServiceTest {
 			// then
 			assertThrows(UserException.class, () -> oauthService.refresh(reissueRefreshToken));
 		}
+	}
+
+	@Test
+	@DisplayName("Apple 로그인 시 기존 사용자를 찾으면 로그인에 성공한다.")
+	void loginWithApple_existingUser_success() {
+		// Given
+		String idToken = "mockIdToken";
+		String nonce = "mockNonce";
+		String socialUniqueId = "mockSocialUniqueId";
+		String email = "test@example.com";
+
+		Claims mockClaims = mock(Claims.class);
+		when(appleTokenValidator.validateAndGetClaims(idToken, nonce)).thenReturn(mockClaims);
+		when(appleTokenValidator.getAppleSocialUniqueId(mockClaims)).thenReturn(socialUniqueId);
+		when(appleTokenValidator.getEmail(mockClaims)).thenReturn(email);
+
+		User existingUser = User.builder()
+				.id(2L)
+				.email(email)
+				.socialUniqueId(socialUniqueId)
+				.socialType(List.of(SocialType.APPLE))
+				.role(UserType.ROLE_USER)
+				.nickName("existingAppleUser")
+				.build();
+		when(oauthRepository.findBySocialUniqueId(socialUniqueId)).thenReturn(Optional.of(existingUser));
+		when(jwtTokenProvider.generateToken(anyString(), any(UserType.class), anyLong())).thenReturn(tokenItem);
+
+		// When
+		TokenItem result = oauthService.loginWithApple(idToken, nonce);
+
+		// Then
+		assertNotNull(result);
+		assertThat(result.accessToken()).isEqualTo(tokenItem.accessToken());
+		assertThat(result.refreshToken()).isEqualTo(tokenItem.refreshToken());
+
+		verify(nonceService, times(1)).validateNonce(nonce);
+		verify(appleTokenValidator, times(1)).validateAndGetClaims(idToken, nonce);
+		verify(oauthRepository, times(1)).findBySocialUniqueId(socialUniqueId);
+		verify(oauthRepository, never()).findByEmail(anyString());
+		verify(oauthRepository, never()).save(any(User.class));
+		verify(jwtTokenProvider, times(1)).generateToken(existingUser.getEmail(), existingUser.getRole(), existingUser.getId());
+	}
+
+	@Test
+	@DisplayName("Apple 로그인 시 신규 사용자이면 회원가입 후 로그인에 성공한다.")
+	void loginWithApple_newUser_success() {
+		// Given
+		String idToken = "mockIdToken";
+		String nonce = "mockNonce";
+		String socialUniqueId = "newSocialUniqueId";
+		String email = "newuser@example.com";
+
+		Claims mockClaims = mock(Claims.class);
+		when(appleTokenValidator.validateAndGetClaims(idToken, nonce)).thenReturn(mockClaims);
+		when(appleTokenValidator.getAppleSocialUniqueId(mockClaims)).thenReturn(socialUniqueId);
+		when(appleTokenValidator.getEmail(mockClaims)).thenReturn(email);
+
+		when(oauthRepository.findBySocialUniqueId(socialUniqueId)).thenReturn(Optional.empty());
+		when(oauthRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+		User newUser = User.builder()
+				.id(3L)
+				.email(email)
+				.socialUniqueId(socialUniqueId)
+				.socialType(List.of(SocialType.APPLE))
+				.role(UserType.ROLE_USER)
+				.nickName("newAppleUser")
+				.build();
+		when(oauthRepository.save(any(User.class))).thenReturn(newUser);
+		when(jwtTokenProvider.generateToken(anyString(), any(UserType.class), anyLong())).thenReturn(tokenItem);
+
+		// When
+		TokenItem result = oauthService.loginWithApple(idToken, nonce);
+
+		// Then
+		assertNotNull(result);
+		assertThat(result.accessToken()).isEqualTo(tokenItem.accessToken());
+		assertThat(result.refreshToken()).isEqualTo(tokenItem.refreshToken());
+
+		verify(nonceService, times(1)).validateNonce(nonce);
+		verify(appleTokenValidator, times(1)).validateAndGetClaims(idToken, nonce);
+		verify(oauthRepository, times(1)).findBySocialUniqueId(socialUniqueId);
+		verify(oauthRepository, times(1)).findByEmail(email);
+		verify(oauthRepository, times(1)).save(any(User.class));
+		verify(jwtTokenProvider, times(1)).generateToken(newUser.getEmail(), newUser.getRole(), newUser.getId());
+	}
+
+	@Test
+	@DisplayName("Apple 로그인 시 Nonce 검증에 실패하면 예외를 발생시킨다.")
+	void loginWithApple_invalidNonce_throwsException() {
+		// Given
+		String idToken = "mockIdToken";
+		String invalidNonce = "invalidNonce";
+
+		doThrow(new IllegalArgumentException("유효하지 않은 Nonce 값입니다."))
+				.when(nonceService).validateNonce(invalidNonce);
+
+		// When & Then
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			oauthService.loginWithApple(idToken, invalidNonce);
+		});
+
+		assertThat(exception.getMessage()).isEqualTo("유효하지 않은 Nonce 값입니다.");
+
+		verify(nonceService, times(1)).validateNonce(invalidNonce);
+		verify(appleTokenValidator, never()).validateAndGetClaims(anyString(), anyString());
+		verify(oauthRepository, never()).findBySocialUniqueId(anyString());
+		verify(oauthRepository, never()).findByEmail(anyString());
+		verify(oauthRepository, never()).save(any(User.class));
+		verify(jwtTokenProvider, never()).generateToken(anyString(), any(UserType.class), anyLong());
 	}
 }

--- a/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
+++ b/src/test/java/app/bottlenote/user/service/OauthServiceTest.java
@@ -1,10 +1,5 @@
 package app.bottlenote.user.service;
 
-import app.bottlenote.global.security.jwt.AppleTokenValidator;
-import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
-import app.bottlenote.global.security.jwt.JwtTokenProvider;
-import app.bottlenote.global.security.jwt.JwtTokenValidator;
-import app.bottlenote.global.service.converter.JsonArrayConverter;
 import app.bottlenote.user.constant.GenderType;
 import app.bottlenote.user.constant.SocialType;
 import app.bottlenote.user.constant.UserType;
@@ -12,65 +7,67 @@ import app.bottlenote.user.domain.User;
 import app.bottlenote.user.dto.request.OauthRequest;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.exception.UserException;
-import app.bottlenote.user.repository.OauthRepository;
+import app.bottlenote.user.fake.FakeAppleTokenValidator;
+import app.bottlenote.user.fake.FakeBCryptPasswordEncoder;
+import app.bottlenote.user.fake.FakeJwtAuthenticationManager;
+import app.bottlenote.user.fake.FakeJwtTokenProvider;
+import app.bottlenote.user.fake.FakeNonceService;
+import app.bottlenote.user.fake.FakeOauthRepository;
+import app.bottlenote.global.security.jwt.JwtTokenValidator;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.lang.reflect.Field;
+import java.security.Key;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @Tag("unit")
 @DisplayName("[unit] [service] OauthService")
-@ExtendWith(MockitoExtension.class)
 class OauthServiceTest {
 
-	@InjectMocks
 	private OauthService oauthService;
-	@Mock
-	private JwtAuthenticationManager jwtAuthenticationManager;
-	@Mock
-	private OauthRepository oauthRepository;
-	@Mock
-	private JwtTokenProvider jwtTokenProvider;
-	@Mock
-	private JsonArrayConverter converter;
-	@Mock
-	private AppleTokenValidator appleTokenValidator; // 추가
-	@Mock
-	private NonceService nonceService; // 추가
+	private FakeJwtAuthenticationManager jwtAuthenticationManager;
+	private FakeOauthRepository oauthRepository;
+	private FakeJwtTokenProvider jwtTokenProvider;
+	private FakeBCryptPasswordEncoder passwordEncoder;
+	private FakeAppleTokenValidator tokenValidator;
+	private FakeNonceService nonceService;
 
 	private String reissueRefreshToken;
 	private OauthRequest request;
 	private User user;
-	private String nickName = "nickName";
-
-	private TokenItem tokenItem;
 
 	@BeforeEach
-	void setUp() {
+	void setUp() throws Exception {
+		// JwtTokenValidator의 static secretKey 필드 초기화
+		initializeJwtTokenValidator();
+		
+		// FakeStub 객체들 초기화
+		oauthRepository = new FakeOauthRepository();
+		jwtTokenProvider = new FakeJwtTokenProvider();
+		jwtAuthenticationManager = new FakeJwtAuthenticationManager();
+		passwordEncoder = new FakeBCryptPasswordEncoder();
+		tokenValidator = new FakeAppleTokenValidator();
+		nonceService = new FakeNonceService();
+
+		// OauthService 초기화
+		oauthService = new OauthService(
+				oauthRepository,
+				jwtTokenProvider,
+				jwtAuthenticationManager,
+				passwordEncoder,
+				tokenValidator,
+				nonceService
+		);
 
 		request = new OauthRequest("cdm2883@naver.com", null, SocialType.KAKAO,
 				null, 26);
@@ -87,125 +84,106 @@ class OauthServiceTest {
 				.role(UserType.ROLE_USER)
 				.build();
 
-		tokenItem = TokenItem.builder()
-				.accessToken("mock-accessToken")
-				.refreshToken("mock-refreshToken")
-				.build();
 
-		reissueRefreshToken = "mock-refreshToken";
+		// 실제 JWT 토큰 생성 (검증 가능한 토큰)
+		reissueRefreshToken = jwtTokenProvider.createRefreshToken("cdm2883@naver.com", UserType.ROLE_USER, 1L);
+	}
+
+	private void initializeJwtTokenValidator() throws Exception {
+		String secret = "dGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4tZ2VuZXJhdGlvbi10ZXN0aW5nLXB1cnBvc2UtbG9uZy1lbm91Z2gtZm9yLWhtYWMtc2hhLTUxMi12ZXJzaW9uLWFuZC1pbXBvcnRhbnQtc2VjdXJpdHktaW4tbW9kZXJuLWphdmEtYXBwbGljYXRpb25z";
+		byte[] keyBytes = Decoders.BASE64.decode(secret);
+		Key secretKey = Keys.hmacShaKeyFor(keyBytes);
+		
+		// reflection을 사용해서 JwtTokenValidator의 static secretKey 필드 설정
+		Field secretKeyField = JwtTokenValidator.class.getDeclaredField("secretKey");
+		secretKeyField.setAccessible(true);
+		secretKeyField.set(null, secretKey);
 	}
 
 	@Test
 	@DisplayName("로그인을 할 수 있다.")
 	void signin_test() {
-
 		//given
+		oauthRepository.save(user); // 사용자 미리 저장
 
 		//when
-		when(oauthRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
-
-		when(jwtTokenProvider.generateToken(user.getEmail(), user.getRole(),
-				user.getId())).thenReturn(tokenItem);
-
 		TokenItem result = oauthService.login(request);
-		System.out.println(result.accessToken() + " " + result.refreshToken());
 
 		//then
-		assertThat(tokenItem.accessToken()).isEqualTo("mock-accessToken");
-		assertThat(tokenItem.refreshToken()).isEqualTo("mock-refreshToken");
+		assertThat(result.accessToken()).isNotNull();
+		assertThat(result.refreshToken()).isNotNull();
+		assertThat(result.accessToken()).isNotEmpty();
+		assertThat(result.refreshToken()).isNotEmpty();
 	}
 
 	@Test
 	@DisplayName("로그인 요청 Email이 DB에 존재하지 않으면 회원가입 로직이 실행된다")
 	void test_Login_Or_CreateAccount_Based_On_EmailExistence() {
+		//given - 사용자가 DB에 존재하지 않는 상태
 
-		when(oauthRepository.findByEmail(anyString())).thenReturn(Optional.empty());
-
-		when(oauthRepository.save(any(User.class))).thenReturn(user);
-
-		when(jwtTokenProvider.generateToken(user.getEmail(), user.getRole(),
-				user.getId())).thenReturn(tokenItem);
-
-		oauthService.login(request);
+		//when
+		TokenItem result = oauthService.login(request);
 
 		//then
-		verify(oauthRepository, times(1)).save(any(User.class));
-
-		assertThat(this.tokenItem.accessToken()).isEqualTo("mock-accessToken");
-		assertThat(this.tokenItem.refreshToken()).isEqualTo("mock-refreshToken");
+		assertThat(result).isNotNull();
+		assertThat(result.accessToken()).isNotNull().isNotEmpty();
+		assertThat(result.refreshToken()).isNotNull().isNotEmpty();
+		// 사용자가 저장되었는지 확인
+		assertThat(oauthRepository.findByEmail("cdm2883@naver.com")).isPresent();
 	}
 
 	@Test
 	@DisplayName("로그인 요청 Email이 DB에 존재하면, 회원가입 로직이 실행되지 않는다")
 	void test_Login_Or_CreateAccount_Based_On_Email_Not_Existence() {
+		//given
+		long initialUserCount = oauthRepository.count();
+		oauthRepository.save(user); // 사용자 미리 저장
 
 		//when
-		when(oauthRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
-
-		when(jwtTokenProvider.generateToken(user.getEmail(), user.getRole(),
-				user.getId())).thenReturn(tokenItem);
-
-		oauthService.login(request);
+		TokenItem result = oauthService.login(request);
 
 		//then
-
-		// save 메서드가 실행되지 않는다.
-		verify(oauthRepository, never()).save(any(User.class));
-
-		assertThat(this.tokenItem.accessToken()).isEqualTo("mock-accessToken");
-		assertThat(this.tokenItem.refreshToken()).isEqualTo("mock-refreshToken");
+		// 새로운 사용자가 생성되지 않았는지 확인
+		assertThat(oauthRepository.count()).isEqualTo(initialUserCount + 1);
+		assertThat(result.accessToken()).isNotNull().isNotEmpty();
+		assertThat(result.refreshToken()).isNotNull().isNotEmpty();
 	}
 
 	@Test
 	@DisplayName("토큰 재발급을 할 수 있다.")
 	void reissue_token() {
-		try (MockedStatic<JwtTokenValidator> mockedValidator = mockStatic(
-				JwtTokenValidator.class)) {
+		//given
+		User userWithRefreshToken = User.builder()
+				.id(1L)
+				.email("cdm2883@naver.com")
+				.gender(GenderType.MALE)
+				.socialType(new ArrayList<>(List.of(SocialType.KAKAO)))
+				.age(26)
+				.nickName("mockNickname")
+				.role(UserType.ROLE_USER)
+				.refreshToken(reissueRefreshToken)
+				.build();
+		oauthRepository.save(userWithRefreshToken);
 
-			//when
-			mockedValidator.when(() -> JwtTokenValidator.validateToken(reissueRefreshToken))
-					.thenReturn(true);
+		//when
+		TokenItem response = oauthService.refresh(reissueRefreshToken);
 
-			when(jwtAuthenticationManager.getAuthentication(reissueRefreshToken)).thenReturn(
-					mock(Authentication.class));
-
-			when(oauthRepository.findByRefreshToken(reissueRefreshToken)).thenReturn(
-					Optional.of(user));
-
-			when(jwtTokenProvider.generateToken(anyString(), any(UserType.class), anyLong()))
-					.thenReturn(TokenItem.builder()
-							.accessToken("newAccessToken")
-							.refreshToken("newRefreshToken")
-							.build());
-
-			// then
-			TokenItem response = oauthService.refresh(reissueRefreshToken);
-
-			// 검증
-			assertNotNull(response);
-			assertThat(response.accessToken()).isEqualTo("newAccessToken");
-			assertThat(response.refreshToken()).isEqualTo("newRefreshToken");
-
-			verify(jwtTokenProvider).generateToken(user.getEmail(), user.getRole(), user.getId());
-		}
+		//then
+		assertNotNull(response);
+		assertThat(response.accessToken()).isNotNull().isNotEmpty();
+		assertThat(response.refreshToken()).isNotNull().isNotEmpty();
 	}
 
 	@Test
 	@DisplayName("토큰 검증에 통과하지 못하면 토큰 재발급에 실패한다")
 	void reissue_token_fail() {
-		try (MockedStatic<JwtTokenValidator> mockedValidator = mockStatic(
-				JwtTokenValidator.class)) {
+		//given
+		String invalidRefreshToken = "invalid-refresh-token";
 
-			//when
-			mockedValidator.when(() -> JwtTokenValidator.validateToken(reissueRefreshToken))
-					.thenReturn(false);
-
-			// then
-			assertThrows(UserException.class, () -> oauthService.refresh(reissueRefreshToken));
-		}
+		//when & then
+		assertThrows(UserException.class, () -> oauthService.refresh(invalidRefreshToken));
 	}
 
-	
 	@Test
 	@DisplayName("Apple 로그인 시 Nonce 검증에 실패하면 예외를 발생시킨다.")
 	void loginWithApple_invalidNonce_throwsException() {
@@ -213,21 +191,26 @@ class OauthServiceTest {
 		String idToken = "mockIdToken";
 		String invalidNonce = "invalidNonce";
 
-		doThrow(new IllegalArgumentException("유효하지 않은 Nonce 값입니다."))
-				.when(nonceService).validateNonce(invalidNonce);
-
 		// When & Then
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-			oauthService.loginWithApple(idToken, invalidNonce);
-		});
+		assertThrows(UserException.class, () -> oauthService.loginWithApple(idToken, invalidNonce));
+	}
 
-		assertThat(exception.getMessage()).isEqualTo("유효하지 않은 Nonce 값입니다.");
+	@Test
+	@DisplayName("Apple 로그인이 성공할 수 있다.")
+	void loginWithApple_success() {
+		// Given
+		String idToken = "validIdToken";
+		String validNonce = nonceService.generateNonce();
 
-		verify(nonceService, times(1)).validateNonce(invalidNonce);
-		verify(appleTokenValidator, never()).validateAndGetClaims(anyString(), anyString());
-		verify(oauthRepository, never()).findBySocialUniqueId(anyString());
-		verify(oauthRepository, never()).findByEmail(anyString());
-		verify(oauthRepository, never()).save(any(User.class));
-		verify(jwtTokenProvider, never()).generateToken(anyString(), any(UserType.class), anyLong());
+		// When
+		TokenItem result = oauthService.loginWithApple(idToken, validNonce);
+
+		// Then
+		assertNotNull(result);
+		assertThat(result.accessToken()).isNotNull().isNotEmpty();
+		assertThat(result.refreshToken()).isNotNull().isNotEmpty();
+
+		// 사용자가 저장되었는지 확인
+		assertThat(oauthRepository.findByEmail("apple.user@example.com")).isPresent();
 	}
 }

--- a/src/test/java/app/docs/user/RestAuthV2ControllerTest.java
+++ b/src/test/java/app/docs/user/RestAuthV2ControllerTest.java
@@ -1,8 +1,11 @@
 package app.docs.user;
 
 import app.bottlenote.global.security.SecurityContextUtil;
+import app.bottlenote.user.config.OauthConfigProperties;
 import app.bottlenote.user.controller.AuthV2Controller;
 import app.bottlenote.user.service.AuthService;
+import app.bottlenote.user.service.NonceService;
+import app.bottlenote.user.service.OauthService;
 import app.docs.AbstractRestDocs;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,11 +31,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("유저 Auth 컨트롤러 V2x RestDocs 테스트")
 class RestAuthV2ControllerTest extends AbstractRestDocs {
 	private final AuthService authService = mock(AuthService.class);
+	private final NonceService nonceService = mock(NonceService.class);
+	private final OauthService oauthService = mock(OauthService.class);
+	private final OauthConfigProperties config = mock(OauthConfigProperties.class);
+
 	private MockedStatic<SecurityContextUtil> mockedSecurityUtil;
 
 	@Override
 	protected Object initController() {
-		return new AuthV2Controller(authService);
+		return new AuthV2Controller(authService, nonceService, oauthService, config);
 	}
 
 	@BeforeEach

--- a/src/test/java/app/docs/user/RestOauthControllerTest.java
+++ b/src/test/java/app/docs/user/RestOauthControllerTest.java
@@ -10,6 +10,7 @@ import app.bottlenote.user.dto.request.GuestCodeRequest;
 import app.bottlenote.user.dto.request.OauthRequest;
 import app.bottlenote.user.dto.response.BasicAccountResponse;
 import app.bottlenote.user.dto.response.TokenItem;
+import app.bottlenote.user.service.NonceService;
 import app.bottlenote.user.service.OauthService;
 import app.docs.AbstractRestDocs;
 import app.external.push.data.request.SingleTokenRequest;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("유저 Auth 컨트롤러 RestDocs 테스트")
 class RestOauthControllerTest extends AbstractRestDocs {
 	private final OauthService oauthService = mock(OauthService.class);
+	private final NonceService nonceService = mock(NonceService.class);
 	private final OauthConfigProperties config;
 
 	public RestOauthControllerTest() {
@@ -52,7 +54,7 @@ class RestOauthControllerTest extends AbstractRestDocs {
 	@Override
 	protected Object initController() {
 
-		return new OauthController(oauthService, config);
+		return new OauthController(oauthService,nonceService, config);
 	}
 
 	@Test

--- a/src/test/java/app/docs/user/RestOauthControllerTest.java
+++ b/src/test/java/app/docs/user/RestOauthControllerTest.java
@@ -10,7 +10,6 @@ import app.bottlenote.user.dto.request.GuestCodeRequest;
 import app.bottlenote.user.dto.request.OauthRequest;
 import app.bottlenote.user.dto.response.BasicAccountResponse;
 import app.bottlenote.user.dto.response.TokenItem;
-import app.bottlenote.user.service.NonceService;
 import app.bottlenote.user.service.OauthService;
 import app.docs.AbstractRestDocs;
 import app.external.push.data.request.SingleTokenRequest;
@@ -40,7 +39,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("유저 Auth 컨트롤러 RestDocs 테스트")
 class RestOauthControllerTest extends AbstractRestDocs {
 	private final OauthService oauthService = mock(OauthService.class);
-	private final NonceService nonceService = mock(NonceService.class);
 	private final OauthConfigProperties config;
 
 	public RestOauthControllerTest() {
@@ -54,7 +52,7 @@ class RestOauthControllerTest extends AbstractRestDocs {
 	@Override
 	protected Object initController() {
 
-		return new OauthController(oauthService,nonceService, config);
+		return new OauthController(oauthService, config);
 	}
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -76,3 +76,6 @@ profanity:
 app:
   thirdParty:
     firebase-configuration-file: src/test/resources/service_account_credentials.json
+
+apple:
+  bundle-id: "com.bottlenote.official.app"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -58,6 +58,8 @@ spring:
 security:
   jwt:
     secret-key: 'c2VjdXJlU2VjcmV0S2V5MTIzNDU2Nzg5MGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QWJDRGVGR2hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlrSg=='
+  nonce:
+    salt: 'test-salt-value-2024'
 
 # AWS S3
 amazon:


### PR DESCRIPTION
Resolves #{이슈-번호}

## 🔑 주요 변경사항 (Key Changes)
### 1. Apple 로그인 전용 API 추가

- GET /api/v1/oauth/apple/nonce: 로그인 시도 전, 재전송 공격 방지를 위한 일회성 nonce 값을 발급하는 API를 추가했습니다.
- POST /api/v1/oauth/apple: id_token과 nonce를 받아 실제 로그인을 처리하는 전용 API를 추가했습니다.

### 2. AppleTokenValidator 추가 (global.security.jwt)

- Apple의 공개키(appleid.apple.com/auth/keys)를 이용해 id_token의 JWS 서명을 검증합니다.
- 토큰의 iss(발급자), aud(수신자), exp(만료시간) 클레임을 Apple 공식 문서에 따라 엄격하게 검증합니다.
- 요청된 nonce 값이 토큰 내의 nonce와 일치하는지 확인하여 재전송 공격을 방어합니다.

### 3. NonceService 추가 (user.service)

#### Nonce 개념 및 필요한 이유


- Nonce 생성 및 전달: 우리 서버가 로그인 시도 직전에 고유한 nonce를 생성해서 클라이언트(앱)에 전달합니다. (GET /login/apple/nonce)

- Apple에 Nonce 전송: 클라이언트는 Apple에 인증을 요청할 때 이 nonce를 포함시킵니다.

- id_token에 Nonce 포함: Apple은 발급하는 id_token 내부에 해당 nonce를 그대로 담아 클라이언트에게 돌려줍니다.

- 최종 검증: 우리 서버는 클라이언트로부터 받은 id_token과 nonce를 대조합니다. 토큰 **안에 있는 nonce**와 클라이언트가 직접 전달한 nonce가 일치하는지, 그리고 이 nonce가 우리가 최초에 발급하고 아직 사용되지 않은 값인지 확인합니다. 검증이 끝나면 이 nonce는 즉시 폐기됩니다.

이 과정을 통해 공격자가 id_token을 탈취하더라도, 이미 사용되고 폐기된 nonce로는 절대 다시 로그인할 수 없습니다.

- 로그인 시도마다 UUID 기반의 고유한 nonce를 생성합니다.
- 생성된 nonce를 Guava Cache를 이용해 일정 시간(10분) 동안만 유효하도록 저장합니다.
- 한 번 사용된 nonce는 즉시 폐기하여 재사용이 불가능하도록 보장합니다.

### 4. OauthService 및 OauthController 리팩토링

- 신규 loginWithApple(idToken, nonce) 메서드를 추가하여 새로운 Apple 로그인 흐름을 처리합니다.
- NonceService와 AppleTokenValidator를 호출하여 검증 단계를 수행합니다.
- 컨트롤러에 신규 엔드포인트를 매핑하고 의존성을 주입했습니다.

### 최종 로그인 Flow
<img width="1423" height="1201" alt="image" src="https://github.com/user-attachments/assets/8a91ddad-4074-4f74-920f-eae0807ce76e" />

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
