### PR TITLE
dev deploy

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/controller/AlcoholQueryController.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/controller/AlcoholQueryController.java
@@ -28,9 +28,22 @@ public class AlcoholQueryController {
 
   @GetMapping("/search")
   public ResponseEntity<?> searchAlcohols(@ModelAttribute @Valid AlcoholSearchRequest request) {
+
+    // 키워드에 따라 큐레이션 ID 매핑 임시 ( 나중에는 이벤트 시작 시점에 로딩해오는게 더 좋을듯
+    request =
+        switch (request.keyword() != null && !request.keyword().isEmpty()
+            ? request.keyword()
+            : "") {
+          case "비 오는 날 추천 위스키" -> request.withCurationId(1L);
+          case "강렬한 폭풍우 피트 추천 위스키" -> request.withCurationId(2L);
+          case "가을 추천 위스키" -> request.withCurationId(3L);
+          default -> request;
+        };
+
     Long id = getUserIdByContext().orElse(-1L);
     PageResponse<AlcoholSearchResponse> pageResponse =
         alcoholQueryService.searchAlcohols(request, id);
+
     return GlobalResponse.ok(
         pageResponse.content(),
         createMetaInfo()

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AlcoholSearchRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AlcoholSearchRequest.java
@@ -21,4 +21,9 @@ public record AlcoholSearchRequest(
     cursor = cursor != null ? cursor : 0L;
     pageSize = pageSize != null ? pageSize : 10L;
   }
+
+  public AlcoholSearchRequest withCurationId(Long curationId) {
+    return new AlcoholSearchRequest(
+        keyword, curationId, category, regionId, sortType, sortOrder, cursor, pageSize);
+  }
 }

--- a/bottlenote-observability/src/main/resources/application-observability.yml
+++ b/bottlenote-observability/src/main/resources/application-observability.yml
@@ -43,7 +43,7 @@ management:
   metrics:
     distribution:
       percentiles-histogram:
-        http.server.requests: true
+        http.server.requests: false # 히스토그램 비활성화
       percentiles:
         http.server.requests: 0.5, 0.95, 0.99
 


### PR DESCRIPTION
This pull request introduces a feature that maps certain search keywords to curated whiskey recommendations by associating them with specific curation IDs. This mapping is implemented directly in the `AlcoholQueryController` and supported by a new method in the `AlcoholSearchRequest` record. Additionally, there is an update to the environment variables submodule.

**Keyword-based curation mapping:**

* Added logic in `AlcoholQueryController` to automatically assign a curation ID to the `AlcoholSearchRequest` based on specific keyword values, enabling curated whiskey recommendations for phrases like "비 오는 날 추천 위스키", "강렬한 폭풍우 피트 추천 위스키", and "가을 추천 위스키".
* Introduced the `withCurationId(Long curationId)` method in `AlcoholSearchRequest` to facilitate the creation of new request instances with an updated curation ID.

**Infrastructure update:**

* Updated the environment variables submodule reference in `git.environment-variables` to the latest commit.