### PR TITLE
deploy dev 

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -3,11 +3,9 @@ name: ci pipeline
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - dev
 
 concurrency:
-  group: "dev-ci-${{ github.ref }}"
+  group: "ci-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 env:

--- a/Dockerfile-admin
+++ b/Dockerfile-admin
@@ -1,0 +1,30 @@
+# 빌드 스테이지
+FROM eclipse-temurin:21-jdk AS builder
+WORKDIR /app
+
+# 빌드에 필요한 파일만 복사 (의존성 캐싱 최적화)
+# 프로젝트 전체 복사
+COPY . .
+
+# 애플리케이션 빌드
+RUN ./gradlew build -x test -x asciidoctor --build-cache --parallel
+
+# 실행 스테이지
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+# 시간대 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 설정 파일 디렉토리 생성
+RUN mkdir -p config
+
+# 빌드 스테이지에서 생성된 JAR 파일만 복사 (product-api 모듈의 실행 가능한 JAR)
+COPY --from=builder /app/bottlenote-product-api/build/libs/bottlenote-product-api.jar /app.jar
+
+# 환경 변수로 프로필 지정 가능하도록 설정
+ENV SPRING_PROFILES_ACTIVE=default
+
+# 실행 시 .env.dev 파일 로드
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/bottlenote-batch/build.gradle
+++ b/bottlenote-batch/build.gradle
@@ -1,5 +1,7 @@
 // batch-module
 dependencies {
+	implementation project(':bottlenote-mono')
+
 	implementation libs.spring.boot.starter.batch
 	testImplementation libs.spring.batch.test
 	implementation libs.spring.boot.starter.quartz

--- a/bottlenote-batch/src/main/java/app/batch/bottlenote/config/PopularAlcoholProperties.java
+++ b/bottlenote-batch/src/main/java/app/batch/bottlenote/config/PopularAlcoholProperties.java
@@ -1,15 +1,13 @@
 package app.batch.bottlenote.config;
 
-import jakarta.annotation.PostConstruct;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * 인기 주류 설정을 위한 Properties 클래스
@@ -27,7 +25,6 @@ public class PopularAlcoholProperties {
 	private Scoring scoring = new Scoring();
 	private Thresholds thresholds = new Thresholds();
 
-	@PostConstruct
 	public void init() {
 		log.info("=".repeat(80));
 		log.info("🚀 인기 주류 설정 로드 완료");

--- a/bottlenote-batch/src/main/java/app/batch/bottlenote/job/BestReviewSelectionJob.java
+++ b/bottlenote-batch/src/main/java/app/batch/bottlenote/job/BestReviewSelectionJob.java
@@ -1,6 +1,9 @@
 package app.batch.bottlenote.job;
 
 import app.batch.bottlenote.data.payload.BestReviewPayload;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
@@ -18,10 +21,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.FileCopyUtils;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * 베스트 리뷰 선정 배치 Job
@@ -93,7 +92,7 @@ public class BestReviewSelectionJob {
 	private String getQueryByResource() {
 		try {
 			// resources 디렉토리 하위의 파일 경로로 접근
-			Resource resource = new ClassPathResource("mysql/sql/best-review-selected.sql");
+			Resource resource = new ClassPathResource("storage/mysql/sql/best-review-selected.sql");
 
 			// getFile() 호출 없이 리소스 내용 읽기
 			String query = new String(FileCopyUtils.copyToByteArray(resource.getInputStream()));

--- a/bottlenote-batch/src/main/java/app/batch/bottlenote/job/PopularAlcoholSelectionJob.java
+++ b/bottlenote-batch/src/main/java/app/batch/bottlenote/job/PopularAlcoholSelectionJob.java
@@ -1,6 +1,10 @@
 package app.batch.bottlenote.job;
 
 import app.batch.bottlenote.data.payload.PopularItemPayload;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
@@ -17,11 +21,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.FileCopyUtils;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 인기 주류 선정 배치 Job
@@ -72,7 +71,7 @@ public class PopularAlcoholSelectionJob {
 	 */
 	private String getQueryByResource() {
 		try {
-			Resource resource = new ClassPathResource("mysql/sql/popularity.sql");
+			Resource resource = new ClassPathResource("storage/mysql/sql/popularity.sql");
 
 			// getFile() 호출 없이 리소스 내용 읽기
 			String query = new String(FileCopyUtils.copyToByteArray(resource.getInputStream()));

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
@@ -1,16 +1,5 @@
 package app.bottlenote.alcohols.repository;
 
-import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
-import static app.bottlenote.alcohols.domain.QAlcoholsTastingTags.alcoholsTastingTags;
-import static app.bottlenote.alcohols.domain.QPopularAlcohol.popularAlcohol;
-import static app.bottlenote.alcohols.domain.QRegion.region;
-import static app.bottlenote.alcohols.domain.QTastingTag.tastingTag;
-import static app.bottlenote.picks.constant.PicksStatus.PICK;
-import static app.bottlenote.picks.domain.QPicks.picks;
-import static app.bottlenote.rating.domain.QRating.rating;
-import static app.bottlenote.review.domain.QReview.review;
-import static com.querydsl.jpa.JPAExpressions.select;
-
 import app.bottlenote.alcohols.constant.AlcoholCategoryGroup;
 import app.bottlenote.alcohols.constant.KeywordTagMapping;
 import app.bottlenote.alcohols.constant.SearchSortType;
@@ -27,319 +16,457 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.JPAExpressions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+
+import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
+import static app.bottlenote.alcohols.domain.QAlcoholsTastingTags.alcoholsTastingTags;
+import static app.bottlenote.alcohols.domain.QPopularAlcohol.popularAlcohol;
+import static app.bottlenote.alcohols.domain.QRegion.region;
+import static app.bottlenote.alcohols.domain.QTastingTag.tastingTag;
+import static app.bottlenote.picks.constant.PicksStatus.PICK;
+import static app.bottlenote.picks.domain.QPicks.picks;
+import static app.bottlenote.rating.domain.QRating.rating;
+import static app.bottlenote.review.domain.QReview.review;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 @Slf4j
 @Component
 public class AlcoholQuerySupporter {
 
-  /** 주류에 연결된 테이스팅 태그 목록을 문자열로 조회 */
-  public static Expression<String> getTastingTags() {
-    return ExpressionUtils.as(
-        JPAExpressions.select(Expressions.stringTemplate("group_concat({0})", tastingTag.korName))
-            .from(alcoholsTastingTags)
-            .join(tastingTag)
-            .on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
-            .where(alcoholsTastingTags.alcohol.id.eq(alcohol.id)),
-        "alcoholsTastingTags");
-  }
+	/**
+	 * 주류에 연결된 테이스팅 태그 목록을 문자열로 조회
+	 */
+	public static Expression<String> getTastingTags() {
+		return ExpressionUtils.as(
+				JPAExpressions.select(Expressions.stringTemplate("group_concat({0})", tastingTag.korName))
+						.from(alcoholsTastingTags)
+						.join(tastingTag)
+						.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+						.where(alcoholsTastingTags.alcohol.id.eq(alcohol.id)),
+				"alcoholsTastingTags");
+	}
 
-  /** 주어진 주류가 인기 순위에 포함되는지 확인 */
-  public BooleanExpression isHot5(NumberPath<Long> id) {
-    LocalDateTime now = LocalDateTime.now();
-    return select(popularAlcohol.count())
-        .from(popularAlcohol)
-        .where(
-            popularAlcohol.alcoholId.eq(id),
-            popularAlcohol.year.eq(now.getYear()),
-            popularAlcohol.month.eq(now.getMonthValue()),
-            popularAlcohol.day.eq(now.getDayOfMonth()))
-        .gt(0L);
-  }
+	/**
+	 * 주어진 주류가 인기 순위에 포함되는지 확인
+	 */
+	public BooleanExpression isHot5(NumberPath<Long> id) {
+		LocalDateTime now = LocalDateTime.now();
+		return select(popularAlcohol.count())
+				.from(popularAlcohol)
+				.where(
+						popularAlcohol.alcoholId.eq(id),
+						popularAlcohol.year.eq(now.getYear()),
+						popularAlcohol.month.eq(now.getMonthValue()),
+						popularAlcohol.day.eq(now.getDayOfMonth()))
+				.gt(0L);
+	}
 
-  /** 사용자가 주류에 찜하기를 했는지 확인하는 서브쿼리 생성 */
-  public BooleanExpression pickedSubQuery(Long userId) {
-    if (userId == -1) return Expressions.asBoolean(false);
+	/**
+	 * 사용자가 주류에 찜하기를 했는지 확인하는 서브쿼리 생성
+	 */
+	public BooleanExpression pickedSubQuery(Long userId) {
+		if (userId == -1) return Expressions.asBoolean(false);
 
-    return JPAExpressions.selectOne()
-        .from(picks)
-        .where(picks.alcoholId.eq(alcohol.id), picks.userId.eq(userId), picks.status.eq(PICK))
-        .exists();
-  }
+		return JPAExpressions.selectOne()
+				.from(picks)
+				.where(picks.alcoholId.eq(alcohol.id), picks.userId.eq(userId), picks.status.eq(PICK))
+				.exists();
+	}
 
-  /** 특정 주류가 사용자에 의해 찜되었는지 확인 */
-  public BooleanExpression isPickedSubquery(Long alcoholId, Long userId) {
-    if (userId == -1) {
-      return Expressions.asBoolean(false);
-    }
-    return Expressions.asBoolean(
-            JPAExpressions.selectOne()
-                .from(picks)
-                .where(
-                    picks
-                        .alcoholId
-                        .eq(alcoholId)
-                        .and(picks.userId.eq(userId))
-                        .and(picks.status.eq(PICK)))
-                .exists())
-        .as("isPicked");
-  }
+	/**
+	 * 특정 주류가 사용자에 의해 찜되었는지 확인
+	 */
+	public BooleanExpression isPickedSubquery(Long alcoholId, Long userId) {
+		if (userId == -1) {
+			return Expressions.asBoolean(false);
+		}
+		return Expressions.asBoolean(
+						JPAExpressions.selectOne()
+								.from(picks)
+								.where(
+										picks
+												.alcoholId
+												.eq(alcoholId)
+												.and(picks.userId.eq(userId))
+												.and(picks.status.eq(PICK)))
+								.exists())
+				.as("isPicked");
+	}
 
-  /** 사용자가 주류에 준 평점 조회 */
-  public NumberExpression<Double> myRating(Long alcoholId, Long userId) {
-    return Expressions.asNumber(
-            JPAExpressions.select(rating.ratingPoint.rating)
-                .from(rating)
-                .where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
-                .limit(1))
-        .coalesce(0.0)
-        .castToNum(Double.class)
-        .as("myRating");
-  }
+	/**
+	 * 사용자가 주류에 준 평점 조회
+	 */
+	public NumberExpression<Double> myRating(Long alcoholId, Long userId) {
+		return Expressions.asNumber(
+						JPAExpressions.select(rating.ratingPoint.rating)
+								.from(rating)
+								.where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
+								.limit(1))
+				.coalesce(0.0)
+				.castToNum(Double.class)
+				.as("myRating");
+	}
 
-  /** 사용자가 주류에 작성한 리뷰들의 평균 평점 계산 */
-  public NumberExpression<Double> averageReviewRating(Long alcoholId, Long userId) {
-    return Expressions.asNumber(
-            JPAExpressions.select(
-                    review
-                        .reviewRating
-                        .avg()
-                        .multiply(2)
-                        .castToNum(Double.class)
-                        .round()
-                        .divide(2)
-                        .coalesce(0.0))
-                .from(review)
-                .where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
-        .castToNum(Double.class)
-        .as("myAvgRating");
-  }
+	/**
+	 * 사용자가 주류에 작성한 리뷰들의 평균 평점 계산
+	 */
+	public NumberExpression<Double> averageReviewRating(Long alcoholId, Long userId) {
+		return Expressions.asNumber(
+						JPAExpressions.select(
+										review
+												.reviewRating
+												.avg()
+												.multiply(2)
+												.castToNum(Double.class)
+												.round()
+												.divide(2)
+												.coalesce(0.0))
+								.from(review)
+								.where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
+				.castToNum(Double.class)
+				.as("myAvgRating");
+	}
 
-  /** 검색 기준과 결과 목록으로 커서 페이징 정보 생성 */
-  public CursorPageable getCursorPageable(
-      AlcoholSearchCriteria criteriaDto,
-      List<AlcoholsSearchItem> fetch,
-      Long cursor,
-      Long pageSize) {
-    boolean hasNext = isHasNext(criteriaDto, fetch);
-    return CursorPageable.builder()
-        .currentCursor(cursor)
-        .cursor(cursor + pageSize)
-        .pageSize(pageSize)
-        .hasNext(hasNext)
-        .build();
-  }
+	/**
+	 * 검색 기준과 결과 목록으로 커서 페이징 정보 생성
+	 */
+	public CursorPageable getCursorPageable(
+			AlcoholSearchCriteria criteriaDto,
+			List<AlcoholsSearchItem> fetch,
+			Long cursor,
+			Long pageSize) {
+		boolean hasNext = isHasNext(criteriaDto, fetch);
+		return CursorPageable.builder()
+				.currentCursor(cursor)
+				.cursor(cursor + pageSize)
+				.pageSize(pageSize)
+				.hasNext(hasNext)
+				.build();
+	}
 
-  /** 다음 페이지 존재 여부 확인 및 초과 항목 제거 */
-  public boolean isHasNext(AlcoholSearchCriteria criteriaDto, List<AlcoholsSearchItem> fetch) {
-    boolean hasNext = fetch.size() > criteriaDto.pageSize();
+	/**
+	 * 다음 페이지 존재 여부 확인 및 초과 항목 제거
+	 */
+	public boolean isHasNext(AlcoholSearchCriteria criteriaDto, List<AlcoholsSearchItem> fetch) {
+		boolean hasNext = fetch.size() > criteriaDto.pageSize();
 
-    if (hasNext) {
-      fetch.remove(fetch.size() - 1);
-    }
-    return hasNext;
-  }
+		if (hasNext) {
+			fetch.remove(fetch.size() - 1);
+		}
+		return hasNext;
+	}
 
-  /** 정렬 조건에 따른 OrderSpecifier 생성 */
-  public OrderSpecifier<?> sortBy(SearchSortType searchSortType, SortOrder sortOrder) {
-    NumberExpression<Double> avgRating = rating.ratingPoint.rating.avg();
-    NumberExpression<Long> reviewCount = review.id.countDistinct();
-    NumberExpression<Long> pickCount = picks.id.countDistinct();
-    return switch (searchSortType) {
-      case POPULAR ->
-          sortOrder == SortOrder.DESC
-              ? avgRating.add(reviewCount).desc()
-              : avgRating.add(reviewCount).asc();
-      case RATING -> sortOrder == SortOrder.DESC ? avgRating.desc() : avgRating.asc();
-      case PICK -> sortOrder == SortOrder.DESC ? pickCount.desc() : pickCount.asc();
-      case REVIEW -> sortOrder == SortOrder.DESC ? reviewCount.desc() : reviewCount.asc();
-    };
-  }
+	/**
+	 * 정렬 조건에 따른 OrderSpecifier 생성
+	 */
+	public OrderSpecifier<?> sortBy(SearchSortType searchSortType, SortOrder sortOrder) {
+		NumberExpression<Double> avgRating = rating.ratingPoint.rating.avg();
+		NumberExpression<Long> reviewCount = review.id.countDistinct();
+		NumberExpression<Long> pickCount = picks.id.countDistinct();
+		return switch (searchSortType) {
+			case POPULAR -> sortOrder == SortOrder.DESC
+					? avgRating.add(reviewCount).desc()
+					: avgRating.add(reviewCount).asc();
+			case RATING -> sortOrder == SortOrder.DESC ? avgRating.desc() : avgRating.asc();
+			case PICK -> sortOrder == SortOrder.DESC ? pickCount.desc() : pickCount.asc();
+			case REVIEW -> sortOrder == SortOrder.DESC ? reviewCount.desc() : reviewCount.asc();
+		};
+	}
 
-  /** 랜덤 정렬 조건 생성 */
-  public OrderSpecifier<?> sortByRandom() {
-    return Expressions.numberTemplate(Double.class, "function('rand')").asc();
-  }
+	/**
+	 * 랜덤 정렬 조건 생성
+	 */
+	public OrderSpecifier<?> sortByRandom() {
+		return Expressions.numberTemplate(Double.class, "function('rand')").asc();
+	}
 
-  /** 이름 포함 여부 조건 생성 */
-  public BooleanExpression eqName(String name) {
-    if (StringUtils.isNullOrEmpty(name)) return null;
+	/**
+	 * 이름 포함 여부 조건 생성
+	 */
+	public BooleanExpression eqName(String name) {
+		if (StringUtils.isNullOrEmpty(name)) return null;
 
-    return alcohol.korName.like("%" + name + "%").or(alcohol.engName.like("%" + name + "%"));
-  }
+		return alcohol.korName.like("%" + name + "%").or(alcohol.engName.like("%" + name + "%"));
+	}
 
-  /** 카테고리 일치 여부 조건 생성 */
-  public BooleanExpression eqCategory(AlcoholCategoryGroup category) {
-    if (Objects.isNull(category)) return null;
+	/**
+	 * 카테고리 일치 여부 조건 생성
+	 */
+	public BooleanExpression eqCategory(AlcoholCategoryGroup category) {
+		if (Objects.isNull(category)) return null;
 
-    return alcohol.categoryGroup.stringValue().like("%" + category + "%");
-  }
+		return alcohol.categoryGroup.stringValue().like("%" + category + "%");
+	}
 
-  /** 지역 일치 여부 조건 생성 */
-  public BooleanExpression eqRegion(Long regionId) {
-    if (regionId == null) return null;
+	/**
+	 * 지역 일치 여부 조건 생성
+	 */
+	public BooleanExpression eqRegion(Long regionId) {
+		if (regionId == null) return null;
 
-    return alcohol.region.id.eq(regionId);
-  }
+		return alcohol.region.id.eq(regionId);
+	}
 
-  /** 사용자가 주류에 준 평점 조회 (QueryDSL 경로 버전) */
-  public NumberExpression<Double> myRating(NumberPath<Long> alcoholId, Long userId) {
-    return Expressions.asNumber(
-            JPAExpressions.select(rating.ratingPoint.rating)
-                .from(rating)
-                .where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
-                .limit(1))
-        .coalesce(0.0)
-        .castToNum(Double.class)
-        .as("myRating");
-  }
+	/**
+	 * 사용자가 주류에 준 평점 조회 (QueryDSL 경로 버전)
+	 */
+	public NumberExpression<Double> myRating(NumberPath<Long> alcoholId, Long userId) {
+		return Expressions.asNumber(
+						JPAExpressions.select(rating.ratingPoint.rating)
+								.from(rating)
+								.where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
+								.limit(1))
+				.coalesce(0.0)
+				.castToNum(Double.class)
+				.as("myRating");
+	}
 
-  /** 사용자가 주류에 작성한 리뷰들의 평균 평점 계산 (QueryDSL 경로 버전) */
-  public NumberExpression<Double> averageReviewRating(NumberPath<Long> alcoholId, Long userId) {
-    return Expressions.asNumber(
-            JPAExpressions.select(
-                    review
-                        .reviewRating
-                        .avg()
-                        .multiply(2)
-                        .castToNum(Double.class)
-                        .round()
-                        .divide(2)
-                        .coalesce(0.0))
-                .from(review)
-                .where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
-        .castToNum(Double.class)
-        .as("myAvgRating");
-  }
+	/**
+	 * 사용자가 주류에 작성한 리뷰들의 평균 평점 계산 (QueryDSL 경로 버전)
+	 */
+	public NumberExpression<Double> averageReviewRating(NumberPath<Long> alcoholId, Long userId) {
+		return Expressions.asNumber(
+						JPAExpressions.select(
+										review
+												.reviewRating
+												.avg()
+												.multiply(2)
+												.castToNum(Double.class)
+												.round()
+												.divide(2)
+												.coalesce(0.0))
+								.from(review)
+								.where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
+				.castToNum(Double.class)
+				.as("myAvgRating");
+	}
 
-  /** 특정 주류가 사용자에 의해 찜되었는지 확인 (QueryDSL 경로 버전) */
-  public BooleanExpression isPickedSubquery(NumberPath<Long> alcoholId, Long userId) {
-    if (userId == -1) {
-      return Expressions.asBoolean(false);
-    }
-    return Expressions.asBoolean(
-            JPAExpressions.selectOne()
-                .from(picks)
-                .where(
-                    picks
-                        .alcoholId
-                        .eq(alcoholId)
-                        .and(picks.userId.eq(userId))
-                        .and(picks.status.eq(PICK)))
-                .exists())
-        .as("isPicked");
-  }
+	/**
+	 * 특정 주류가 사용자에 의해 찜되었는지 확인 (QueryDSL 경로 버전)
+	 */
+	public BooleanExpression isPickedSubquery(NumberPath<Long> alcoholId, Long userId) {
+		if (userId == -1) {
+			return Expressions.asBoolean(false);
+		}
+		return Expressions.asBoolean(
+						JPAExpressions.selectOne()
+								.from(picks)
+								.where(
+										picks
+												.alcoholId
+												.eq(alcoholId)
+												.and(picks.userId.eq(userId))
+												.and(picks.status.eq(PICK)))
+								.exists())
+				.as("isPicked");
+	}
 
-  /** 다수 키워드에 대한 검색 조건 생성 */
-  public BooleanExpression keywordsMatch(List<String> keywords) {
-    if (keywords == null || keywords.isEmpty()) {
-      return null;
-    }
+	/**
+	 * 다수 키워드에 대한 검색 조건 생성
+	 */
+	public BooleanExpression keywordsMatch(List<String> keywords) {
+		if (keywords == null || keywords.isEmpty()) {
+			return null;
+		}
 
-    BooleanExpression finalCondition = null;
+		BooleanExpression finalCondition = null;
 
-    // 각 키워드에 대해 개별 조건을 생성하고 AND 연산으로 결합
-    for (String keyword : keywords) {
-      if (StringUtils.isNullOrEmpty(keyword)) {
-        continue; // 빈 키워드는 건너뛰기
-      }
-      // 현재 키워드에 대한 기본 필드 검색 조건
-      BooleanExpression basicCondition =
-          alcohol
-              .korName
-              .likeIgnoreCase("%" + keyword + "%")
-              .or(alcohol.engName.likeIgnoreCase("%" + keyword + "%"))
-              .or(alcohol.korCategory.likeIgnoreCase("%" + keyword + "%"))
-              .or(alcohol.engCategory.likeIgnoreCase("%" + keyword + "%"))
-              .or(region.korName.likeIgnoreCase("%" + keyword + "%"))
-              .or(region.engName.likeIgnoreCase("%" + keyword + "%"));
+		// 각 키워드에 대해 개별 조건을 생성하고 AND 연산으로 결합
+		for (String keyword : keywords) {
+			if (StringUtils.isNullOrEmpty(keyword)) {
+				continue; // 빈 키워드는 건너뛰기
+			}
+			// 현재 키워드에 대한 기본 필드 검색 조건
+			BooleanExpression basicCondition =
+					alcohol
+							.korName
+							.likeIgnoreCase("%" + keyword + "%")
+							.or(alcohol.engName.likeIgnoreCase("%" + keyword + "%"))
+							.or(alcohol.korCategory.likeIgnoreCase("%" + keyword + "%"))
+							.or(alcohol.engCategory.likeIgnoreCase("%" + keyword + "%"))
+							.or(region.korName.likeIgnoreCase("%" + keyword + "%"))
+							.or(region.engName.likeIgnoreCase("%" + keyword + "%"));
 
-      // 현재 키워드에 대한 테이스팅 태그 검색 조건
-      BooleanExpression tastingTagCondition =
-          JPAExpressions.selectOne()
-              .from(alcoholsTastingTags)
-              .join(tastingTag)
-              .on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
-              .where(
-                  alcoholsTastingTags.alcohol.id.eq(alcohol.id),
-                  tastingTag
-                      .korName
-                      .likeIgnoreCase("%" + keyword + "%")
-                      .or(tastingTag.engName.likeIgnoreCase("%" + keyword + "%")))
-              .exists();
+			// 현재 키워드에 대한 테이스팅 태그 검색 조건
+			BooleanExpression tastingTagCondition =
+					JPAExpressions.selectOne()
+							.from(alcoholsTastingTags)
+							.join(tastingTag)
+							.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+							.where(
+									alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+									tastingTag
+											.korName
+											.likeIgnoreCase("%" + keyword + "%")
+											.or(tastingTag.engName.likeIgnoreCase("%" + keyword + "%")))
+							.exists();
 
-      // 현재 키워드에 대한 조건 (기본 필드 또는 테이스팅 태그)
-      BooleanExpression keywordCondition = basicCondition.or(tastingTagCondition);
+			// 현재 키워드에 대한 조건 (기본 필드 또는 테이스팅 태그)
+			BooleanExpression keywordCondition = basicCondition.or(tastingTagCondition);
 
-      // 결과 조건에 AND로 결합
-      if (finalCondition == null) {
-        finalCondition = keywordCondition;
-      } else {
-        finalCondition = finalCondition.and(keywordCondition);
-      }
-    }
+			// 결과 조건에 AND로 결합
+			if (finalCondition == null) {
+				finalCondition = keywordCondition;
+			} else {
+				finalCondition = finalCondition.and(keywordCondition);
+			}
+		}
 
-    return finalCondition;
-  }
+		return finalCondition;
+	}
 
-  /** 단건 키워드 검색 조건 생성 */
-  public BooleanExpression keywordMatch(String keyword) {
-    if (StringUtils.isNullOrEmpty(keyword)) return null;
+	/**
+	 * 단건 키워드 검색 조건 생성
+	 */
+	public BooleanExpression keywordMatch(String keyword) {
+		if (StringUtils.isNullOrEmpty(keyword)) return null;
 
-    // 기본 검색 조건 (이름, 카테고리)
-    BooleanExpression basicSearch =
-        alcohol
-            .korName
-            .like("%" + keyword + "%")
-            .or(alcohol.engName.like("%" + keyword + "%"))
-            .or(alcohol.korCategory.like("%" + keyword + "%"))
-            .or(alcohol.engCategory.like("%" + keyword + "%"));
+		// 띄어쓰기로 분리하여 단어별 검색
+		String[] words = keyword.trim().split("\\s+");
 
-    // 미리 정의된 태그 검색 조건
-    BooleanExpression predefinedTagSearch = getTastingTagsExpression(keyword);
+		// 단어가 여러 개인 경우 각 단어를 개별적으로 매칭 (순서 무관)
+		if (words.length > 1) {
+			return multiWordSearch(words);
+		}
 
-    // **동적 태그 검색 조건 추가** (현재 누락된 부분)
-    BooleanExpression dynamicTagSearch =
-        JPAExpressions.selectOne()
-            .from(alcoholsTastingTags)
-            .join(tastingTag)
-            .on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
-            .where(
-                alcoholsTastingTags.alcohol.id.eq(alcohol.id),
-                tastingTag
-                    .korName
-                    .like("%" + keyword + "%")
-                    .or(tastingTag.engName.like("%" + keyword + "%")))
-            .exists();
+		// 단일 단어인 경우 기존 로직 사용
+		return singleWordSearch(keyword);
+	}
 
-    // 모든 조건을 OR로 결합
-    BooleanExpression result = basicSearch.or(dynamicTagSearch);
-    if (predefinedTagSearch != null) {
-      result = result.or(predefinedTagSearch);
-    }
+	/**
+	 * 여러 단어 검색 - 각 단어가 모두 포함되어야 함 (순서 무관)
+	 */
+	private BooleanExpression multiWordSearch(String[] words) {
+		BooleanExpression condition = null;
 
-    return result;
-  }
+		for (String word : words) {
+			if (StringUtils.isNullOrEmpty(word)) continue;
 
-  public BooleanExpression getTastingTagsExpression(String keyword) {
-    var tagMapping = KeywordTagMapping.findByKeyword(keyword);
+			// 각 단어에 대한 검색 조건 (OR)
+			BooleanExpression wordCondition =
+					alcohol.korName.like("%" + word + "%")
+							.or(alcohol.engName.like("%" + word + "%"))
+							.or(alcohol.korCategory.like("%" + word + "%"))
+							.or(alcohol.engCategory.like("%" + word + "%"));
 
-    if (tagMapping.isPresent()) {
-      List<Long> tagIds = tagMapping.get().getIncludeTags();
+			// 동적 태그 검색 조건 추가
+			BooleanExpression tagSearch =
+					JPAExpressions.selectOne()
+							.from(alcoholsTastingTags)
+							.join(tastingTag)
+							.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+							.where(
+									alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+									tastingTag.korName.like("%" + word + "%")
+											.or(tastingTag.engName.like("%" + word + "%")))
+							.exists();
 
-      if (tagIds != null && !tagIds.isEmpty()) {
-        return JPAExpressions.selectOne()
-            .from(alcoholsTastingTags)
-            .where(
-                alcoholsTastingTags.alcohol.id.eq(alcohol.id),
-                alcoholsTastingTags.tastingTag.id.in(tagIds))
-            .exists();
-      }
-    }
-    return null;
-  }
+			wordCondition = wordCondition.or(tagSearch);
+
+			// 미리 정의된 태그 검색 조건
+			BooleanExpression predefinedTagSearch = getTastingTagsExpression(word);
+			if (predefinedTagSearch != null) {
+				wordCondition = wordCondition.or(predefinedTagSearch);
+			}
+
+			// 각 단어 조건을 AND로 결합
+			condition = (condition == null) ? wordCondition : condition.and(wordCondition);
+		}
+
+		return condition;
+	}
+
+	/**
+	 * 단일 단어 검색
+	 */
+	private BooleanExpression singleWordSearch(String keyword) {
+		String keywordWithoutSpaces = keyword.replaceAll("\\s+", "");
+
+		// 띄어쓰기 제거한 키워드로 각 문자 사이에 공백이 0개 이상 올 수 있는 패턴 생성
+		String flexiblePattern = buildFlexiblePattern(keywordWithoutSpaces);
+
+		// 기본 검색 조건 (이름, 카테고리)
+		BooleanExpression basicSearch =
+				alcohol
+						.korName
+						.like("%" + keyword + "%")
+						.or(alcohol.engName.like("%" + keyword + "%"))
+						.or(alcohol.korCategory.like("%" + keyword + "%"))
+						.or(alcohol.engCategory.like("%" + keyword + "%"));
+
+		// 띄어쓰기 무시 검색 조건 추가
+		BooleanExpression flexibleSearch =
+				alcohol
+						.korName
+						.likeIgnoreCase("%" + flexiblePattern + "%")
+						.or(alcohol.engName.likeIgnoreCase("%" + flexiblePattern + "%"))
+						.or(alcohol.korCategory.likeIgnoreCase("%" + flexiblePattern + "%"))
+						.or(alcohol.engCategory.likeIgnoreCase("%" + flexiblePattern + "%"));
+
+		// 미리 정의된 태그 검색 조건
+		BooleanExpression predefinedTagSearch = getTastingTagsExpression(keyword);
+
+		// 동적 태그 검색 조건 추가
+		BooleanExpression dynamicTagSearch =
+				JPAExpressions.selectOne()
+						.from(alcoholsTastingTags)
+						.join(tastingTag)
+						.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+						.where(
+								alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+								tastingTag
+										.korName
+										.like("%" + keyword + "%")
+										.or(tastingTag.engName.like("%" + keyword + "%"))
+										.or(tastingTag.korName.likeIgnoreCase("%" + flexiblePattern + "%"))
+										.or(tastingTag.engName.likeIgnoreCase("%" + flexiblePattern + "%")))
+						.exists();
+
+		// 모든 조건을 OR로 결합
+		BooleanExpression result = basicSearch.or(flexibleSearch).or(dynamicTagSearch);
+		if (predefinedTagSearch != null) {
+			result = result.or(predefinedTagSearch);
+		}
+
+		return result;
+	}
+
+	/**
+	 * 띄어쓰기를 무시한 유연한 패턴 생성 (각 문자 사이에 공백 허용)
+	 */
+	private String buildFlexiblePattern(String keyword) {
+		if (keyword.isEmpty()) return keyword;
+
+		StringBuilder pattern = new StringBuilder();
+		for (int i = 0; i < keyword.length(); i++) {
+			pattern.append(keyword.charAt(i));
+			if (i < keyword.length() - 1) {
+				pattern.append("%");
+			}
+		}
+		return pattern.toString();
+	}
+
+	public BooleanExpression getTastingTagsExpression(String keyword) {
+		var tagMapping = KeywordTagMapping.findByKeyword(keyword);
+
+		if (tagMapping.isPresent()) {
+			List<Long> tagIds = tagMapping.get().getIncludeTags();
+
+			if (tagIds != null && !tagIds.isEmpty()) {
+				return JPAExpressions.selectOne()
+						.from(alcoholsTastingTags)
+						.where(
+								alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+								alcoholsTastingTags.tastingTag.id.in(tagIds))
+						.exists();
+			}
+		}
+		return null;
+	}
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/AlcoholQuerySupporter.java
@@ -1,5 +1,16 @@
 package app.bottlenote.alcohols.repository;
 
+import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
+import static app.bottlenote.alcohols.domain.QAlcoholsTastingTags.alcoholsTastingTags;
+import static app.bottlenote.alcohols.domain.QPopularAlcohol.popularAlcohol;
+import static app.bottlenote.alcohols.domain.QRegion.region;
+import static app.bottlenote.alcohols.domain.QTastingTag.tastingTag;
+import static app.bottlenote.picks.constant.PicksStatus.PICK;
+import static app.bottlenote.picks.domain.QPicks.picks;
+import static app.bottlenote.rating.domain.QRating.rating;
+import static app.bottlenote.review.domain.QReview.review;
+import static com.querydsl.jpa.JPAExpressions.select;
+
 import app.bottlenote.alcohols.constant.AlcoholCategoryGroup;
 import app.bottlenote.alcohols.constant.KeywordTagMapping;
 import app.bottlenote.alcohols.constant.SearchSortType;
@@ -16,457 +27,408 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.JPAExpressions;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-
-import static app.bottlenote.alcohols.domain.QAlcohol.alcohol;
-import static app.bottlenote.alcohols.domain.QAlcoholsTastingTags.alcoholsTastingTags;
-import static app.bottlenote.alcohols.domain.QPopularAlcohol.popularAlcohol;
-import static app.bottlenote.alcohols.domain.QRegion.region;
-import static app.bottlenote.alcohols.domain.QTastingTag.tastingTag;
-import static app.bottlenote.picks.constant.PicksStatus.PICK;
-import static app.bottlenote.picks.domain.QPicks.picks;
-import static app.bottlenote.rating.domain.QRating.rating;
-import static app.bottlenote.review.domain.QReview.review;
-import static com.querydsl.jpa.JPAExpressions.select;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 public class AlcoholQuerySupporter {
 
-	/**
-	 * 주류에 연결된 테이스팅 태그 목록을 문자열로 조회
-	 */
-	public static Expression<String> getTastingTags() {
-		return ExpressionUtils.as(
-				JPAExpressions.select(Expressions.stringTemplate("group_concat({0})", tastingTag.korName))
-						.from(alcoholsTastingTags)
-						.join(tastingTag)
-						.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
-						.where(alcoholsTastingTags.alcohol.id.eq(alcohol.id)),
-				"alcoholsTastingTags");
-	}
+  /** 주류에 연결된 테이스팅 태그 목록을 문자열로 조회 */
+  public static Expression<String> getTastingTags() {
+    return ExpressionUtils.as(
+        JPAExpressions.select(Expressions.stringTemplate("group_concat({0})", tastingTag.korName))
+            .from(alcoholsTastingTags)
+            .join(tastingTag)
+            .on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+            .where(alcoholsTastingTags.alcohol.id.eq(alcohol.id)),
+        "alcoholsTastingTags");
+  }
 
-	/**
-	 * 주어진 주류가 인기 순위에 포함되는지 확인
-	 */
-	public BooleanExpression isHot5(NumberPath<Long> id) {
-		LocalDateTime now = LocalDateTime.now();
-		return select(popularAlcohol.count())
-				.from(popularAlcohol)
-				.where(
-						popularAlcohol.alcoholId.eq(id),
-						popularAlcohol.year.eq(now.getYear()),
-						popularAlcohol.month.eq(now.getMonthValue()),
-						popularAlcohol.day.eq(now.getDayOfMonth()))
-				.gt(0L);
-	}
+  /** 주어진 주류가 인기 순위에 포함되는지 확인 */
+  public BooleanExpression isHot5(NumberPath<Long> id) {
+    LocalDateTime now = LocalDateTime.now();
+    return select(popularAlcohol.count())
+        .from(popularAlcohol)
+        .where(
+            popularAlcohol.alcoholId.eq(id),
+            popularAlcohol.year.eq(now.getYear()),
+            popularAlcohol.month.eq(now.getMonthValue()),
+            popularAlcohol.day.eq(now.getDayOfMonth()))
+        .gt(0L);
+  }
 
-	/**
-	 * 사용자가 주류에 찜하기를 했는지 확인하는 서브쿼리 생성
-	 */
-	public BooleanExpression pickedSubQuery(Long userId) {
-		if (userId == -1) return Expressions.asBoolean(false);
+  /** 사용자가 주류에 찜하기를 했는지 확인하는 서브쿼리 생성 */
+  public BooleanExpression pickedSubQuery(Long userId) {
+    if (userId == -1) return Expressions.asBoolean(false);
 
-		return JPAExpressions.selectOne()
-				.from(picks)
-				.where(picks.alcoholId.eq(alcohol.id), picks.userId.eq(userId), picks.status.eq(PICK))
-				.exists();
-	}
+    return JPAExpressions.selectOne()
+        .from(picks)
+        .where(picks.alcoholId.eq(alcohol.id), picks.userId.eq(userId), picks.status.eq(PICK))
+        .exists();
+  }
 
-	/**
-	 * 특정 주류가 사용자에 의해 찜되었는지 확인
-	 */
-	public BooleanExpression isPickedSubquery(Long alcoholId, Long userId) {
-		if (userId == -1) {
-			return Expressions.asBoolean(false);
-		}
-		return Expressions.asBoolean(
-						JPAExpressions.selectOne()
-								.from(picks)
-								.where(
-										picks
-												.alcoholId
-												.eq(alcoholId)
-												.and(picks.userId.eq(userId))
-												.and(picks.status.eq(PICK)))
-								.exists())
-				.as("isPicked");
-	}
+  /** 특정 주류가 사용자에 의해 찜되었는지 확인 */
+  public BooleanExpression isPickedSubquery(Long alcoholId, Long userId) {
+    if (userId == -1) {
+      return Expressions.asBoolean(false);
+    }
+    return Expressions.asBoolean(
+            JPAExpressions.selectOne()
+                .from(picks)
+                .where(
+                    picks
+                        .alcoholId
+                        .eq(alcoholId)
+                        .and(picks.userId.eq(userId))
+                        .and(picks.status.eq(PICK)))
+                .exists())
+        .as("isPicked");
+  }
 
-	/**
-	 * 사용자가 주류에 준 평점 조회
-	 */
-	public NumberExpression<Double> myRating(Long alcoholId, Long userId) {
-		return Expressions.asNumber(
-						JPAExpressions.select(rating.ratingPoint.rating)
-								.from(rating)
-								.where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
-								.limit(1))
-				.coalesce(0.0)
-				.castToNum(Double.class)
-				.as("myRating");
-	}
+  /** 사용자가 주류에 준 평점 조회 */
+  public NumberExpression<Double> myRating(Long alcoholId, Long userId) {
+    return Expressions.asNumber(
+            JPAExpressions.select(rating.ratingPoint.rating)
+                .from(rating)
+                .where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
+                .limit(1))
+        .coalesce(0.0)
+        .castToNum(Double.class)
+        .as("myRating");
+  }
 
-	/**
-	 * 사용자가 주류에 작성한 리뷰들의 평균 평점 계산
-	 */
-	public NumberExpression<Double> averageReviewRating(Long alcoholId, Long userId) {
-		return Expressions.asNumber(
-						JPAExpressions.select(
-										review
-												.reviewRating
-												.avg()
-												.multiply(2)
-												.castToNum(Double.class)
-												.round()
-												.divide(2)
-												.coalesce(0.0))
-								.from(review)
-								.where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
-				.castToNum(Double.class)
-				.as("myAvgRating");
-	}
+  /** 사용자가 주류에 작성한 리뷰들의 평균 평점 계산 */
+  public NumberExpression<Double> averageReviewRating(Long alcoholId, Long userId) {
+    return Expressions.asNumber(
+            JPAExpressions.select(
+                    review
+                        .reviewRating
+                        .avg()
+                        .multiply(2)
+                        .castToNum(Double.class)
+                        .round()
+                        .divide(2)
+                        .coalesce(0.0))
+                .from(review)
+                .where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
+        .castToNum(Double.class)
+        .as("myAvgRating");
+  }
 
-	/**
-	 * 검색 기준과 결과 목록으로 커서 페이징 정보 생성
-	 */
-	public CursorPageable getCursorPageable(
-			AlcoholSearchCriteria criteriaDto,
-			List<AlcoholsSearchItem> fetch,
-			Long cursor,
-			Long pageSize) {
-		boolean hasNext = isHasNext(criteriaDto, fetch);
-		return CursorPageable.builder()
-				.currentCursor(cursor)
-				.cursor(cursor + pageSize)
-				.pageSize(pageSize)
-				.hasNext(hasNext)
-				.build();
-	}
+  /** 검색 기준과 결과 목록으로 커서 페이징 정보 생성 */
+  public CursorPageable getCursorPageable(
+      AlcoholSearchCriteria criteriaDto,
+      List<AlcoholsSearchItem> fetch,
+      Long cursor,
+      Long pageSize) {
+    boolean hasNext = isHasNext(criteriaDto, fetch);
+    return CursorPageable.builder()
+        .currentCursor(cursor)
+        .cursor(cursor + pageSize)
+        .pageSize(pageSize)
+        .hasNext(hasNext)
+        .build();
+  }
 
-	/**
-	 * 다음 페이지 존재 여부 확인 및 초과 항목 제거
-	 */
-	public boolean isHasNext(AlcoholSearchCriteria criteriaDto, List<AlcoholsSearchItem> fetch) {
-		boolean hasNext = fetch.size() > criteriaDto.pageSize();
+  /** 다음 페이지 존재 여부 확인 및 초과 항목 제거 */
+  public boolean isHasNext(AlcoholSearchCriteria criteriaDto, List<AlcoholsSearchItem> fetch) {
+    boolean hasNext = fetch.size() > criteriaDto.pageSize();
 
-		if (hasNext) {
-			fetch.remove(fetch.size() - 1);
-		}
-		return hasNext;
-	}
+    if (hasNext) {
+      fetch.remove(fetch.size() - 1);
+    }
+    return hasNext;
+  }
 
-	/**
-	 * 정렬 조건에 따른 OrderSpecifier 생성
-	 */
-	public OrderSpecifier<?> sortBy(SearchSortType searchSortType, SortOrder sortOrder) {
-		NumberExpression<Double> avgRating = rating.ratingPoint.rating.avg();
-		NumberExpression<Long> reviewCount = review.id.countDistinct();
-		NumberExpression<Long> pickCount = picks.id.countDistinct();
-		return switch (searchSortType) {
-			case POPULAR -> sortOrder == SortOrder.DESC
-					? avgRating.add(reviewCount).desc()
-					: avgRating.add(reviewCount).asc();
-			case RATING -> sortOrder == SortOrder.DESC ? avgRating.desc() : avgRating.asc();
-			case PICK -> sortOrder == SortOrder.DESC ? pickCount.desc() : pickCount.asc();
-			case REVIEW -> sortOrder == SortOrder.DESC ? reviewCount.desc() : reviewCount.asc();
-		};
-	}
+  /** 정렬 조건에 따른 OrderSpecifier 생성 */
+  public OrderSpecifier<?> sortBy(SearchSortType searchSortType, SortOrder sortOrder) {
+    NumberExpression<Double> avgRating = rating.ratingPoint.rating.avg();
+    NumberExpression<Long> reviewCount = review.id.countDistinct();
+    NumberExpression<Long> pickCount = picks.id.countDistinct();
+    return switch (searchSortType) {
+      case POPULAR ->
+          sortOrder == SortOrder.DESC
+              ? avgRating.add(reviewCount).desc()
+              : avgRating.add(reviewCount).asc();
+      case RATING -> sortOrder == SortOrder.DESC ? avgRating.desc() : avgRating.asc();
+      case PICK -> sortOrder == SortOrder.DESC ? pickCount.desc() : pickCount.asc();
+      case REVIEW -> sortOrder == SortOrder.DESC ? reviewCount.desc() : reviewCount.asc();
+    };
+  }
 
-	/**
-	 * 랜덤 정렬 조건 생성
-	 */
-	public OrderSpecifier<?> sortByRandom() {
-		return Expressions.numberTemplate(Double.class, "function('rand')").asc();
-	}
+  /** 랜덤 정렬 조건 생성 */
+  public OrderSpecifier<?> sortByRandom() {
+    return Expressions.numberTemplate(Double.class, "function('rand')").asc();
+  }
 
-	/**
-	 * 이름 포함 여부 조건 생성
-	 */
-	public BooleanExpression eqName(String name) {
-		if (StringUtils.isNullOrEmpty(name)) return null;
+  /** 이름 포함 여부 조건 생성 */
+  public BooleanExpression eqName(String name) {
+    if (StringUtils.isNullOrEmpty(name)) return null;
 
-		return alcohol.korName.like("%" + name + "%").or(alcohol.engName.like("%" + name + "%"));
-	}
+    return alcohol.korName.like("%" + name + "%").or(alcohol.engName.like("%" + name + "%"));
+  }
 
-	/**
-	 * 카테고리 일치 여부 조건 생성
-	 */
-	public BooleanExpression eqCategory(AlcoholCategoryGroup category) {
-		if (Objects.isNull(category)) return null;
+  /** 카테고리 일치 여부 조건 생성 */
+  public BooleanExpression eqCategory(AlcoholCategoryGroup category) {
+    if (Objects.isNull(category)) return null;
 
-		return alcohol.categoryGroup.stringValue().like("%" + category + "%");
-	}
+    return alcohol.categoryGroup.stringValue().like("%" + category + "%");
+  }
 
-	/**
-	 * 지역 일치 여부 조건 생성
-	 */
-	public BooleanExpression eqRegion(Long regionId) {
-		if (regionId == null) return null;
+  /** 지역 일치 여부 조건 생성 */
+  public BooleanExpression eqRegion(Long regionId) {
+    if (regionId == null) return null;
 
-		return alcohol.region.id.eq(regionId);
-	}
+    return alcohol.region.id.eq(regionId);
+  }
 
-	/**
-	 * 사용자가 주류에 준 평점 조회 (QueryDSL 경로 버전)
-	 */
-	public NumberExpression<Double> myRating(NumberPath<Long> alcoholId, Long userId) {
-		return Expressions.asNumber(
-						JPAExpressions.select(rating.ratingPoint.rating)
-								.from(rating)
-								.where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
-								.limit(1))
-				.coalesce(0.0)
-				.castToNum(Double.class)
-				.as("myRating");
-	}
+  /** 사용자가 주류에 준 평점 조회 (QueryDSL 경로 버전) */
+  public NumberExpression<Double> myRating(NumberPath<Long> alcoholId, Long userId) {
+    return Expressions.asNumber(
+            JPAExpressions.select(rating.ratingPoint.rating)
+                .from(rating)
+                .where(rating.id.alcoholId.eq(alcoholId).and(rating.id.userId.eq(userId)))
+                .limit(1))
+        .coalesce(0.0)
+        .castToNum(Double.class)
+        .as("myRating");
+  }
 
-	/**
-	 * 사용자가 주류에 작성한 리뷰들의 평균 평점 계산 (QueryDSL 경로 버전)
-	 */
-	public NumberExpression<Double> averageReviewRating(NumberPath<Long> alcoholId, Long userId) {
-		return Expressions.asNumber(
-						JPAExpressions.select(
-										review
-												.reviewRating
-												.avg()
-												.multiply(2)
-												.castToNum(Double.class)
-												.round()
-												.divide(2)
-												.coalesce(0.0))
-								.from(review)
-								.where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
-				.castToNum(Double.class)
-				.as("myAvgRating");
-	}
+  /** 사용자가 주류에 작성한 리뷰들의 평균 평점 계산 (QueryDSL 경로 버전) */
+  public NumberExpression<Double> averageReviewRating(NumberPath<Long> alcoholId, Long userId) {
+    return Expressions.asNumber(
+            JPAExpressions.select(
+                    review
+                        .reviewRating
+                        .avg()
+                        .multiply(2)
+                        .castToNum(Double.class)
+                        .round()
+                        .divide(2)
+                        .coalesce(0.0))
+                .from(review)
+                .where(review.alcoholId.eq(alcoholId).and(review.userId.eq(userId))))
+        .castToNum(Double.class)
+        .as("myAvgRating");
+  }
 
-	/**
-	 * 특정 주류가 사용자에 의해 찜되었는지 확인 (QueryDSL 경로 버전)
-	 */
-	public BooleanExpression isPickedSubquery(NumberPath<Long> alcoholId, Long userId) {
-		if (userId == -1) {
-			return Expressions.asBoolean(false);
-		}
-		return Expressions.asBoolean(
-						JPAExpressions.selectOne()
-								.from(picks)
-								.where(
-										picks
-												.alcoholId
-												.eq(alcoholId)
-												.and(picks.userId.eq(userId))
-												.and(picks.status.eq(PICK)))
-								.exists())
-				.as("isPicked");
-	}
+  /** 특정 주류가 사용자에 의해 찜되었는지 확인 (QueryDSL 경로 버전) */
+  public BooleanExpression isPickedSubquery(NumberPath<Long> alcoholId, Long userId) {
+    if (userId == -1) {
+      return Expressions.asBoolean(false);
+    }
+    return Expressions.asBoolean(
+            JPAExpressions.selectOne()
+                .from(picks)
+                .where(
+                    picks
+                        .alcoholId
+                        .eq(alcoholId)
+                        .and(picks.userId.eq(userId))
+                        .and(picks.status.eq(PICK)))
+                .exists())
+        .as("isPicked");
+  }
 
-	/**
-	 * 다수 키워드에 대한 검색 조건 생성
-	 */
-	public BooleanExpression keywordsMatch(List<String> keywords) {
-		if (keywords == null || keywords.isEmpty()) {
-			return null;
-		}
+  /** 다수 키워드에 대한 검색 조건 생성 */
+  public BooleanExpression keywordsMatch(List<String> keywords) {
+    if (keywords == null || keywords.isEmpty()) {
+      return null;
+    }
 
-		BooleanExpression finalCondition = null;
+    BooleanExpression finalCondition = null;
 
-		// 각 키워드에 대해 개별 조건을 생성하고 AND 연산으로 결합
-		for (String keyword : keywords) {
-			if (StringUtils.isNullOrEmpty(keyword)) {
-				continue; // 빈 키워드는 건너뛰기
-			}
-			// 현재 키워드에 대한 기본 필드 검색 조건
-			BooleanExpression basicCondition =
-					alcohol
-							.korName
-							.likeIgnoreCase("%" + keyword + "%")
-							.or(alcohol.engName.likeIgnoreCase("%" + keyword + "%"))
-							.or(alcohol.korCategory.likeIgnoreCase("%" + keyword + "%"))
-							.or(alcohol.engCategory.likeIgnoreCase("%" + keyword + "%"))
-							.or(region.korName.likeIgnoreCase("%" + keyword + "%"))
-							.or(region.engName.likeIgnoreCase("%" + keyword + "%"));
+    // 각 키워드에 대해 개별 조건을 생성하고 AND 연산으로 결합
+    for (String keyword : keywords) {
+      if (StringUtils.isNullOrEmpty(keyword)) {
+        continue; // 빈 키워드는 건너뛰기
+      }
+      // 현재 키워드에 대한 기본 필드 검색 조건
+      BooleanExpression basicCondition =
+          alcohol
+              .korName
+              .likeIgnoreCase("%" + keyword + "%")
+              .or(alcohol.engName.likeIgnoreCase("%" + keyword + "%"))
+              .or(alcohol.korCategory.likeIgnoreCase("%" + keyword + "%"))
+              .or(alcohol.engCategory.likeIgnoreCase("%" + keyword + "%"))
+              .or(region.korName.likeIgnoreCase("%" + keyword + "%"))
+              .or(region.engName.likeIgnoreCase("%" + keyword + "%"));
 
-			// 현재 키워드에 대한 테이스팅 태그 검색 조건
-			BooleanExpression tastingTagCondition =
-					JPAExpressions.selectOne()
-							.from(alcoholsTastingTags)
-							.join(tastingTag)
-							.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
-							.where(
-									alcoholsTastingTags.alcohol.id.eq(alcohol.id),
-									tastingTag
-											.korName
-											.likeIgnoreCase("%" + keyword + "%")
-											.or(tastingTag.engName.likeIgnoreCase("%" + keyword + "%")))
-							.exists();
+      // 현재 키워드에 대한 테이스팅 태그 검색 조건
+      BooleanExpression tastingTagCondition =
+          JPAExpressions.selectOne()
+              .from(alcoholsTastingTags)
+              .join(tastingTag)
+              .on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+              .where(
+                  alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+                  tastingTag
+                      .korName
+                      .likeIgnoreCase("%" + keyword + "%")
+                      .or(tastingTag.engName.likeIgnoreCase("%" + keyword + "%")))
+              .exists();
 
-			// 현재 키워드에 대한 조건 (기본 필드 또는 테이스팅 태그)
-			BooleanExpression keywordCondition = basicCondition.or(tastingTagCondition);
+      // 현재 키워드에 대한 조건 (기본 필드 또는 테이스팅 태그)
+      BooleanExpression keywordCondition = basicCondition.or(tastingTagCondition);
 
-			// 결과 조건에 AND로 결합
-			if (finalCondition == null) {
-				finalCondition = keywordCondition;
-			} else {
-				finalCondition = finalCondition.and(keywordCondition);
-			}
-		}
+      // 결과 조건에 AND로 결합
+      if (finalCondition == null) {
+        finalCondition = keywordCondition;
+      } else {
+        finalCondition = finalCondition.and(keywordCondition);
+      }
+    }
 
-		return finalCondition;
-	}
+    return finalCondition;
+  }
 
-	/**
-	 * 단건 키워드 검색 조건 생성
-	 */
-	public BooleanExpression keywordMatch(String keyword) {
-		if (StringUtils.isNullOrEmpty(keyword)) return null;
+  /** 단건 키워드 검색 조건 생성 */
+  public BooleanExpression keywordMatch(String keyword) {
+    if (StringUtils.isNullOrEmpty(keyword)) return null;
 
-		// 띄어쓰기로 분리하여 단어별 검색
-		String[] words = keyword.trim().split("\\s+");
+    // 띄어쓰기로 분리하여 단어별 검색
+    String[] words = keyword.trim().split("\\s+");
 
-		// 단어가 여러 개인 경우 각 단어를 개별적으로 매칭 (순서 무관)
-		if (words.length > 1) {
-			return multiWordSearch(words);
-		}
+    // 단어가 여러 개인 경우 각 단어를 개별적으로 매칭 (순서 무관)
+    if (words.length > 1) {
+      return multiWordSearch(words);
+    }
 
-		// 단일 단어인 경우 기존 로직 사용
-		return singleWordSearch(keyword);
-	}
+    // 단일 단어인 경우 기존 로직 사용
+    return singleWordSearch(keyword);
+  }
 
-	/**
-	 * 여러 단어 검색 - 각 단어가 모두 포함되어야 함 (순서 무관)
-	 */
-	private BooleanExpression multiWordSearch(String[] words) {
-		BooleanExpression condition = null;
+  /** 여러 단어 검색 - 각 단어가 모두 포함되어야 함 (순서 무관) */
+  private BooleanExpression multiWordSearch(String[] words) {
+    BooleanExpression condition = null;
 
-		for (String word : words) {
-			if (StringUtils.isNullOrEmpty(word)) continue;
+    for (String word : words) {
+      if (StringUtils.isNullOrEmpty(word)) continue;
 
-			// 각 단어에 대한 검색 조건 (OR)
-			BooleanExpression wordCondition =
-					alcohol.korName.like("%" + word + "%")
-							.or(alcohol.engName.like("%" + word + "%"))
-							.or(alcohol.korCategory.like("%" + word + "%"))
-							.or(alcohol.engCategory.like("%" + word + "%"));
+      // 각 단어에 대한 검색 조건 (OR)
+      BooleanExpression wordCondition =
+          alcohol
+              .korName
+              .like("%" + word + "%")
+              .or(alcohol.engName.like("%" + word + "%"))
+              .or(alcohol.korCategory.like("%" + word + "%"))
+              .or(alcohol.engCategory.like("%" + word + "%"));
 
-			// 동적 태그 검색 조건 추가
-			BooleanExpression tagSearch =
-					JPAExpressions.selectOne()
-							.from(alcoholsTastingTags)
-							.join(tastingTag)
-							.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
-							.where(
-									alcoholsTastingTags.alcohol.id.eq(alcohol.id),
-									tastingTag.korName.like("%" + word + "%")
-											.or(tastingTag.engName.like("%" + word + "%")))
-							.exists();
+      // 동적 태그 검색 조건 추가
+      BooleanExpression tagSearch =
+          JPAExpressions.selectOne()
+              .from(alcoholsTastingTags)
+              .join(tastingTag)
+              .on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+              .where(
+                  alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+                  tastingTag
+                      .korName
+                      .like("%" + word + "%")
+                      .or(tastingTag.engName.like("%" + word + "%")))
+              .exists();
 
-			wordCondition = wordCondition.or(tagSearch);
+      wordCondition = wordCondition.or(tagSearch);
 
-			// 미리 정의된 태그 검색 조건
-			BooleanExpression predefinedTagSearch = getTastingTagsExpression(word);
-			if (predefinedTagSearch != null) {
-				wordCondition = wordCondition.or(predefinedTagSearch);
-			}
+      // 미리 정의된 태그 검색 조건
+      BooleanExpression predefinedTagSearch = getTastingTagsExpression(word);
+      if (predefinedTagSearch != null) {
+        wordCondition = wordCondition.or(predefinedTagSearch);
+      }
 
-			// 각 단어 조건을 AND로 결합
-			condition = (condition == null) ? wordCondition : condition.and(wordCondition);
-		}
+      // 각 단어 조건을 AND로 결합
+      condition = (condition == null) ? wordCondition : condition.and(wordCondition);
+    }
 
-		return condition;
-	}
+    return condition;
+  }
 
-	/**
-	 * 단일 단어 검색
-	 */
-	private BooleanExpression singleWordSearch(String keyword) {
-		String keywordWithoutSpaces = keyword.replaceAll("\\s+", "");
+  /** 단일 단어 검색 */
+  private BooleanExpression singleWordSearch(String keyword) {
+    String keywordWithoutSpaces = keyword.replaceAll("\\s+", "");
 
-		// 띄어쓰기 제거한 키워드로 각 문자 사이에 공백이 0개 이상 올 수 있는 패턴 생성
-		String flexiblePattern = buildFlexiblePattern(keywordWithoutSpaces);
+    // 띄어쓰기 제거한 키워드로 각 문자 사이에 공백이 0개 이상 올 수 있는 패턴 생성
+    String flexiblePattern = buildFlexiblePattern(keywordWithoutSpaces);
 
-		// 기본 검색 조건 (이름, 카테고리)
-		BooleanExpression basicSearch =
-				alcohol
-						.korName
-						.like("%" + keyword + "%")
-						.or(alcohol.engName.like("%" + keyword + "%"))
-						.or(alcohol.korCategory.like("%" + keyword + "%"))
-						.or(alcohol.engCategory.like("%" + keyword + "%"));
+    // 기본 검색 조건 (이름, 카테고리)
+    BooleanExpression basicSearch =
+        alcohol
+            .korName
+            .like("%" + keyword + "%")
+            .or(alcohol.engName.like("%" + keyword + "%"))
+            .or(alcohol.korCategory.like("%" + keyword + "%"))
+            .or(alcohol.engCategory.like("%" + keyword + "%"));
 
-		// 띄어쓰기 무시 검색 조건 추가
-		BooleanExpression flexibleSearch =
-				alcohol
-						.korName
-						.likeIgnoreCase("%" + flexiblePattern + "%")
-						.or(alcohol.engName.likeIgnoreCase("%" + flexiblePattern + "%"))
-						.or(alcohol.korCategory.likeIgnoreCase("%" + flexiblePattern + "%"))
-						.or(alcohol.engCategory.likeIgnoreCase("%" + flexiblePattern + "%"));
+    // 띄어쓰기 무시 검색 조건 추가
+    BooleanExpression flexibleSearch =
+        alcohol
+            .korName
+            .likeIgnoreCase("%" + flexiblePattern + "%")
+            .or(alcohol.engName.likeIgnoreCase("%" + flexiblePattern + "%"))
+            .or(alcohol.korCategory.likeIgnoreCase("%" + flexiblePattern + "%"))
+            .or(alcohol.engCategory.likeIgnoreCase("%" + flexiblePattern + "%"));
 
-		// 미리 정의된 태그 검색 조건
-		BooleanExpression predefinedTagSearch = getTastingTagsExpression(keyword);
+    // 미리 정의된 태그 검색 조건
+    BooleanExpression predefinedTagSearch = getTastingTagsExpression(keyword);
 
-		// 동적 태그 검색 조건 추가
-		BooleanExpression dynamicTagSearch =
-				JPAExpressions.selectOne()
-						.from(alcoholsTastingTags)
-						.join(tastingTag)
-						.on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
-						.where(
-								alcoholsTastingTags.alcohol.id.eq(alcohol.id),
-								tastingTag
-										.korName
-										.like("%" + keyword + "%")
-										.or(tastingTag.engName.like("%" + keyword + "%"))
-										.or(tastingTag.korName.likeIgnoreCase("%" + flexiblePattern + "%"))
-										.or(tastingTag.engName.likeIgnoreCase("%" + flexiblePattern + "%")))
-						.exists();
+    // 동적 태그 검색 조건 추가
+    BooleanExpression dynamicTagSearch =
+        JPAExpressions.selectOne()
+            .from(alcoholsTastingTags)
+            .join(tastingTag)
+            .on(alcoholsTastingTags.tastingTag.id.eq(tastingTag.id))
+            .where(
+                alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+                tastingTag
+                    .korName
+                    .like("%" + keyword + "%")
+                    .or(tastingTag.engName.like("%" + keyword + "%"))
+                    .or(tastingTag.korName.likeIgnoreCase("%" + flexiblePattern + "%"))
+                    .or(tastingTag.engName.likeIgnoreCase("%" + flexiblePattern + "%")))
+            .exists();
 
-		// 모든 조건을 OR로 결합
-		BooleanExpression result = basicSearch.or(flexibleSearch).or(dynamicTagSearch);
-		if (predefinedTagSearch != null) {
-			result = result.or(predefinedTagSearch);
-		}
+    // 모든 조건을 OR로 결합
+    BooleanExpression result = basicSearch.or(flexibleSearch).or(dynamicTagSearch);
+    if (predefinedTagSearch != null) {
+      result = result.or(predefinedTagSearch);
+    }
 
-		return result;
-	}
+    return result;
+  }
 
-	/**
-	 * 띄어쓰기를 무시한 유연한 패턴 생성 (각 문자 사이에 공백 허용)
-	 */
-	private String buildFlexiblePattern(String keyword) {
-		if (keyword.isEmpty()) return keyword;
+  /** 띄어쓰기를 무시한 유연한 패턴 생성 (각 문자 사이에 공백 허용) */
+  private String buildFlexiblePattern(String keyword) {
+    if (keyword.isEmpty()) return keyword;
 
-		StringBuilder pattern = new StringBuilder();
-		for (int i = 0; i < keyword.length(); i++) {
-			pattern.append(keyword.charAt(i));
-			if (i < keyword.length() - 1) {
-				pattern.append("%");
-			}
-		}
-		return pattern.toString();
-	}
+    StringBuilder pattern = new StringBuilder();
+    for (int i = 0; i < keyword.length(); i++) {
+      pattern.append(keyword.charAt(i));
+      if (i < keyword.length() - 1) {
+        pattern.append("%");
+      }
+    }
+    return pattern.toString();
+  }
 
-	public BooleanExpression getTastingTagsExpression(String keyword) {
-		var tagMapping = KeywordTagMapping.findByKeyword(keyword);
+  public BooleanExpression getTastingTagsExpression(String keyword) {
+    var tagMapping = KeywordTagMapping.findByKeyword(keyword);
 
-		if (tagMapping.isPresent()) {
-			List<Long> tagIds = tagMapping.get().getIncludeTags();
+    if (tagMapping.isPresent()) {
+      List<Long> tagIds = tagMapping.get().getIncludeTags();
 
-			if (tagIds != null && !tagIds.isEmpty()) {
-				return JPAExpressions.selectOne()
-						.from(alcoholsTastingTags)
-						.where(
-								alcoholsTastingTags.alcohol.id.eq(alcohol.id),
-								alcoholsTastingTags.tastingTag.id.in(tagIds))
-						.exists();
-			}
-		}
-		return null;
-	}
+      if (tagIds != null && !tagIds.isEmpty()) {
+        return JPAExpressions.selectOne()
+            .from(alcoholsTastingTags)
+            .where(
+                alcoholsTastingTags.alcohol.id.eq(alcohol.id),
+                alcoholsTastingTags.tastingTag.id.in(tagIds))
+            .exists();
+      }
+    }
+    return null;
+  }
 }

--- a/bottlenote-product-api/build.gradle
+++ b/bottlenote-product-api/build.gradle
@@ -15,6 +15,7 @@ configurations {
 
 dependencies {
 	implementation project(':bottlenote-mono')
+	implementation project(':bottlenote-batch')
 
 	// Spring Boot Web
 	implementation libs.spring.boot.starter.web
@@ -66,6 +67,21 @@ bootJar {
 
 jar {
 	enabled = true
+}
+
+sourceSets {
+	main {
+		resources {
+			srcDirs = ['src/main/resources',
+					   "${rootProject.projectDir}/git.environment-variables"]
+		}
+	}
+	test {
+		resources {
+			srcDirs = ['src/test/resources',
+					   "${rootProject.projectDir}/git.environment-variables"]
+		}
+	}
 }
 
 tasks.register("prepareKotlinBuildScriptModel") {}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/fixture/AlcoholTestFactory.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/fixture/AlcoholTestFactory.java
@@ -175,6 +175,31 @@ public class AlcoholTestFactory {
     return alcohol;
   }
 
+  /** 정확한 이름으로 Alcohol 생성 (접미사 없음) - 연관 엔티티 자동 생성 */
+  @Transactional
+  public Alcohol persistAlcoholWithName(String korName, String engName) {
+    // 연관 엔티티 자동 생성
+    Region region = persistRegionInternal();
+    Distillery distillery = persistDistilleryInternal();
+
+    Alcohol alcohol =
+        Alcohol.builder()
+            .korName(korName)
+            .engName(engName)
+            .abv("40%")
+            .type(AlcoholType.WHISKY)
+            .korCategory("위스키")
+            .engCategory("Whiskey")
+            .categoryGroup(AlcoholCategoryGroup.SINGLE_MALT)
+            .region(region)
+            .distillery(distillery)
+            .cask("Oak")
+            .imageUrl("https://example.com/custom.jpg")
+            .build();
+    em.persist(alcohol);
+    return alcohol;
+  }
+
   /** 연관 엔티티와 함께 Alcohol 생성 */
   @Transactional
   public Alcohol persistAlcohol(AlcoholType type, Region region, Distillery distillery) {

--- a/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/integration/AlcoholQueryIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/integration/AlcoholQueryIntegrationTest.java
@@ -377,7 +377,8 @@ class AlcoholQueryIntegrationTest extends IntegrationTestSupport {
   @DisplayName("일부 단어만 입력해도 검색할 수 있다")
   void test_11() throws Exception {
     // given - "조니 워커 블랙 라벨" 알코올 생성
-    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("조니 워커 블랙 라벨", "Johnny Walker Black Label");
+    Alcohol alcohol =
+        alcoholTestFactory.persistAlcoholWithName("조니 워커 블랙 라벨", "Johnny Walker Black Label");
 
     // when - "조니 블랙"으로만 검색 (워커, 라벨 생략)
     MvcResult result =

--- a/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/integration/AlcoholQueryIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/integration/AlcoholQueryIntegrationTest.java
@@ -161,4 +161,245 @@ class AlcoholQueryIntegrationTest extends IntegrationTestSupport {
     assertEquals(1, alcoholDetail.friendsInfo().getFollowerCount());
     assertEquals(follower.getId(), alcoholDetail.friendsInfo().getFriends().getFirst().userId());
   }
+
+  @Test
+  @DisplayName("띄어쓰기가 있는 알코올 이름을 띄어쓰기 없이 검색할 수 있다.")
+  void test_4() throws Exception {
+    // given - 띄어쓰기가 있는 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("럼 릭", "Rum Rick");
+
+    // when - 띄어쓰기 없이 검색
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "럼릭")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+    assertEquals("럼 릭", responseData.getAlcohols().getFirst().getKorName());
+  }
+
+  @Test
+  @DisplayName("띄어쓰기가 없는 알코올 이름을 띄어쓰기와 함께 검색할 수 있다.")
+  void test_5() throws Exception {
+    // given - 띄어쓰기가 없는 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("럼릭", "RumRick");
+
+    // when - 띄어쓰기와 함께 검색
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "럼 릭")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+    assertEquals("럼릭", responseData.getAlcohols().getFirst().getKorName());
+  }
+
+  @Test
+  @DisplayName("영어 알코올 이름도 띄어쓰기 무시 검색이 가능하다.")
+  void test_6() throws Exception {
+    // given - 영어 이름에 띄어쓰기가 있는 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("위스키", "Jack Daniels");
+
+    // when - 띄어쓰기 없이 영어로 검색
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "JackDaniels")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+    assertEquals("Jack Daniels", responseData.getAlcohols().getFirst().getEngName());
+  }
+
+  @Test
+  @DisplayName("테이스팅 태그도 띄어쓰기 무시 검색이 가능하다.")
+  void test_7() throws Exception {
+    // given - 띄어쓰기가 있는 테이스팅 태그를 가진 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcohol();
+    TastingTag tag = TastingTag.builder().korName("과일 향").engName("fruity aroma").build();
+    alcoholTestFactory.appendTastingTag(alcohol, tag);
+
+    // when - 띄어쓰기 없이 태그로 검색
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "과일향")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+  }
+
+  @Test
+  @DisplayName("단어 순서를 바꿔서 검색할 수 있다 - 글래드스톤 엑스를 엑스 글래드스톤으로 검색")
+  void test_8() throws Exception {
+    // given - "글래드스톤 엑스" 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("글래드스톤 엑스", "Gladstone X");
+
+    // when - 순서를 바꿔서 "엑스 글래드스톤"으로 검색
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "엑스 글래드스톤")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+    assertEquals("글래드스톤 엑스", responseData.getAlcohols().getFirst().getKorName());
+  }
+
+  @Test
+  @DisplayName("영어 이름도 단어 순서를 바꿔서 검색할 수 있다 - Jack Daniels를 Daniels Jack으로 검색")
+  void test_9() throws Exception {
+    // given - "Jack Daniels" 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("잭 다니엘스", "Jack Daniels");
+
+    // when - 순서를 바꿔서 "Daniels Jack"으로 검색
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "Daniels Jack")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+    assertEquals("Jack Daniels", responseData.getAlcohols().getFirst().getEngName());
+  }
+
+  @Test
+  @DisplayName("세 단어 이상도 순서 무관하게 검색할 수 있다")
+  void test_10() throws Exception {
+    // given - 세 단어로 구성된 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("조니 워커 블랙", "Johnny Walker Black");
+
+    // when - 순서를 바꿔서 검색
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "블랙 조니 워커")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+    assertEquals("조니 워커 블랙", responseData.getAlcohols().getFirst().getKorName());
+  }
+
+  @Test
+  @DisplayName("일부 단어만 입력해도 검색할 수 있다")
+  void test_11() throws Exception {
+    // given - "조니 워커 블랙 라벨" 알코올 생성
+    Alcohol alcohol = alcoholTestFactory.persistAlcoholWithName("조니 워커 블랙 라벨", "Johnny Walker Black Label");
+
+    // when - "조니 블랙"으로만 검색 (워커, 라벨 생략)
+    MvcResult result =
+        mockMvc
+            .perform(
+                get("/api/v1/alcohols/search")
+                    .param("keyword", "조니 블랙")
+                    .contentType(APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + getToken())
+                    .with(csrf()))
+            .andDo(print())
+            .andReturn();
+
+    // then
+    String responseString = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+    GlobalResponse response = mapper.readValue(responseString, GlobalResponse.class);
+    AlcoholSearchResponse responseData =
+        mapper.convertValue(response.getData(), AlcoholSearchResponse.class);
+
+    assertNotNull(responseData);
+    assertEquals(1, responseData.getTotalCount());
+    assertEquals(alcohol.getId(), responseData.getAlcohols().getFirst().getAlcoholId());
+    assertEquals("조니 워커 블랙 라벨", responseData.getAlcohols().getFirst().getKorName());
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ subprojects {
 		sourceCompatibility = JavaVersion.VERSION_21
 		targetCompatibility = JavaVersion.VERSION_21
 	}
+	plugins.withId('com.diffplug.spotless') {
+		tasks.named('compileJava').configure {
+			dependsOn 'spotlessApply'
+		}
+	}
 
 	dependencyManagement {
 		imports {

--- a/build.gradle
+++ b/build.gradle
@@ -68,21 +68,6 @@ subprojects {
 		}
 	}
 
-	sourceSets {
-		main {
-			resources {
-				srcDirs = ['src/main/resources',
-						   '../git.environment-variables']
-			}
-		}
-		test {
-			resources {
-				srcDirs = ['src/test/resources',
-						   '../git.environment-variables']
-			}
-		}
-	}
-
 	// Spotless 설정 (mono, product-api에서 사용)
 	if (project.name in ['bottlenote-mono', 'bottlenote-product-api']) {
 		apply plugin: 'com.diffplug.spotless'


### PR DESCRIPTION
This pull request adds robust improvements to the alcohol search feature, enabling flexible keyword matching regardless of spacing or word order, and expands test coverage for these cases. It also includes a small update to the CI pipeline configuration. The changes focus on making search queries for alcohol names and tasting tags much more user-friendly and forgiving, especially for Korean and English names.

### Search feature enhancements

* Refactored the `keywordMatch` method in `AlcoholQuerySupporter.java` to support multi-word searches where words can be in any order, and to ignore spaces in both alcohol names and tasting tags. This includes logic for dynamically building flexible search patterns and combining search conditions.
* Added logic to match keywords even if the user omits or adds spaces, by generating flexible patterns that allow arbitrary whitespace between characters. This applies to both Korean and English names and tasting tags. [[1]](diffhunk://#diff-e11a2c4bcb03ad17a0e4c7b0ac1bf249932af3e7717dff51feeb0e2b78cacd13R366-R378) [[2]](diffhunk://#diff-e11a2c4bcb03ad17a0e4c7b0ac1bf249932af3e7717dff51feeb0e2b78cacd13L316-R416)

### Test coverage improvements

* Added multiple integration tests in `AlcoholQueryIntegrationTest.java` to verify the new search behaviors: searching with/without spaces, in different word orders, and partial keyword matching for both alcohol names and tasting tags.
* Introduced a new test fixture method `persistAlcoholWithName` in `AlcoholTestFactory.java` to easily create alcohol entities with exact names for precise test scenarios.

### CI pipeline update

* Updated the CI workflow in `.github/workflows/continuous_integration.yml` to improve concurrency group naming, ensuring that CI runs are grouped correctly by branch or pull request head reference.