### PR TITLE
refactor: migrate common components from legacy/global to shared module v2

### DIFF
--- a/bottlenote-legacy/src/main/java/app/bottlenote/global/security/jwt/JwtExceptionType.java
+++ b/bottlenote-legacy/src/main/java/app/bottlenote/global/security/jwt/JwtExceptionType.java
@@ -3,30 +3,30 @@ package app.bottlenote.global.security.jwt;
 import app.bottlenote.shared.exception.custom.code.ExceptionCode;
 import org.springframework.http.HttpStatus;
 
-// todo : shared module로 이동
+//  todo : shared module로 이동
 public enum JwtExceptionType implements ExceptionCode {
-  INVALID_SIGNATURE("잘못된 JWT 서명입니다.", HttpStatus.UNAUTHORIZED),
-  MALFORMED_TOKEN("잘못된 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
-  EXPIRED_TOKEN("만료된 JWT 토큰입니다.", HttpStatus.FORBIDDEN),
-  UNSUPPORTED_TOKEN("지원되지 않는 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
-  ILLEGAL_ARGUMENT("잘못 된 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
-  UNKNOWN_ERROR("JWT 처리 중 알 수 없는 오류가 발생했습니다.", HttpStatus.UNAUTHORIZED);
+	INVALID_SIGNATURE("잘못된 JWT 서명입니다.", HttpStatus.UNAUTHORIZED),
+	MALFORMED_TOKEN("잘못된 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
+	EXPIRED_TOKEN("만료된 JWT 토큰입니다.", HttpStatus.FORBIDDEN),
+	UNSUPPORTED_TOKEN("지원되지 않는 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
+	ILLEGAL_ARGUMENT("잘못 된 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED),
+	UNKNOWN_ERROR("JWT 처리 중 알 수 없는 오류가 발생했습니다.", HttpStatus.UNAUTHORIZED);
 
-  private final String message;
-  private final HttpStatus status;
+	private final String message;
+	private final HttpStatus status;
 
-  JwtExceptionType(String message, HttpStatus status) {
-    this.message = message;
-    this.status = status;
-  }
+	JwtExceptionType(String message, HttpStatus status) {
+		this.message = message;
+		this.status = status;
+	}
 
-  @Override
-  public String getMessage() {
-    return message;
-  }
+	@Override
+	public String getMessage() {
+		return message;
+	}
 
-  @Override
-  public HttpStatus getHttpStatus() {
-    return status;
-  }
+	@Override
+	public HttpStatus getHttpStatus() {
+		return status;
+	}
 }


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?

- legacy모듈의 도메인 별 dto (request, response)를 shared로 옮기기 
- total count + Item로 되어 있는 것들은 CollectionResponse로 수정할 수 있으면 하기
- Exception도 옮기기 
- 어노테이션도 shared로 옮기기

---

# RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
