### PR TITLE
docs: 리뷰 작성 길이 및 테이스팅 태그 제한 확장에 따른 문서 업데이트

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/review/domain/ReviewTastingTags.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/domain/ReviewTastingTags.java
@@ -22,7 +22,7 @@ import org.springframework.util.CollectionUtils;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class ReviewTastingTags {
 
-  private static final int TASTING_TAG_MAX_SIZE = 10;
+  private static final int TASTING_TAG_MAX_SIZE = 15;
 
   @OneToMany(
       mappedBy = "review",

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewCreateRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewCreateRequest.java
@@ -19,7 +19,7 @@ public record ReviewCreateRequest(
         Long alcoholId,
     ReviewDisplayStatus status,
     @NotEmpty(message = "REVIEW_CONTENT_REQUIRED")
-        @Size(max = 500, message = "REVIEW_CONTENT_MAXIMUM")
+        @Size(max = 700, message = "REVIEW_CONTENT_MAXIMUM")
         String content,
     SizeType sizeType,
     @DecimalMin(value = "0.0", message = "PRICE_MINIMUM")

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequest.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public record ReviewModifyRequest(
     @NotEmpty(message = "REVIEW_CONTENT_REQUIRED")
-        @Size(max = 500, message = "REVIEW_CONTENT_MAXIMUM")
+        @Size(max = 700, message = "REVIEW_CONTENT_MAXIMUM")
         String content,
     @NotNull(message = "REVIEW_DISPLAY_STATUS_NOT_EMPTY") ReviewDisplayStatus status,
     @DecimalMin(value = "0.0", message = "PRICE_MINIMUM")

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/exception/ReviewExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/exception/ReviewExceptionCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ReviewExceptionCode implements ExceptionCode {
   REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다"),
   INVALID_TASTING_TAG_LENGTH(HttpStatus.BAD_REQUEST, "테이스팅 태그의 길이는 12자 이하로만 작성할 수 있습니다."),
-  INVALID_TASTING_TAG_LIST_SIZE(HttpStatus.BAD_REQUEST, "테이스팅 태그는 10개까지만 작성할 수 있습니다."),
+  INVALID_TASTING_TAG_LIST_SIZE(HttpStatus.BAD_REQUEST, "테이스팅 태그는 15개까지만 작성할 수 있습니다."),
   INVALID_IMAGE_URL_MAX_SIZE(HttpStatus.BAD_REQUEST, "이미지는 최대 5장까지만 업로드 할 수 있습니다"),
   INVALID_CALL_BACK_URL(HttpStatus.BAD_REQUEST, "잘못된 콜백 URL입니다."),
   NOT_FOUND_REVIEW_REPLY(HttpStatus.BAD_REQUEST, "댓글을 찾을 수 없습니다."),

--- a/bottlenote-product-api/src/docs/asciidoc/api/review/review-create.adoc
+++ b/bottlenote-product-api/src/docs/asciidoc/api/review/review-create.adoc
@@ -3,13 +3,13 @@
 리뷰 등록 기능입니다.
 RequestBody로 요청을 전달합니다.
 
-- content는 반드시 존재해야 하며 500자를 넘을 수 없습니다.
+- content는 반드시 존재해야 하며 700자를 넘을 수 없습니다.
 
 - status의 기본값은 PUBLIC으로 설정됩니다.
 
 - locationInfo와 imageUrlList는 NULL일 수 있습니다.
 이미지는 최대 5장까지 업로드가 허용됩니다.
-- tastingTagList는 10개까지 허용되며, 각 tastingTag는 최대 12자 길이로 제한됩니다.
+- tastingTagList는 15개까지 허용되며, 각 tastingTag는 최대 12자 길이로 제한됩니다.
 
 리뷰 등록이 성공적으로 수행되면, 저장된 리뷰의 ID와 리뷰 내용, 그리고 리뷰를 작성한 위스키의 리뷰 조회 URL이 반환됩니다.
 

--- a/bottlenote-product-api/src/docs/asciidoc/api/review/review-modify.adoc
+++ b/bottlenote-product-api/src/docs/asciidoc/api/review/review-modify.adoc
@@ -6,7 +6,7 @@
 
 수정 내용은 RequestBody로 요청을 전달합니다.
 
-content(리뷰 내용)의 길이는 500자로 제한되며, price(가격은)
+content(리뷰 내용)의 길이는 700자로 제한되며, price(가격은)
 0 ~ 1조 범위만 가능합니다.
 
 ReviewStatus와 SizeType은 아래 ENUM을 참고해주세요.

--- a/bottlenote-product-api/src/test/java/app/docs/review/RestReviewControllerDocsTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/review/RestReviewControllerDocsTest.java
@@ -121,7 +121,9 @@ class RestReviewControllerDocsTest extends AbstractRestDocs {
                     fieldWithPath("imageUrlList").type(ARRAY).description("이미지 URL 목록"),
                     fieldWithPath("imageUrlList[].order").type(NUMBER).description("이미지 순서"),
                     fieldWithPath("imageUrlList[].viewUrl").type(STRING).description("이미지 뷰 URL"),
-                    fieldWithPath("tastingTagList[]").type(ARRAY).description("테이스팅 태그 목록 (최대 15개)"),
+                    fieldWithPath("tastingTagList[]")
+                        .type(ARRAY)
+                        .description("테이스팅 태그 목록 (최대 15개)"),
                     fieldWithPath("rating").description("리뷰별점 (해당 리뷰를 남길 시점의 별점 )")),
                 responseFields(
                     fieldWithPath("success").type(BOOLEAN).description("요청 성공 여부"),

--- a/bottlenote-product-api/src/test/java/app/docs/review/RestReviewControllerDocsTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/review/RestReviewControllerDocsTest.java
@@ -84,7 +84,7 @@ class RestReviewControllerDocsTest extends AbstractRestDocs {
                 "review/review-create",
                 requestFields(
                     fieldWithPath("alcoholId").type(NUMBER).description("술 ID"),
-                    fieldWithPath("content").type(STRING).description("리뷰 내용"),
+                    fieldWithPath("content").type(STRING).description("리뷰 내용 (최대 700자)"),
                     fieldWithPath("status").type(STRING).description("리뷰 상태"),
                     fieldWithPath("price").type(NUMBER).description("가격"),
                     fieldWithPath("sizeType").type(STRING).description("술 타입 (잔 or 병"),
@@ -121,7 +121,7 @@ class RestReviewControllerDocsTest extends AbstractRestDocs {
                     fieldWithPath("imageUrlList").type(ARRAY).description("이미지 URL 목록"),
                     fieldWithPath("imageUrlList[].order").type(NUMBER).description("이미지 순서"),
                     fieldWithPath("imageUrlList[].viewUrl").type(STRING).description("이미지 뷰 URL"),
-                    fieldWithPath("tastingTagList[]").type(ARRAY).description("테이스팅 태그 목록"),
+                    fieldWithPath("tastingTagList[]").type(ARRAY).description("테이스팅 태그 목록 (최대 15개)"),
                     fieldWithPath("rating").description("리뷰별점 (해당 리뷰를 남길 시점의 별점 )")),
                 responseFields(
                     fieldWithPath("success").type(BOOLEAN).description("요청 성공 여부"),
@@ -493,7 +493,7 @@ class RestReviewControllerDocsTest extends AbstractRestDocs {
             document(
                 "review/review-update",
                 requestFields(
-                    fieldWithPath("content").type(STRING).description("리뷰 내용").optional(),
+                    fieldWithPath("content").type(STRING).description("리뷰 내용 (최대 700자)").optional(),
                     fieldWithPath("status").type(STRING).description("리뷰 상태").optional(),
                     fieldWithPath("price").type(NUMBER).description("가격").optional(),
                     fieldWithPath("sizeType").type(STRING).description("술 타입 (잔 or 병)").optional(),
@@ -530,7 +530,7 @@ class RestReviewControllerDocsTest extends AbstractRestDocs {
                     fieldWithPath("imageUrlList").type(ARRAY).description("이미지 URL 목록"),
                     fieldWithPath("imageUrlList[].order").type(NUMBER).description("이미지 순서"),
                     fieldWithPath("imageUrlList[].viewUrl").type(STRING).description("이미지 뷰 URL"),
-                    fieldWithPath("tastingTagList").description("테이스팅 태그 목록").optional()),
+                    fieldWithPath("tastingTagList").description("테이스팅 태그 목록 (최대 15개)").optional()),
                 responseFields(
                     fieldWithPath("success").description("응답 성공 여부"),
                     fieldWithPath("code").description("응답 코드(http status code)"),


### PR DESCRIPTION
## Summary
리뷰 작성 길이와 테이스팅 태그 개수 제한 확장에 따른 문서 및 예외 메시지 업데이트

## Changes
### 예외 메시지 수정
- `ReviewExceptionCode`: 테이스팅 태그 제한 메시지 10개 → 15개로 수정

### API 문서 (AsciiDoc) 수정
- `review-create.adoc`: 리뷰 내용 500자 → 700자, 테이스팅 태그 10개 → 15개 명시
- `review-modify.adoc`: 리뷰 내용 500자 → 700자 명시

### REST Docs 필드 설명 추가
- `RestReviewControllerDocsTest`: 모든 리뷰 content 및 tastingTagList 필드에 제한사항 추가
  - content: "리뷰 내용 (최대 700자)"
  - tastingTagList: "테이스팅 태그 목록 (최대 15개)"

## Related Issue
- Resolves bottle-note/workspace#121

## Test Plan
- [x] 예외 메시지 확인
- [x] API 문서 일관성 확인
- [x] REST Docs 필드 설명 확인