### PR TITLE
refactor: 비즈니스 문의 API 수정

### DIFF
--- a/src/main/java/app/bottlenote/support/business/constant/BusinessSupportType.java
+++ b/src/main/java/app/bottlenote/support/business/constant/BusinessSupportType.java
@@ -1,0 +1,16 @@
+package app.bottlenote.support.business.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum BusinessSupportType {
+	EVENT("이벤트 관련 문의"),
+	ADVERTISEMENT("광고 관련 문의"),
+	ETC("기타 문의");
+
+	private final String description;
+
+	BusinessSupportType(String description) {
+		this.description = description;
+	}
+}

--- a/src/main/java/app/bottlenote/support/business/constant/ContactType.java
+++ b/src/main/java/app/bottlenote/support/business/constant/ContactType.java
@@ -1,8 +1,0 @@
-package app.bottlenote.support.business.constant;
-
-import lombok.Getter;
-
-@Getter
-public enum ContactType {
-	EMAIL, PHONE, ETC;
-}

--- a/src/main/java/app/bottlenote/support/business/domain/BusinessImage.java
+++ b/src/main/java/app/bottlenote/support/business/domain/BusinessImage.java
@@ -1,0 +1,42 @@
+package app.bottlenote.support.business.domain;
+
+import app.bottlenote.common.domain.BaseEntity;
+import app.bottlenote.common.image.ImageInfo;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@Entity(name = "business_image")
+@Table(name = "business_images")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BusinessImage extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Embedded
+	@Comment("비즈니스 문의 이미지")
+	private ImageInfo businessImageInfo;
+
+	@Comment("비즈니스 문의 아이디")
+	@Column(name = "business_support_id", nullable = false)
+	private Long businessSupportId;
+
+	@Builder
+	public BusinessImage(Long id, ImageInfo businessImageInfo, Long businessSupportId) {
+		this.id = id;
+		this.businessImageInfo = businessImageInfo;
+		this.businessSupportId = businessSupportId;
+	}
+}

--- a/src/main/java/app/bottlenote/support/business/domain/BusinessImageList.java
+++ b/src/main/java/app/bottlenote/support/business/domain/BusinessImageList.java
@@ -1,0 +1,67 @@
+package app.bottlenote.support.business.domain;
+
+import app.bottlenote.common.image.ImageInfo;
+import app.bottlenote.common.image.ImageUtil;
+import app.bottlenote.support.business.dto.request.BusinessImageItem;
+import app.bottlenote.support.business.exception.BusinessSupportException;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static app.bottlenote.review.exception.ReviewExceptionCode.INVALID_IMAGE_URL_MAX_SIZE;
+
+@Embeddable
+@RequiredArgsConstructor
+@Getter
+public class BusinessImageList {
+
+	@Comment("비즈니스 문의 이미지")
+	@OneToMany(
+		mappedBy = "businessSupportId",
+		fetch = FetchType.LAZY,
+		cascade = CascadeType.ALL,
+		orphanRemoval = true)
+	private List<BusinessImage> businessImages = new ArrayList<>();
+
+	private void validateOverMaxSize(List<BusinessImage> businessImageList) {
+		if (businessImageList.size() > 5) {
+			throw new BusinessSupportException(INVALID_IMAGE_URL_MAX_SIZE);
+		}
+	}
+
+	public void addImages(List<BusinessImageItem> images, Long businessSupportId) {
+		this.businessImages.addAll(makeBusinessImageList(images, businessSupportId));
+	}
+
+	public void clear() {
+		this.businessImages.clear();
+	}
+
+	public List<BusinessImage> makeBusinessImageList(List<BusinessImageItem> images, Long businessSupportId) {
+		List<BusinessImage> businessImageList = images.stream()
+			.map(image -> BusinessImage.builder()
+				.businessImageInfo(
+					ImageInfo.builder()
+						.order(image.order())
+						.imageUrl(image.viewUrl())
+						.imagePath(ImageUtil.getImagePath(image.viewUrl()))
+						.imageKey(ImageUtil.getImageKey(image.viewUrl()))
+						.imageName(ImageUtil.getImageName(image.viewUrl()))
+						.build()
+				)
+				.businessSupportId(businessSupportId)
+				.build())
+			.toList();
+
+		validateOverMaxSize(businessImageList);
+
+		return businessImageList;
+	}
+}

--- a/src/main/java/app/bottlenote/support/business/domain/BusinessSupport.java
+++ b/src/main/java/app/bottlenote/support/business/domain/BusinessSupport.java
@@ -1,9 +1,11 @@
 package app.bottlenote.support.business.domain;
 
 import app.bottlenote.common.domain.BaseEntity;
-import app.bottlenote.support.business.constant.ContactType;
+import app.bottlenote.support.business.constant.BusinessSupportType;
+import app.bottlenote.support.business.dto.request.BusinessImageItem;
 import app.bottlenote.support.constant.StatusType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,6 +18,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+
+import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Entity(name = "business_support")
@@ -31,14 +36,26 @@ public class BusinessSupport extends BaseEntity {
 	@Column(name = "user_id", nullable = false)
 	private Long userId;
 
+	@Comment("문의 제목")
+	@Column(name = "title", nullable = false)
+	private String title;
+
 	@Comment("문의 내용")
 	@Column(name = "content", nullable = false)
 	private String content;
 
-	@Comment("연락 방식")
-	@Column(name = "contact_way")
+	@Comment("연락처")
+	@Column(name = "contact", nullable = false)
+	private String contact;
+
+	@Comment("문의 유형")
+	@Column(name = "business_support_type")
 	@Enumerated(EnumType.STRING)
-	private ContactType contactWay;
+	private BusinessSupportType businessSupportType;
+
+	@Embedded
+	@Comment("비즈니스 문의 이미지")
+	private BusinessImageList businessImageList = new BusinessImageList();
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status")
@@ -54,26 +71,46 @@ public class BusinessSupport extends BaseEntity {
 	private String responseContent;
 
 	@Builder
-	private BusinessSupport(Long id, Long userId, String content, ContactType contactWay, Long adminId, String responseContent) {
+	private BusinessSupport(Long id, Long userId, String title, String content, String contact, BusinessSupportType businessSupportType, Long adminId, String responseContent) {
 		this.id = id;
 		this.userId = userId;
+		this.title = title;
 		this.content = content;
-		this.contactWay = contactWay;
+		this.contact = contact;
+		this.businessSupportType = businessSupportType;
 		this.adminId = adminId;
 		this.responseContent = responseContent;
 	}
 
-	public static BusinessSupport create(Long userId, String content, ContactType contactWay) {
+	public static BusinessSupport create(Long userId, String title, String content, String contact, BusinessSupportType businessSupportType) {
 		return BusinessSupport.builder()
 				.userId(userId)
+				.title(title)
 				.content(content)
-				.contactWay(contactWay)
+				.contact(contact)
+				.businessSupportType(businessSupportType)
 				.build();
 	}
 
-	public void update(String content, ContactType contactWay) {
+	public void saveImages(List<BusinessImageItem> images, Long businessSupportId) {
+		businessImageList.addImages(images, businessSupportId);
+	}
+
+	public void updateImages(List<BusinessImageItem> images, Long businessSupportId) {
+		businessImageList.clear();
+		businessImageList.addImages(images, businessSupportId);
+	}
+
+	public void update(String title, String content, String contact, BusinessSupportType businessSupportType, List<BusinessImageItem> images) {
+		Objects.requireNonNull(title, "title은 필수입니다");
+		Objects.requireNonNull(content, "content는 필수입니다");
+		Objects.requireNonNull(contact, "contact는 필수입니다");
+		Objects.requireNonNull(businessSupportType, "contactType은 필수입니다");
+		this.title = title;
 		this.content = content;
-		this.contactWay = contactWay;
+		this.contact = contact;
+		this.businessSupportType = businessSupportType;
+		updateImages(images, this.id);
 	}
 
 	public void delete() {

--- a/src/main/java/app/bottlenote/support/business/dto/request/BusinessImageItem.java
+++ b/src/main/java/app/bottlenote/support/business/dto/request/BusinessImageItem.java
@@ -1,0 +1,16 @@
+package app.bottlenote.support.business.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record BusinessImageItem(
+	Long order,
+	String viewUrl
+) {
+	public static BusinessImageItem create(Long order, String viewUrl) {
+		return BusinessImageItem.builder()
+				.order(order)
+				.viewUrl(viewUrl)
+				.build();
+	}
+}

--- a/src/main/java/app/bottlenote/support/business/dto/request/BusinessSupportUpsertRequest.java
+++ b/src/main/java/app/bottlenote/support/business/dto/request/BusinessSupportUpsertRequest.java
@@ -1,15 +1,35 @@
 package app.bottlenote.support.business.dto.request;
 
-import app.bottlenote.support.business.constant.ContactType;
+import app.bottlenote.support.business.constant.BusinessSupportType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
 public record BusinessSupportUpsertRequest(
+		@NotEmpty(message = "TITLE_NOT_EMPTY")
+		@Size(max = 100)
+		String title,
+
+		@NotEmpty(message = "CONTENT_NOT_EMPTY")
 		@Size(max = 500)
 		String content,
 
-		ContactType contactWay
+		@NotEmpty(message = "CONTACT_NOT_EMPTY")
+		String contact,
+
+		@NotNull(message = "REQUIRED_CONTACT_TYPE")
+		BusinessSupportType businessSupportType,
+
+		@Valid
+		List<BusinessImageItem> imageUrlList
 ) {
+	public BusinessSupportUpsertRequest {
+		imageUrlList = imageUrlList == null ? List.of() : imageUrlList;
+	}
 }
 

--- a/src/main/java/app/bottlenote/support/business/dto/response/BusinessInfoResponse.java
+++ b/src/main/java/app/bottlenote/support/business/dto/response/BusinessInfoResponse.java
@@ -8,11 +8,12 @@ import java.time.LocalDateTime;
 @Builder
 public record BusinessInfoResponse(
 		Long id,
+		String title,
 		String content,
 		LocalDateTime createAt,
 		StatusType status
 ) {
-		public static BusinessInfoResponse of(Long id, String content, LocalDateTime createAt, StatusType status) {
-			return new BusinessInfoResponse(id, content, createAt, status);
+		public static BusinessInfoResponse of(Long id, String title, String content, LocalDateTime createAt, StatusType status) {
+			return new BusinessInfoResponse(id, title, content, createAt, status);
 		}
 	}

--- a/src/main/java/app/bottlenote/support/business/dto/response/BusinessSupportDetailItem.java
+++ b/src/main/java/app/bottlenote/support/business/dto/response/BusinessSupportDetailItem.java
@@ -1,15 +1,21 @@
 package app.bottlenote.support.business.dto.response;
 
+import app.bottlenote.support.business.constant.BusinessSupportType;
+import app.bottlenote.support.business.dto.request.BusinessImageItem;
 import app.bottlenote.support.constant.StatusType;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record BusinessSupportDetailItem(
 		Long id,
+		String title,
 		String content,
-		String contactWay,
+		String contact,
+		BusinessSupportType businessSupportType,
+		List<BusinessImageItem> imageUrlList,
 		LocalDateTime createAt,
 		StatusType status,
 		Long adminId,

--- a/src/test/java/app/bottlenote/support/business/fixture/BusinessSupportTestFactory.java
+++ b/src/test/java/app/bottlenote/support/business/fixture/BusinessSupportTestFactory.java
@@ -1,6 +1,6 @@
 package app.bottlenote.support.business.fixture;
 
-import app.bottlenote.support.business.constant.ContactType;
+import app.bottlenote.support.business.constant.BusinessSupportType;
 import app.bottlenote.support.business.domain.BusinessSupport;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ public class BusinessSupportTestFactory {
 
 	@Transactional
 	public BusinessSupport persist(Long userId) {
-		BusinessSupport bs = BusinessSupport.create(userId, "문의", ContactType.EMAIL);
+		BusinessSupport bs = BusinessSupport.create(userId, "이벤트 협업 관련 문의드려요", "blah blah", "test@naver.com", BusinessSupportType.EVENT);
 		em.persist(bs);
 		em.flush();
 		return bs;

--- a/src/test/java/app/bottlenote/support/business/integration/BusinessSupportIntegrationTest.java
+++ b/src/test/java/app/bottlenote/support/business/integration/BusinessSupportIntegrationTest.java
@@ -1,7 +1,7 @@
 package app.bottlenote.support.business.integration;
 
 import app.bottlenote.IntegrationTestSupport;
-import app.bottlenote.support.business.constant.ContactType;
+import app.bottlenote.support.business.constant.BusinessSupportType;
 import app.bottlenote.support.business.domain.BusinessSupport;
 import app.bottlenote.support.business.dto.request.BusinessSupportUpsertRequest;
 import app.bottlenote.support.business.fixture.BusinessSupportTestFactory;
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -37,7 +39,7 @@ class BusinessSupportIntegrationTest extends IntegrationTestSupport {
 	@Test
 	@DisplayName("비지니스 문의를 등록할 수 있다.")
 	void register() throws Exception {
-		BusinessSupportUpsertRequest req = new BusinessSupportUpsertRequest("문의", ContactType.EMAIL);
+		BusinessSupportUpsertRequest req = new BusinessSupportUpsertRequest("이벤트 협업 관련 문의드려요", "blah blah", "test@naver.com", BusinessSupportType.EVENT, List.of());
 
 		mockMvc.perform(post("/api/v1/business-support")
 						.contentType(APPLICATION_JSON)
@@ -58,13 +60,13 @@ class BusinessSupportIntegrationTest extends IntegrationTestSupport {
 	@DisplayName("인증되지 않은 사용자는 문의를 등록할 수 없다.")
 	void register_fail_unauthorized() throws Exception {
 		// given
-		BusinessSupportUpsertRequest request = new BusinessSupportUpsertRequest("문의", ContactType.EMAIL);
+		BusinessSupportUpsertRequest req = new BusinessSupportUpsertRequest("이벤트 협업 관련 문의드려요", "blah blah", "test@naver.com", BusinessSupportType.EVENT, List.of());
 
 		// when & then
 		mockMvc.perform(post("/api/v1/business-support")
 						.with(csrf())
 						.contentType(APPLICATION_JSON)
-						.content(mapper.writeValueAsString(request)))
+						.content(mapper.writeValueAsString(req)))
 				.andDo(print())
 				.andExpect(status().isBadRequest());
 	}
@@ -75,7 +77,7 @@ class BusinessSupportIntegrationTest extends IntegrationTestSupport {
 		// given
 		User user = userFactory.persistUser();
 		businessFactory.persist(user.getId());
-		
+
 		// when & then
 		mockMvc.perform(get("/api/v1/business-support")
 						.header("Authorization", "Bearer " + getToken()))
@@ -116,14 +118,14 @@ class BusinessSupportIntegrationTest extends IntegrationTestSupport {
 		// given
 		User user = userFactory.persistUser();
 		BusinessSupport support = businessFactory.persist(user.getId());
-		BusinessSupportUpsertRequest request = new BusinessSupportUpsertRequest("수정된 내용입니다.", ContactType.PHONE);
+		BusinessSupportUpsertRequest req = new BusinessSupportUpsertRequest("이벤트 협업 관련 문의드려요", "blah blah", "test@naver.com", BusinessSupportType.EVENT, List.of());
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/business-support/{id}", support.getId())
 						.with(csrf())
 						.header("Authorization", "Bearer " + getToken())
 						.contentType(APPLICATION_JSON)
-						.content(mapper.writeValueAsString(request)))
+						.content(mapper.writeValueAsString(req)))
 				.andDo(print())
 				.andExpect(status().isOk());
 	}


### PR DESCRIPTION

# 해결하려는 문제가 무엇인가요?

- 비즈니스 문의 API Figma에 맞게 수정
  - 문의 제목 추가
  - 연락처 필드 추가 (Enum 필요없음, @NotEmpty만 검증)
  - ContactType 필드를 ‘문의유형’으로 수정 (이벤트 관련 문의, 광고 관련 문의, 기타 문의) 로 수정
  - 이미지 첨부 가능하도록 수정



# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
