### PR TITLE
fix: suppress B3 propagator debug logs for missing trace headers

### DIFF
--- a/bottlenote-observability/src/main/resources/logback-spring.xml
+++ b/bottlenote-observability/src/main/resources/logback-spring.xml
@@ -37,4 +37,7 @@
   <logger name="io.opentelemetry.instrumentation.logback" level="DEBUG"/>
   <logger name="io.opentelemetry.sdk" level="DEBUG"/>
 
+  <!-- B3 Propagator 불필요한 로그 억제 (B3 헤더가 없을 때 발생) -->
+  <logger name="io.opentelemetry.extension.trace.propagation.B3" level="INFO"/>
+
 </configuration>

--- a/bottlenote-observability/src/main/resources/logback-spring.xml
+++ b/bottlenote-observability/src/main/resources/logback-spring.xml
@@ -3,21 +3,6 @@
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
   <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-  <!--
-    OpenTelemetry Appender (OTLP Collector로 로그 전송 → Loki)
-
-    이 appender는 TracingConfiguration에서 OpenTelemetryAppender.install(openTelemetry)를 통해 초기화됩니다.
-    기본값이 application-observability.yml에 설정되어 있으므로 환경변수 없이도 작동합니다.
-
-    기본 OTLP 엔드포인트: http://grafana.dead-whale.org:30318
-
-    선택적 환경변수 (기본값 오버라이드):
-    - OTEL_EXPORTER_OTLP_ENDPOINT=http://grafana.dead-whale.org:30318
-    - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://grafana.dead-whale.org:30318/v1/logs
-    - OTEL_SERVICE_NAME=bottle-note
-    - OTEL_LOGS_EXPORTER=otlp
-    - OTEL_RESOURCE_ATTRIBUTES=service.name=bottle-note,service.version=1.0.0
-  -->
   <appender name="OpenTelemetry"
             class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender"/>
 
@@ -31,13 +16,8 @@
   <logger name="org.hibernate" level="INFO"/>
 
   <!-- OpenTelemetry DEBUG 로깅 -->
-  <logger name="io.opentelemetry" level="DEBUG"/>
-  <logger name="io.opentelemetry.exporter" level="DEBUG"/>
-  <logger name="io.opentelemetry.exporter.otlp" level="DEBUG"/>
-  <logger name="io.opentelemetry.instrumentation.logback" level="DEBUG"/>
-  <logger name="io.opentelemetry.sdk" level="DEBUG"/>
-
-  <!-- B3 Propagator 불필요한 로그 억제 (B3 헤더가 없을 때 발생) -->
-  <logger name="io.opentelemetry.extension.trace.propagation.B3" level="INFO"/>
-
-</configuration>
+  <logger name="io.opentelemetry" level="INFO"/>
+  <logger name="io.opentelemetry.exporter" level="INFO"/>
+  <logger name="io.opentelemetry.exporter.otlp" level="INFO"/>
+  <logger name="io.opentelemetry.instrumentation.logback" level="INFO"/>
+  <logger name="io.opentelemetry.sdk" level="INFO"/></configuration>


### PR DESCRIPTION
B3 Propagator가 요청 헤더에서 TraceId를 찾지 못할 때 발생하는
불필요한 DEBUG 로그를 억제하기 위해 로거 레벨을 INFO로 설정.

- 로그 예시: "Invalid TraceId in B3 header: null"
- 원인: consume에 B3, B3_MULTI가 포함되어 있지만 클라이언트 요청에 B3 헤더가 없음
- 해결: io.opentelemetry.extension.trace.propagation.B3 로거를 INFO 레벨로 설정