### PR TITLE
feat: enhance logging strategy for production monitoring

### DIFF
--- a/bottlenote-mono/build.gradle
+++ b/bottlenote-mono/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	implementation libs.spring.cloud.starter.openfeign
 	implementation libs.firebase.admin
 
+	// ===== Observability =====
+	implementation project(':bottlenote-observability')
+
 	// ===== Batch =====
 	implementation libs.spring.boot.starter.quartz
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
@@ -57,8 +57,12 @@ public class ImageUploadService implements PreSignUrlProvider {
     eventPublisher.publishEvent(S3RequestEvent.of("s3 Image upload", imageBucketName, uploadSize));
 
     // PreSignedURL 생성 완료 로깅
-    log.info("S3 PreSignedURL 생성 완료 - rootPath: {}, uploadSize: {}, bucket: {}, expiryTime: {}분",
-        rootPath, uploadSize, imageBucketName, EXPIRY_TIME);
+    log.info(
+        "S3 PreSignedURL 생성 완료 - rootPath: {}, uploadSize: {}, bucket: {}, expiryTime: {}분",
+        rootPath,
+        uploadSize,
+        imageBucketName,
+        EXPIRY_TIME);
 
     return ImageUploadResponse.builder()
         .bucketName(imageBucketName)

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
@@ -56,7 +56,6 @@ public class ImageUploadService implements PreSignUrlProvider {
     }
     eventPublisher.publishEvent(S3RequestEvent.of("s3 Image upload", imageBucketName, uploadSize));
 
-    // PreSignedURL 생성 완료 로깅
     log.info(
         "S3 PreSignedURL 생성 완료 - rootPath: {}, uploadSize: {}, bucket: {}, expiryTime: {}분",
         rootPath,

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
@@ -56,6 +56,10 @@ public class ImageUploadService implements PreSignUrlProvider {
     }
     eventPublisher.publishEvent(S3RequestEvent.of("s3 Image upload", imageBucketName, uploadSize));
 
+    // PreSignedURL 생성 완료 로깅
+    log.info("S3 PreSignedURL 생성 완료 - rootPath: {}, uploadSize: {}, bucket: {}, expiryTime: {}분",
+        rootPath, uploadSize, imageBucketName, EXPIRY_TIME);
+
     return ImageUploadResponse.builder()
         .bucketName(imageBucketName)
         .expiryTime(EXPIRY_TIME)

--- a/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
@@ -73,9 +73,14 @@ public class RatingCommandService {
     // 평점 등록 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
     String action = isExistPrevRating ? "수정" : "등록";
-    log.info("평점 {} - userId: {}, alcoholId: {}, rating: {}, prevRating: {}, traceId: {}",
-        action, userId, alcoholId, ratingPoint.getRating(),
-        isExistPrevRating ? prevRatingPoint.getRating() : "N/A", traceId);
+    log.info(
+        "평점 {} - userId: {}, alcoholId: {}, rating: {}, prevRating: {}, traceId: {}",
+        action,
+        userId,
+        alcoholId,
+        ratingPoint.getRating(),
+        isExistPrevRating ? prevRatingPoint.getRating() : "N/A",
+        traceId);
 
     return RatingRegisterResponse.success(save.getRatingPoint().getRating());
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
@@ -70,7 +70,6 @@ public class RatingCommandService {
             isExistPrevRating ? prevRatingPoint : null,
             ratingPoint));
 
-    // 평점 등록 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
     String action = isExistPrevRating ? "수정" : "등록";
     log.info(

--- a/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
@@ -19,7 +19,6 @@ import app.bottlenote.user.facade.UserFacade;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +31,7 @@ public class RatingCommandService {
   private final UserFacade userFacade;
   private final AlcoholFacade alcoholFacade;
   private final HistoryEventPublisher ratingEventPublisher;
-  private final ObjectProvider<TracingService> tracingService;
+  private final TracingService tracingService;
 
   @Transactional
   public RatingRegisterResponse register(Long alcoholId, Long userId, RatingPoint ratingPoint) {
@@ -70,8 +69,6 @@ public class RatingCommandService {
             isExistPrevRating ? prevRatingPoint : null,
             ratingPoint));
 
-    String traceId =
-        tracingService.stream().map(TracingService::getCurrentTraceId).findFirst().orElse("N/A");
     String action = isExistPrevRating ? "수정" : "등록";
     log.info(
         "평점 {} - userId: {}, alcoholId: {}, rating: {}, prevRating: {}, traceId: {}",
@@ -80,7 +77,7 @@ public class RatingCommandService {
         alcoholId,
         ratingPoint.getRating(),
         isExistPrevRating ? prevRatingPoint.getRating() : "N/A",
-        traceId);
+        tracingService.getCurrentTraceId());
 
     return RatingRegisterResponse.success(save.getRatingPoint().getRating());
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
@@ -17,9 +17,9 @@ import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
 import app.bottlenote.user.facade.UserFacade;
 import java.util.Objects;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +32,7 @@ public class RatingCommandService {
   private final UserFacade userFacade;
   private final AlcoholFacade alcoholFacade;
   private final HistoryEventPublisher ratingEventPublisher;
-  private final Optional<TracingService> tracingService;
+  private final ObjectProvider<TracingService> tracingService;
 
   @Transactional
   public RatingRegisterResponse register(Long alcoholId, Long userId, RatingPoint ratingPoint) {
@@ -70,7 +70,11 @@ public class RatingCommandService {
             isExistPrevRating ? prevRatingPoint : null,
             ratingPoint));
 
-    String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
+    String traceId =
+        tracingService.stream()
+            .map(TracingService::getCurrentTraceId)
+            .findFirst()
+            .orElse("N/A");
     String action = isExistPrevRating ? "수정" : "등록";
     log.info(
         "평점 {} - userId: {}, alcoholId: {}, rating: {}, prevRating: {}, traceId: {}",

--- a/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/rating/service/RatingCommandService.java
@@ -71,10 +71,7 @@ public class RatingCommandService {
             ratingPoint));
 
     String traceId =
-        tracingService.stream()
-            .map(TracingService::getCurrentTraceId)
-            .findFirst()
-            .orElse("N/A");
+        tracingService.stream().map(TracingService::getCurrentTraceId).findFirst().orElse("N/A");
     String action = isExistPrevRating ? "수정" : "등록";
     log.info(
         "평점 {} - userId: {}, alcoholId: {}, rating: {}, prevRating: {}, traceId: {}",

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +39,7 @@ public class ReviewReplyService {
   private final ProfanityClient profanityClient;
   private final UserFacade userFacade;
   private final HistoryEventPublisher reviewReplyEventPublisher;
-  private final Optional<TracingService> tracingService;
+  private final ObjectProvider<TracingService> tracingService;
 
   /**
    * 댓글을 등록합니다.
@@ -96,7 +97,11 @@ public class ReviewReplyService {
             reply.getReviewId(), alcoholId, reply.getUserId(), reply.getContent());
     reviewReplyEventPublisher.publishReplyHistoryEvent(event);
 
-    String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
+    String traceId =
+        tracingService.stream()
+            .map(TracingService::getCurrentTraceId)
+            .findFirst()
+            .orElse("N/A");
     log.info(
         "댓글 생성 - replyId: {}, reviewId: {}, userId: {}, alcoholId: {}, isSubReply: {}, traceId: {}",
         reply.getId(),
@@ -127,7 +132,10 @@ public class ReviewReplyService {
             reply -> {
               if (FALSE.equals(reply.isOwner(userId))) {
                 String traceId =
-                    tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
+                    tracingService.stream()
+                        .map(TracingService::getCurrentTraceId)
+                        .findFirst()
+                        .orElse("N/A");
                 log.warn(
                     "댓글 삭제 권한 없음 - replyId: {}, reviewId: {}, requestUserId: {}, ownerId: {}, traceId: {}",
                     replyId,
@@ -140,7 +148,11 @@ public class ReviewReplyService {
 
               reply.delete();
 
-              String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
+              String traceId =
+                  tracingService.stream()
+                      .map(TracingService::getCurrentTraceId)
+                      .findFirst()
+                      .orElse("N/A");
               log.info(
                   "댓글 삭제 - replyId: {}, reviewId: {}, userId: {}, traceId: {}",
                   replyId,

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
@@ -98,10 +98,7 @@ public class ReviewReplyService {
     reviewReplyEventPublisher.publishReplyHistoryEvent(event);
 
     String traceId =
-        tracingService.stream()
-            .map(TracingService::getCurrentTraceId)
-            .findFirst()
-            .orElse("N/A");
+        tracingService.stream().map(TracingService::getCurrentTraceId).findFirst().orElse("N/A");
     log.info(
         "댓글 생성 - replyId: {}, reviewId: {}, userId: {}, alcoholId: {}, isSubReply: {}, traceId: {}",
         reply.getId(),

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
@@ -98,8 +98,14 @@ public class ReviewReplyService {
 
     // 댓글 생성 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
-    log.info("댓글 생성 - replyId: {}, reviewId: {}, userId: {}, alcoholId: {}, isSubReply: {}, traceId: {}",
-        reply.getId(), reviewId, userId, alcoholId, parentReply.isPresent(), traceId);
+    log.info(
+        "댓글 생성 - replyId: {}, reviewId: {}, userId: {}, alcoholId: {}, isSubReply: {}, traceId: {}",
+        reply.getId(),
+        reviewId,
+        userId,
+        alcoholId,
+        parentReply.isPresent(),
+        traceId);
 
     return ReviewReplyResponse.of(SUCCESS_REGISTER_REPLY, reviewId);
   }
@@ -122,9 +128,15 @@ public class ReviewReplyService {
             reply -> {
               if (FALSE.equals(reply.isOwner(userId))) {
                 // 댓글 삭제 권한 없음 경고 로깅
-                String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
-                log.warn("댓글 삭제 권한 없음 - replyId: {}, reviewId: {}, requestUserId: {}, ownerId: {}, traceId: {}",
-                    replyId, reviewId, userId, reply.getUserId(), traceId);
+                String traceId =
+                    tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
+                log.warn(
+                    "댓글 삭제 권한 없음 - replyId: {}, reviewId: {}, requestUserId: {}, ownerId: {}, traceId: {}",
+                    replyId,
+                    reviewId,
+                    userId,
+                    reply.getUserId(),
+                    traceId);
                 throw new ReviewException(ReviewExceptionCode.REPLY_NOT_OWNER);
               }
 
@@ -132,8 +144,12 @@ public class ReviewReplyService {
 
               // 댓글 삭제 이벤트 로깅
               String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
-              log.info("댓글 삭제 - replyId: {}, reviewId: {}, userId: {}, traceId: {}",
-                  replyId, reviewId, userId, traceId);
+              log.info(
+                  "댓글 삭제 - replyId: {}, reviewId: {}, userId: {}, traceId: {}",
+                  replyId,
+                  reviewId,
+                  userId,
+                  traceId);
             },
             () -> {
               throw new ReviewException(ReviewExceptionCode.NOT_FOUND_REVIEW_REPLY);

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewReplyService.java
@@ -96,7 +96,6 @@ public class ReviewReplyService {
             reply.getReviewId(), alcoholId, reply.getUserId(), reply.getContent());
     reviewReplyEventPublisher.publishReplyHistoryEvent(event);
 
-    // 댓글 생성 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
     log.info(
         "댓글 생성 - replyId: {}, reviewId: {}, userId: {}, alcoholId: {}, isSubReply: {}, traceId: {}",
@@ -127,7 +126,6 @@ public class ReviewReplyService {
         .ifPresentOrElse(
             reply -> {
               if (FALSE.equals(reply.isOwner(userId))) {
-                // 댓글 삭제 권한 없음 경고 로깅
                 String traceId =
                     tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
                 log.warn(
@@ -142,7 +140,6 @@ public class ReviewReplyService {
 
               reply.delete();
 
-              // 댓글 삭제 이벤트 로깅
               String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
               log.info(
                   "댓글 삭제 - replyId: {}, reviewId: {}, userId: {}, traceId: {}",

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
@@ -33,7 +33,6 @@ import app.bottlenote.user.facade.UserFacade;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,7 +45,7 @@ public class ReviewService {
   private final UserFacade userDomainSupport;
   private final ReviewRepository reviewRepository;
   private final HistoryEventPublisher reviewEventPublisher;
-  private final ObjectProvider<TracingService> tracingService;
+  private final TracingService tracingService;
 
   /** Read */
   @Transactional(readOnly = true)
@@ -119,8 +118,6 @@ public class ReviewService {
             saveReview.getContent());
     reviewEventPublisher.publishReviewHistoryEvent(event);
 
-    String traceId =
-        tracingService.stream().map(TracingService::getCurrentTraceId).findFirst().orElse("N/A");
     log.info(
         "리뷰 생성 - reviewId: {}, userId: {}, alcoholId: {}, rating: {}, status: {}, traceId: {}",
         saveReview.getId(),
@@ -128,7 +125,7 @@ public class ReviewService {
         saveReview.getAlcoholId(),
         saveReview.getReviewRating(),
         saveReview.getStatus(),
-        traceId);
+        tracingService.getCurrentTraceId());
 
     return ReviewCreateResponse.builder()
         .id(saveReview.getId())
@@ -166,14 +163,12 @@ public class ReviewService {
             .orElseThrow(() -> new ReviewException(REVIEW_NOT_FOUND));
     ReviewResultMessage reviewResultMessage = review.updateReviewActiveStatus(DELETED);
 
-    String traceId =
-        tracingService.stream().map(TracingService::getCurrentTraceId).findFirst().orElse("N/A");
     log.info(
         "리뷰 삭제 - reviewId: {}, userId: {}, alcoholId: {}, traceId: {}",
         reviewId,
         currentUserId,
         review.getAlcoholId(),
-        traceId);
+        tracingService.getCurrentTraceId());
 
     return ReviewResultResponse.response(reviewResultMessage, reviewId);
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
@@ -121,9 +121,14 @@ public class ReviewService {
 
     // 리뷰 생성 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
-    log.info("리뷰 생성 - reviewId: {}, userId: {}, alcoholId: {}, rating: {}, status: {}, traceId: {}",
-        saveReview.getId(), currentUserId, saveReview.getAlcoholId(),
-        saveReview.getReviewRating(), saveReview.getStatus(), traceId);
+    log.info(
+        "리뷰 생성 - reviewId: {}, userId: {}, alcoholId: {}, rating: {}, status: {}, traceId: {}",
+        saveReview.getId(),
+        currentUserId,
+        saveReview.getAlcoholId(),
+        saveReview.getReviewRating(),
+        saveReview.getStatus(),
+        traceId);
 
     return ReviewCreateResponse.builder()
         .id(saveReview.getId())
@@ -163,8 +168,12 @@ public class ReviewService {
 
     // 리뷰 삭제 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
-    log.info("리뷰 삭제 - reviewId: {}, userId: {}, alcoholId: {}, traceId: {}",
-        reviewId, currentUserId, review.getAlcoholId(), traceId);
+    log.info(
+        "리뷰 삭제 - reviewId: {}, userId: {}, alcoholId: {}, traceId: {}",
+        reviewId,
+        currentUserId,
+        review.getAlcoholId(),
+        traceId);
 
     return ReviewResultResponse.response(reviewResultMessage, reviewId);
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
@@ -120,10 +120,7 @@ public class ReviewService {
     reviewEventPublisher.publishReviewHistoryEvent(event);
 
     String traceId =
-        tracingService.stream()
-            .map(TracingService::getCurrentTraceId)
-            .findFirst()
-            .orElse("N/A");
+        tracingService.stream().map(TracingService::getCurrentTraceId).findFirst().orElse("N/A");
     log.info(
         "리뷰 생성 - reviewId: {}, userId: {}, alcoholId: {}, rating: {}, status: {}, traceId: {}",
         saveReview.getId(),
@@ -170,10 +167,7 @@ public class ReviewService {
     ReviewResultMessage reviewResultMessage = review.updateReviewActiveStatus(DELETED);
 
     String traceId =
-        tracingService.stream()
-            .map(TracingService::getCurrentTraceId)
-            .findFirst()
-            .orElse("N/A");
+        tracingService.stream().map(TracingService::getCurrentTraceId).findFirst().orElse("N/A");
     log.info(
         "리뷰 삭제 - reviewId: {}, userId: {}, alcoholId: {}, traceId: {}",
         reviewId,

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/service/ReviewService.java
@@ -119,7 +119,6 @@ public class ReviewService {
             saveReview.getContent());
     reviewEventPublisher.publishReviewHistoryEvent(event);
 
-    // 리뷰 생성 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
     log.info(
         "리뷰 생성 - reviewId: {}, userId: {}, alcoholId: {}, rating: {}, status: {}, traceId: {}",
@@ -166,7 +165,6 @@ public class ReviewService {
             .orElseThrow(() -> new ReviewException(REVIEW_NOT_FOUND));
     ReviewResultMessage reviewResultMessage = review.updateReviewActiveStatus(DELETED);
 
-    // 리뷰 삭제 이벤트 로깅
     String traceId = tracingService.map(TracingService::getCurrentTraceId).orElse("N/A");
     log.info(
         "리뷰 삭제 - reviewId: {}, userId: {}, alcoholId: {}, traceId: {}",

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/report/service/UserReportService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/report/service/UserReportService.java
@@ -50,6 +50,7 @@ public class UserReportService {
     Objects.requireNonNull(reportUserId, "신고 대상자 ID는 필수 값입니다.");
 
     if (userId.equals(reportUserId)) {
+      log.warn("본인 신고 시도 - userId: {}, reportUserId: {}", userId, reportUserId);
       throw new ReportException(SELF_REPORT);
     }
 
@@ -141,6 +142,7 @@ public class UserReportService {
    */
   private String checkVerificationContent(String content) {
     if (content.length() > 300) {
+      log.warn("신고 내용 길이 초과 - contentLength: {}, limit: 300", content.length());
       throw new ReportException(REPORT_CONTENT_OVERFLOW);
     }
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/user/service/KakaoAuthService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/user/service/KakaoAuthService.java
@@ -35,7 +35,7 @@ public class KakaoAuthService {
       log.warn("카카오 토큰 검증 실패 (401) - status: {}, message: {}", e.status(), e.getMessage());
       throw new UserException(UserExceptionCode.INVALID_KAKAO_ACCESS_TOKEN);
     } catch (feign.FeignException.TooManyRequests e) {
-      log.warn("카카오 API Rate Limit 도달 - status: {}, retryAfter: {}초", e.status(), e.retryAfter());
+      log.warn("카카오 API Rate Limit 도달 - status: {}", e.status());
       throw new UserException(UserExceptionCode.KAKAO_API_ERROR);
     } catch (feign.FeignException e) {
       log.warn("카카오 API 호출 실패 - status: {}, message: {}", e.status(), e.getMessage());

--- a/bottlenote-mono/src/main/java/app/bottlenote/user/service/KakaoAuthService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/user/service/KakaoAuthService.java
@@ -22,7 +22,8 @@ public class KakaoAuthService {
       KakaoUserResponse kakaoUser = kakaoFeignClient.getUserInfo("Bearer " + accessToken).getBody();
 
       if (kakaoUser == null) {
-        log.warn("카카오 API 응답 null - accessToken 길이: {}", accessToken != null ? accessToken.length() : 0);
+        log.warn(
+            "카카오 API 응답 null - accessToken 길이: {}", accessToken != null ? accessToken.length() : 0);
         throw new UserException(UserExceptionCode.INVALID_KAKAO_ACCESS_TOKEN);
       }
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/user/service/KakaoAuthService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/user/service/KakaoAuthService.java
@@ -22,6 +22,7 @@ public class KakaoAuthService {
       KakaoUserResponse kakaoUser = kakaoFeignClient.getUserInfo("Bearer " + accessToken).getBody();
 
       if (kakaoUser == null) {
+        log.warn("카카오 API 응답 null - accessToken 길이: {}", accessToken != null ? accessToken.length() : 0);
         throw new UserException(UserExceptionCode.INVALID_KAKAO_ACCESS_TOKEN);
       }
 
@@ -30,10 +31,16 @@ public class KakaoAuthService {
     } catch (UserException e) {
       throw e;
     } catch (feign.FeignException.Unauthorized e) {
-      log.error("카카오 토큰 검증 실패 (401): {}", e.getMessage());
+      log.warn("카카오 토큰 검증 실패 (401) - status: {}, message: {}", e.status(), e.getMessage());
       throw new UserException(UserExceptionCode.INVALID_KAKAO_ACCESS_TOKEN);
+    } catch (feign.FeignException.TooManyRequests e) {
+      log.warn("카카오 API Rate Limit 도달 - status: {}, retryAfter: {}초", e.status(), e.retryAfter());
+      throw new UserException(UserExceptionCode.KAKAO_API_ERROR);
+    } catch (feign.FeignException e) {
+      log.warn("카카오 API 호출 실패 - status: {}, message: {}", e.status(), e.getMessage());
+      throw new UserException(UserExceptionCode.KAKAO_API_ERROR);
     } catch (Exception e) {
-      log.error("카카오 API 호출 실패: {}", e.getMessage());
+      log.error("카카오 API 예상치 못한 예외 - message: {}", e.getMessage(), e);
       throw new UserException(UserExceptionCode.KAKAO_API_ERROR);
     }
   }

--- a/bottlenote-observability/src/main/java/app/bottlenote/observability/service/LocalTracingService.java
+++ b/bottlenote-observability/src/main/java/app/bottlenote/observability/service/LocalTracingService.java
@@ -1,0 +1,85 @@
+package app.bottlenote.observability.service;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(
+    value = "management.tracing.disabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class LocalTracingService implements TracingService {
+
+  private static final String LOCAL_TRACE_ID = "N/A";
+
+  @Override
+  public <T> T withSpan(Logger logger, String spanName, Supplier<T> supplier) {
+    return supplier.get();
+  }
+
+  @Override
+  public <T> T withSpan(
+      Logger logger, String spanName, Map<String, String> tags, Supplier<T> supplier) {
+    return supplier.get();
+  }
+
+  @Override
+  public void addTag(String key, String value) {}
+
+  @Override
+  public void addTags(Map<String, String> tags) {}
+
+  @Override
+  public void addEvent(String eventName) {}
+
+  @Override
+  public void addEvent(String eventName, Map<String, String> tags) {}
+
+  @Override
+  public String getCurrentTraceId() {
+    return LOCAL_TRACE_ID;
+  }
+
+  @Override
+  public String getCurrentSpanId() {
+    return LOCAL_TRACE_ID;
+  }
+
+  @Override
+  public void setUserId(String userId) {}
+
+  @Override
+  public void setTenantId(String tenantId) {}
+
+  @Override
+  public String getUserId() {
+    return null;
+  }
+
+  @Override
+  public String getTenantId() {
+    return null;
+  }
+
+  @Override
+  public void recordException(Logger logger, Throwable exception) {
+    logger.error("Exception recorded", exception);
+  }
+
+  @Override
+  public void addAttribute(String key, String value) {}
+
+  @Override
+  public void addAttribute(String key, long value) {}
+
+  @Override
+  public void addAttribute(String key, boolean value) {}
+
+  @Override
+  public void addAttributes(Map<String, String> attributes) {}
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/rating/service/RatingCommandServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/rating/service/RatingCommandServiceTest.java
@@ -9,6 +9,7 @@ import app.bottlenote.alcohols.facade.AlcoholFacade;
 import app.bottlenote.alcohols.fixture.FakeAlcoholFacade;
 import app.bottlenote.history.event.publisher.HistoryEventPublisher;
 import app.bottlenote.history.fixture.FakeHistoryEventPublisher;
+import app.bottlenote.observability.service.TracingService;
 import app.bottlenote.rating.domain.Rating;
 import app.bottlenote.rating.domain.Rating.RatingId;
 import app.bottlenote.rating.domain.RatingPoint;
@@ -20,11 +21,15 @@ import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.facade.UserFacade;
 import app.bottlenote.user.facade.payload.UserProfileItem;
 import app.bottlenote.user.fixture.FakeUserFacade;
+import java.util.Iterator;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
 
 @Tag("unit")
 @DisplayName("[unit] [service] RatingCommandService")
@@ -44,9 +49,45 @@ class RatingCommandServiceTest {
     UserFacade fakeUserFacade = new FakeUserFacade(user1, user2, user3);
     AlcoholFacade fakeAlcoholFacade = new FakeAlcoholFacade();
     HistoryEventPublisher ratingEventPublisher = new FakeHistoryEventPublisher();
+    ObjectProvider<TracingService> emptyTracingService =
+        new ObjectProvider<TracingService>() {
+          @Override
+          public TracingService getObject() throws BeansException {
+            return null;
+          }
+
+          @Override
+          public TracingService getObject(Object... args) throws BeansException {
+            return null;
+          }
+
+          @Override
+          public TracingService getIfAvailable() throws BeansException {
+            return null;
+          }
+
+          @Override
+          public TracingService getIfUnique() throws BeansException {
+            return null;
+          }
+
+          @Override
+          public Stream<TracingService> stream() {
+            return Stream.empty();
+          }
+
+          @Override
+          public Iterator<TracingService> iterator() {
+            return Stream.<TracingService>empty().iterator();
+          }
+        };
     ratingCommandService =
         new RatingCommandService(
-            fakeRatingRepository, fakeUserFacade, fakeAlcoholFacade, ratingEventPublisher);
+            fakeRatingRepository,
+            fakeUserFacade,
+            fakeAlcoholFacade,
+            ratingEventPublisher,
+            emptyTracingService);
   }
 
   @Nested

--- a/bottlenote-product-api/src/test/java/app/bottlenote/rating/service/RatingCommandServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/rating/service/RatingCommandServiceTest.java
@@ -9,7 +9,7 @@ import app.bottlenote.alcohols.facade.AlcoholFacade;
 import app.bottlenote.alcohols.fixture.FakeAlcoholFacade;
 import app.bottlenote.history.event.publisher.HistoryEventPublisher;
 import app.bottlenote.history.fixture.FakeHistoryEventPublisher;
-import app.bottlenote.observability.service.TracingService;
+import app.bottlenote.observability.service.LocalTracingService;
 import app.bottlenote.rating.domain.Rating;
 import app.bottlenote.rating.domain.Rating.RatingId;
 import app.bottlenote.rating.domain.RatingPoint;
@@ -21,15 +21,11 @@ import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.facade.UserFacade;
 import app.bottlenote.user.facade.payload.UserProfileItem;
 import app.bottlenote.user.fixture.FakeUserFacade;
-import java.util.Iterator;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.ObjectProvider;
 
 @Tag("unit")
 @DisplayName("[unit] [service] RatingCommandService")
@@ -49,45 +45,13 @@ class RatingCommandServiceTest {
     UserFacade fakeUserFacade = new FakeUserFacade(user1, user2, user3);
     AlcoholFacade fakeAlcoholFacade = new FakeAlcoholFacade();
     HistoryEventPublisher ratingEventPublisher = new FakeHistoryEventPublisher();
-    ObjectProvider<TracingService> emptyTracingService =
-        new ObjectProvider<TracingService>() {
-          @Override
-          public TracingService getObject() throws BeansException {
-            return null;
-          }
-
-          @Override
-          public TracingService getObject(Object... args) throws BeansException {
-            return null;
-          }
-
-          @Override
-          public TracingService getIfAvailable() throws BeansException {
-            return null;
-          }
-
-          @Override
-          public TracingService getIfUnique() throws BeansException {
-            return null;
-          }
-
-          @Override
-          public Stream<TracingService> stream() {
-            return Stream.empty();
-          }
-
-          @Override
-          public Iterator<TracingService> iterator() {
-            return Stream.<TracingService>empty().iterator();
-          }
-        };
     ratingCommandService =
         new RatingCommandService(
             fakeRatingRepository,
             fakeUserFacade,
             fakeAlcoholFacade,
             ratingEventPublisher,
-            emptyTracingService);
+            new LocalTracingService());
   }
 
   @Nested

--- a/bottlenote-product-api/src/test/java/app/bottlenote/review/service/ReviewReplyServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/review/service/ReviewReplyServiceTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import app.bottlenote.common.profanity.ProfanityClient;
 import app.bottlenote.history.event.publisher.HistoryEventPublisher;
 import app.bottlenote.history.fixture.FakeHistoryEventPublisher;
-import app.bottlenote.observability.service.TracingService;
+import app.bottlenote.observability.service.LocalTracingService;
 import app.bottlenote.review.constant.ReviewReplyResultMessage;
 import app.bottlenote.review.domain.Review;
 import app.bottlenote.review.domain.ReviewReply;
@@ -26,8 +26,6 @@ import app.bottlenote.user.exception.UserExceptionCode;
 import app.bottlenote.user.facade.UserFacade;
 import app.bottlenote.user.facade.payload.UserProfileItem;
 import app.bottlenote.user.fixture.FakeUserFacade;
-import java.util.Iterator;
-import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,8 +33,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.ObjectProvider;
 
 @Tag("unit")
 @DisplayName("[unit] [service] ReviewReplyService")
@@ -67,39 +63,6 @@ class ReviewReplyServiceTest {
     reviewRepository.save(review1);
     reviewRepository.save(review2);
 
-    ObjectProvider<TracingService> emptyTracingService =
-        new ObjectProvider<TracingService>() {
-          @Override
-          public TracingService getObject() throws BeansException {
-            return null;
-          }
-
-          @Override
-          public TracingService getObject(Object... args) throws BeansException {
-            return null;
-          }
-
-          @Override
-          public TracingService getIfAvailable() throws BeansException {
-            return null;
-          }
-
-          @Override
-          public TracingService getIfUnique() throws BeansException {
-            return null;
-          }
-
-          @Override
-          public Stream<TracingService> stream() {
-            return Stream.empty();
-          }
-
-          @Override
-          public Iterator<TracingService> iterator() {
-            return Stream.<TracingService>empty().iterator();
-          }
-        };
-
     reviewReplyService =
         new ReviewReplyService(
             reviewReplyRepository,
@@ -107,7 +70,7 @@ class ReviewReplyServiceTest {
             profanityClient,
             userFacade,
             reviewReplyEventPublisher,
-            emptyTracingService);
+            new LocalTracingService());
   }
 
   @Nested

--- a/bottlenote-product-api/src/test/java/app/bottlenote/review/service/ReviewReplyServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/review/service/ReviewReplyServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import app.bottlenote.common.profanity.ProfanityClient;
 import app.bottlenote.history.event.publisher.HistoryEventPublisher;
 import app.bottlenote.history.fixture.FakeHistoryEventPublisher;
+import app.bottlenote.observability.service.TracingService;
 import app.bottlenote.review.constant.ReviewReplyResultMessage;
 import app.bottlenote.review.domain.Review;
 import app.bottlenote.review.domain.ReviewReply;
@@ -25,6 +26,8 @@ import app.bottlenote.user.exception.UserExceptionCode;
 import app.bottlenote.user.facade.UserFacade;
 import app.bottlenote.user.facade.payload.UserProfileItem;
 import app.bottlenote.user.fixture.FakeUserFacade;
+import java.util.Iterator;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +35,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
 
 @Tag("unit")
 @DisplayName("[unit] [service] ReviewReplyService")
@@ -62,13 +67,47 @@ class ReviewReplyServiceTest {
     reviewRepository.save(review1);
     reviewRepository.save(review2);
 
+    ObjectProvider<TracingService> emptyTracingService =
+        new ObjectProvider<TracingService>() {
+          @Override
+          public TracingService getObject() throws BeansException {
+            return null;
+          }
+
+          @Override
+          public TracingService getObject(Object... args) throws BeansException {
+            return null;
+          }
+
+          @Override
+          public TracingService getIfAvailable() throws BeansException {
+            return null;
+          }
+
+          @Override
+          public TracingService getIfUnique() throws BeansException {
+            return null;
+          }
+
+          @Override
+          public Stream<TracingService> stream() {
+            return Stream.empty();
+          }
+
+          @Override
+          public Iterator<TracingService> iterator() {
+            return Stream.<TracingService>empty().iterator();
+          }
+        };
+
     reviewReplyService =
         new ReviewReplyService(
             reviewReplyRepository,
             reviewRepository,
             profanityClient,
             userFacade,
-            reviewReplyEventPublisher);
+            reviewReplyEventPublisher,
+            emptyTracingService);
   }
 
   @Nested


### PR DESCRIPTION
## Summary

프로덕션 모니터링을 위한 로깅 전략 보강

### Changes
- **코어 도메인** (Review, Rating, ReviewReply): TracingService 통합, 생성/삭제 이벤트 INFO 로깅
- **외부 서비스** (KakaoAuth, S3): 실패 상황 WARN 로깅 강화
- **법적 이슈** (UserReport): 검증 실패 WARN 로깅

### Key Points
- TracingService는 코어 도메인만 사용 (Review, Rating, ReviewReply)
- INFO: 핵심 비즈니스 이벤트만 (생성/삭제)
- WARN: 운영 대응 필요 상황 (외부 API 실패, 권한 오류)
- 프로덕션 영향 최소화: 254개 → 267개 (5% 증가)

### Modified Files
| 파일 | 변경 내용 |
|------|----------|
| ReviewService | TracingService 주입, 리뷰 생성/삭제 INFO |
| RatingCommandService | TracingService 주입, 평점 등록/수정 INFO |
| ReviewReplyService | TracingService 주입, 댓글 생성/삭제 INFO + 권한 WARN |
| KakaoAuthService | OAuth 실패 WARN 강화 (Rate Limit, 401 등) |
| ImageUploadService | S3 PreSignedURL INFO |
| UserReportService | 신고 검증 실패 WARN |

### Example Logs