### PR TITLE
feat: Admin 문의사항 관리 API 구현 (목록/상세/답변)

### DIFF
--- a/bottlenote-admin-api/src/docs/asciidoc/admin-api.adoc
+++ b/bottlenote-admin-api/src/docs/asciidoc/admin-api.adoc
@@ -35,3 +35,9 @@ include::api/admin-auth/auth.adoc[]
 == Alcohol API
 
 include::api/admin-alcohols/alcohols.adoc[]
+
+'''
+
+== Help API
+
+include::api/admin-help/help.adoc[]

--- a/bottlenote-admin-api/src/docs/asciidoc/api/admin-help/help.adoc
+++ b/bottlenote-admin-api/src/docs/asciidoc/api/admin-help/help.adoc
@@ -1,0 +1,100 @@
+=== 문의 목록 조회 ===
+
+- 전체 문의 목록을 조회합니다.
+- 상태(status)와 유형(type)으로 필터링할 수 있습니다.
+- 커서 기반 페이징을 지원합니다.
+
+[source]
+----
+GET /admin/api/v1/helps
+----
+
+[discrete]
+==== 요청 헤더 ====
+
+[discrete]
+include::{snippets}/admin/help/list/request-headers.adoc[]
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/help/list/query-parameters.adoc[]
+include::{snippets}/admin/help/list/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/help/list/response-fields.adoc[]
+include::{snippets}/admin/help/list/http-response.adoc[]
+
+'''
+
+=== 문의 상세 조회 ===
+
+- 특정 문의의 상세 정보를 조회합니다.
+- 문의 내용, 이미지, 답변 내용 등을 확인할 수 있습니다.
+
+[source]
+----
+GET /admin/api/v1/helps/{helpId}
+----
+
+[discrete]
+==== 요청 헤더 ====
+
+[discrete]
+include::{snippets}/admin/help/detail/request-headers.adoc[]
+
+[discrete]
+==== 경로 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/help/detail/path-parameters.adoc[]
+include::{snippets}/admin/help/detail/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/help/detail/response-fields.adoc[]
+include::{snippets}/admin/help/detail/http-response.adoc[]
+
+'''
+
+=== 문의 답변 등록 ===
+
+- 문의에 대한 답변을 등록합니다.
+- 처리 상태를 SUCCESS(처리 완료) 또는 REJECT(반려)로 설정할 수 있습니다.
+
+[source]
+----
+POST /admin/api/v1/helps/{helpId}/answer
+----
+
+[discrete]
+==== 요청 헤더 ====
+
+[discrete]
+include::{snippets}/admin/help/answer/request-headers.adoc[]
+
+[discrete]
+==== 경로 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/help/answer/path-parameters.adoc[]
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/help/answer/request-fields.adoc[]
+include::{snippets}/admin/help/answer/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/help/answer/response-fields.adoc[]
+include::{snippets}/admin/help/answer/http-response.adoc[]

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/AdminHelpController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/AdminHelpController.kt
@@ -1,0 +1,48 @@
+package app.bottlenote.support.help.presentation
+
+import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.security.SecurityContextUtil
+import app.bottlenote.support.help.dto.request.AdminHelpAnswerRequest
+import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest
+import app.bottlenote.support.help.service.AdminHelpService
+import app.bottlenote.user.exception.UserException
+import app.bottlenote.user.exception.UserExceptionCode
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/helps")
+class AdminHelpController(
+	private val adminHelpService: AdminHelpService
+) {
+
+	@GetMapping
+	fun getHelpList(@ModelAttribute request: AdminHelpPageableRequest): ResponseEntity<*> {
+		val response = adminHelpService.getHelpList(request)
+		return GlobalResponse.ok(response)
+	}
+
+	@GetMapping("/{helpId}")
+	fun getHelpDetail(@PathVariable helpId: Long): ResponseEntity<*> {
+		val response = adminHelpService.getHelpDetail(helpId)
+		return GlobalResponse.ok(response)
+	}
+
+	@PostMapping("/{helpId}/answer")
+	fun answerHelp(
+		@PathVariable helpId: Long,
+		@RequestBody @Valid request: AdminHelpAnswerRequest
+	): ResponseEntity<*> {
+		val adminId = SecurityContextUtil.getAdminUserIdByContext()
+			.orElseThrow { UserException(UserExceptionCode.REQUIRED_USER_ID) }
+		val response = adminHelpService.answerHelp(helpId, adminId, request)
+		return GlobalResponse.ok(response)
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/help/AdminHelpControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/help/AdminHelpControllerDocsTest.kt
@@ -1,0 +1,252 @@
+package app.docs.help
+
+import app.bottlenote.global.security.SecurityContextUtil
+import app.bottlenote.global.service.cursor.CursorPageable
+import app.bottlenote.global.service.cursor.PageResponse
+import app.bottlenote.support.constant.StatusType
+import app.bottlenote.support.help.constant.HelpType
+import app.bottlenote.support.help.dto.request.HelpImageItem
+import app.bottlenote.support.help.dto.response.AdminHelpAnswerResponse
+import app.bottlenote.support.help.dto.response.AdminHelpDetailResponse
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse
+import app.bottlenote.support.help.presentation.AdminHelpController
+import app.bottlenote.support.help.service.AdminHelpService
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.BDDMockito.given
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
+import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.operation.preprocess.Preprocessors.*
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.restdocs.request.RequestDocumentation.*
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+import java.time.LocalDateTime
+import java.util.*
+
+@WebMvcTest(
+	controllers = [AdminHelpController::class],
+	excludeAutoConfiguration = [SecurityAutoConfiguration::class]
+)
+@AutoConfigureRestDocs
+@DisplayName("Admin Help 컨트롤러 RestDocs 테스트")
+class AdminHelpControllerDocsTest {
+
+	@Autowired
+	private lateinit var mvc: MockMvcTester
+
+	@Autowired
+	private lateinit var objectMapper: ObjectMapper
+
+	@MockitoBean
+	private lateinit var adminHelpService: AdminHelpService
+
+	@Test
+	@DisplayName("문의 목록 조회")
+	fun getHelpList() {
+		// given
+		val helpList = listOf(
+			AdminHelpListResponse.AdminHelpInfo.builder()
+				.helpId(1L)
+				.userId(100L)
+				.userNickname("테스트유저")
+				.title("위스키 관련 문의")
+				.type(HelpType.WHISKEY)
+				.status(StatusType.WAITING)
+				.createAt(LocalDateTime.now())
+				.build()
+		)
+		val response = AdminHelpListResponse.of(1L, helpList)
+		val cursorPageable = CursorPageable.builder()
+			.cursor(20L)
+			.pageSize(20L)
+			.hasNext(false)
+			.currentCursor(0L)
+			.build()
+		val pageResponse = PageResponse.of(response, cursorPageable)
+
+		given(adminHelpService.getHelpList(any())).willReturn(pageResponse)
+
+		// when & then
+		assertThat(
+			mvc.get().uri("/helps")
+				.header("Authorization", "Bearer test_access_token")
+				.param("status", StatusType.WAITING.name)
+				.param("type", HelpType.WHISKEY.name)
+				.param("cursor", "0")
+				.param("pageSize", "20")
+		)
+			.hasStatusOk()
+			.apply(
+				document(
+					"admin/help/list",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(
+						headerWithName("Authorization").description("Bearer 액세스 토큰")
+					),
+					queryParameters(
+						parameterWithName("status").optional().description("상태 필터 (WAITING, SUCCESS, REJECT, DELETED)"),
+						parameterWithName("type").optional().description("문의 유형 필터 (WHISKEY, REVIEW, USER, ETC)"),
+						parameterWithName("cursor").optional().description("페이징 커서 (기본값: 0)"),
+						parameterWithName("pageSize").optional().description("페이지 크기 (기본값: 20)")
+					),
+					responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+						fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+						fieldWithPath("data.content.totalCount").type(JsonFieldType.NUMBER).description("전체 문의 수"),
+						fieldWithPath("data.content.helpList[].helpId").type(JsonFieldType.NUMBER).description("문의 ID"),
+						fieldWithPath("data.content.helpList[].userId").type(JsonFieldType.NUMBER).description("문의자 ID"),
+						fieldWithPath("data.content.helpList[].userNickname").type(JsonFieldType.STRING).description("문의자 닉네임"),
+						fieldWithPath("data.content.helpList[].title").type(JsonFieldType.STRING).description("문의 제목"),
+						fieldWithPath("data.content.helpList[].type").type(JsonFieldType.STRING).description("문의 유형"),
+						fieldWithPath("data.content.helpList[].status").type(JsonFieldType.STRING).description("처리 상태"),
+						fieldWithPath("data.content.helpList[].createAt").type(JsonFieldType.STRING).description("생성일시"),
+						fieldWithPath("data.cursorPageable.cursor").type(JsonFieldType.NUMBER).description("다음 커서"),
+						fieldWithPath("data.cursorPageable.pageSize").type(JsonFieldType.NUMBER).description("페이지 크기"),
+						fieldWithPath("data.cursorPageable.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+						fieldWithPath("data.cursorPageable.currentCursor").type(JsonFieldType.NUMBER).description("현재 커서"),
+						fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+						fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).ignored(),
+						fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).ignored(),
+						fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).ignored(),
+						fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).ignored()
+					)
+				)
+			)
+	}
+
+	@Test
+	@DisplayName("문의 상세 조회")
+	fun getHelpDetail() {
+		// given
+		val response = AdminHelpDetailResponse.builder()
+			.helpId(1L)
+			.userId(100L)
+			.userNickname("테스트유저")
+			.title("위스키 관련 문의")
+			.content("위스키에 대해 문의드립니다.")
+			.type(HelpType.WHISKEY)
+			.imageUrlList(listOf(HelpImageItem.create(1, "https://example.com/image.jpg")))
+			.status(StatusType.WAITING)
+			.adminId(null)
+			.responseContent(null)
+			.createAt(LocalDateTime.now())
+			.lastModifyAt(LocalDateTime.now())
+			.build()
+
+		given(adminHelpService.getHelpDetail(anyLong())).willReturn(response)
+
+		// when & then
+		assertThat(
+			mvc.get().uri("/helps/1")
+				.header("Authorization", "Bearer test_access_token")
+		)
+			.hasStatusOk()
+			.apply(
+				document(
+					"admin/help/detail",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(
+						headerWithName("Authorization").description("Bearer 액세스 토큰")
+					),
+					pathParameters(
+						parameterWithName("helpId").description("문의 ID")
+					),
+					responseFields(
+						fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+						fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+						fieldWithPath("data.helpId").type(JsonFieldType.NUMBER).description("문의 ID"),
+						fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("문의자 ID"),
+						fieldWithPath("data.userNickname").type(JsonFieldType.STRING).description("문의자 닉네임"),
+						fieldWithPath("data.title").type(JsonFieldType.STRING).description("문의 제목"),
+						fieldWithPath("data.content").type(JsonFieldType.STRING).description("문의 내용"),
+						fieldWithPath("data.type").type(JsonFieldType.STRING).description("문의 유형"),
+						fieldWithPath("data.imageUrlList[].order").type(JsonFieldType.NUMBER).description("이미지 순서"),
+						fieldWithPath("data.imageUrlList[].imageUrl").type(JsonFieldType.STRING).description("이미지 URL"),
+						fieldWithPath("data.status").type(JsonFieldType.STRING).description("처리 상태"),
+						fieldWithPath("data.adminId").type(JsonFieldType.NULL).description("담당 관리자 ID"),
+						fieldWithPath("data.responseContent").type(JsonFieldType.NULL).description("답변 내용"),
+						fieldWithPath("data.createAt").type(JsonFieldType.STRING).description("생성일시"),
+						fieldWithPath("data.lastModifyAt").type(JsonFieldType.STRING).description("수정일시"),
+						fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+						fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).ignored(),
+						fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).ignored(),
+						fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).ignored(),
+						fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).ignored()
+					)
+				)
+			)
+	}
+
+	@Test
+	@DisplayName("문의 답변 등록")
+	fun answerHelp() {
+		// given
+		val response = AdminHelpAnswerResponse.of(1L, StatusType.SUCCESS)
+
+		given(adminHelpService.answerHelp(anyLong(), anyLong(), any())).willReturn(response)
+
+		Mockito.mockStatic(SecurityContextUtil::class.java).use { mockedStatic: MockedStatic<SecurityContextUtil> ->
+			mockedStatic.`when`<Optional<Long>> { SecurityContextUtil.getAdminUserIdByContext() }
+				.thenReturn(Optional.of(1L))
+
+			val request = mapOf(
+				"responseContent" to "답변 내용입니다.",
+				"status" to StatusType.SUCCESS.name
+			)
+
+			// when & then
+			assertThat(
+				mvc.post().uri("/helps/1/answer")
+					.header("Authorization", "Bearer test_access_token")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+			)
+				.hasStatusOk()
+				.apply(
+					document(
+						"admin/help/answer",
+						preprocessRequest(prettyPrint()),
+						preprocessResponse(prettyPrint()),
+						requestHeaders(
+							headerWithName("Authorization").description("Bearer 액세스 토큰")
+						),
+						pathParameters(
+							parameterWithName("helpId").description("문의 ID")
+						),
+						requestFields(
+							fieldWithPath("responseContent").type(JsonFieldType.STRING).description("답변 내용"),
+							fieldWithPath("status").type(JsonFieldType.STRING).description("처리 상태 (SUCCESS, REJECT)")
+						),
+						responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+							fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+							fieldWithPath("data.helpId").type(JsonFieldType.NUMBER).description("문의 ID"),
+							fieldWithPath("data.status").type(JsonFieldType.STRING).description("처리 상태"),
+							fieldWithPath("data.message").type(JsonFieldType.STRING).description("결과 메시지"),
+							fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+							fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).ignored()
+						)
+					)
+				)
+		}
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/help/AdminHelpIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/help/AdminHelpIntegrationTest.kt
@@ -1,0 +1,252 @@
+package app.integration.help
+
+import app.IntegrationTestSupport
+import app.bottlenote.support.constant.StatusType
+import app.bottlenote.support.help.constant.HelpType
+import app.bottlenote.support.help.fixture.HelpTestFactory
+import app.bottlenote.user.fixture.UserTestFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+
+@Tag("admin_integration")
+@DisplayName("[integration] Admin Help API 통합 테스트")
+class AdminHelpIntegrationTest : IntegrationTestSupport() {
+
+	@Autowired
+	private lateinit var helpTestFactory: HelpTestFactory
+
+	@Autowired
+	private lateinit var userTestFactory: UserTestFactory
+
+	private lateinit var accessToken: String
+
+	@BeforeEach
+	fun setUp() {
+		val admin = adminUserTestFactory.persistRootAdmin()
+		accessToken = getAccessToken(admin)
+	}
+
+	@Nested
+	@DisplayName("문의 목록 조회 API")
+	inner class GetHelpListTest {
+
+		@Test
+		@DisplayName("문의 목록을 조회할 수 있다")
+		fun getHelpList() {
+			// given
+			val user = userTestFactory.persistUser()
+			helpTestFactory.persistMultipleHelpsByUser(user.id, HelpType.WHISKEY, 5)
+
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/helps")
+					.header("Authorization", "Bearer $accessToken")
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(true)
+		}
+
+		@Test
+		@DisplayName("상태로 필터링하여 조회할 수 있다")
+		fun getHelpListFilterByStatus() {
+			// given
+			val user = userTestFactory.persistUser()
+			helpTestFactory.persistHelp(user.id, HelpType.WHISKEY)
+
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/helps")
+					.header("Authorization", "Bearer $accessToken")
+					.param("status", StatusType.WAITING.name)
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(true)
+		}
+
+		@Test
+		@DisplayName("문의 유형으로 필터링하여 조회할 수 있다")
+		fun getHelpListFilterByType() {
+			// given
+			val user = userTestFactory.persistUser()
+			helpTestFactory.persistHelp(user.id, HelpType.WHISKEY)
+			helpTestFactory.persistHelp(user.id, HelpType.REVIEW)
+
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/helps")
+					.header("Authorization", "Bearer $accessToken")
+					.param("type", HelpType.WHISKEY.name)
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(true)
+		}
+
+		@Test
+		@DisplayName("인증 없이 조회하면 실패한다")
+		fun getHelpListWithoutAuth() {
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/helps")
+			)
+				.hasStatus4xxClientError()
+		}
+	}
+
+	@Nested
+	@DisplayName("문의 상세 조회 API")
+	inner class GetHelpDetailTest {
+
+		@Test
+		@DisplayName("문의 상세를 조회할 수 있다")
+		fun getHelpDetail() {
+			// given
+			val user = userTestFactory.persistUser()
+			val help = helpTestFactory.persistHelp(user.id, HelpType.WHISKEY, "테스트 제목", "테스트 내용")
+
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/helps/${help.id}")
+					.header("Authorization", "Bearer $accessToken")
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(true)
+
+			assertThat(
+				mockMvcTester.get().uri("/helps/${help.id}")
+					.header("Authorization", "Bearer $accessToken")
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.title").isEqualTo("테스트 제목")
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 문의를 조회하면 실패한다")
+		fun getHelpDetailNotFound() {
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/helps/99999")
+					.header("Authorization", "Bearer $accessToken")
+			)
+				.hasStatus4xxClientError()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(false)
+		}
+	}
+
+	@Nested
+	@DisplayName("문의 답변 등록 API")
+	inner class AnswerHelpTest {
+
+		@Test
+		@DisplayName("문의에 답변을 등록할 수 있다")
+		fun answerHelp() {
+			// given
+			val user = userTestFactory.persistUser()
+			val help = helpTestFactory.persistHelp(user.id, HelpType.WHISKEY)
+
+			val request = mapOf(
+				"responseContent" to "답변 내용입니다.",
+				"status" to StatusType.SUCCESS.name
+			)
+
+			// when & then
+			assertThat(
+				mockMvcTester.post().uri("/helps/${help.id}/answer")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(true)
+
+			assertThat(
+				mockMvcTester.post().uri("/helps/${help.id}/answer")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.status").isEqualTo(StatusType.SUCCESS.name)
+		}
+
+		@Test
+		@DisplayName("반려 상태로 답변을 등록할 수 있다")
+		fun answerHelpWithReject() {
+			// given
+			val user = userTestFactory.persistUser()
+			val help = helpTestFactory.persistHelp(user.id, HelpType.WHISKEY)
+
+			val request = mapOf(
+				"responseContent" to "반려 사유입니다.",
+				"status" to StatusType.REJECT.name
+			)
+
+			// when & then
+			assertThat(
+				mockMvcTester.post().uri("/helps/${help.id}/answer")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.status").isEqualTo(StatusType.REJECT.name)
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 문의에 답변하면 실패한다")
+		fun answerHelpNotFound() {
+			// given
+			val request = mapOf(
+				"responseContent" to "답변 내용입니다.",
+				"status" to StatusType.SUCCESS.name
+			)
+
+			// when & then
+			assertThat(
+				mockMvcTester.post().uri("/helps/99999/answer")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+				.hasStatus4xxClientError()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(false)
+		}
+
+		@Test
+		@DisplayName("답변 내용 없이 요청하면 실패한다")
+		fun answerHelpWithoutContent() {
+			// given
+			val user = userTestFactory.persistUser()
+			val help = helpTestFactory.persistHelp(user.id, HelpType.WHISKEY)
+
+			val request = mapOf(
+				"responseContent" to "",
+				"status" to StatusType.SUCCESS.name
+			)
+
+			// when & then
+			assertThat(
+				mockMvcTester.post().uri("/helps/${help.id}/answer")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+				.hasStatus4xxClientError()
+		}
+	}
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/domain/Help.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/domain/Help.java
@@ -113,4 +113,13 @@ public class Help extends BaseEntity {
   public boolean isMyHelpPost(Long userId) {
     return this.userId.equals(userId);
   }
+
+  public void answer(Long adminId, String responseContent, StatusType status) {
+    Objects.requireNonNull(adminId, "adminId는 필수입니다");
+    Objects.requireNonNull(responseContent, "responseContent는 필수입니다");
+    Objects.requireNonNull(status, "status는 필수입니다");
+    this.adminId = adminId;
+    this.responseContent = responseContent;
+    this.status = status;
+  }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/domain/HelpRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/domain/HelpRepository.java
@@ -2,7 +2,9 @@ package app.bottlenote.support.help.domain;
 
 import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.support.help.constant.HelpType;
+import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
 import app.bottlenote.support.help.dto.request.HelpPageableRequest;
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +25,6 @@ public interface HelpRepository {
 
   PageResponse<HelpListResponse> getHelpList(
       HelpPageableRequest helpPageableRequest, Long currentUserId);
+
+  PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/request/AdminHelpAnswerRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/request/AdminHelpAnswerRequest.java
@@ -1,0 +1,9 @@
+package app.bottlenote.support.help.dto.request;
+
+import app.bottlenote.support.constant.StatusType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminHelpAnswerRequest(
+    @NotBlank(message = "답변 내용은 필수입니다.") String responseContent,
+    @NotNull(message = "처리 상태는 필수입니다.") StatusType status) {}

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/request/AdminHelpPageableRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/request/AdminHelpPageableRequest.java
@@ -1,0 +1,15 @@
+package app.bottlenote.support.help.dto.request;
+
+import app.bottlenote.support.constant.StatusType;
+import app.bottlenote.support.help.constant.HelpType;
+import lombok.Builder;
+
+public record AdminHelpPageableRequest(
+    StatusType status, HelpType type, Long cursor, Long pageSize) {
+
+  @Builder
+  public AdminHelpPageableRequest {
+    cursor = cursor != null ? cursor : 0L;
+    pageSize = pageSize != null ? pageSize : 20L;
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/response/AdminHelpAnswerResponse.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/response/AdminHelpAnswerResponse.java
@@ -1,0 +1,10 @@
+package app.bottlenote.support.help.dto.response;
+
+import app.bottlenote.support.constant.StatusType;
+
+public record AdminHelpAnswerResponse(Long helpId, StatusType status, String message) {
+
+  public static AdminHelpAnswerResponse of(Long helpId, StatusType status) {
+    return new AdminHelpAnswerResponse(helpId, status, "답변이 등록되었습니다.");
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/response/AdminHelpDetailResponse.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/response/AdminHelpDetailResponse.java
@@ -1,0 +1,23 @@
+package app.bottlenote.support.help.dto.response;
+
+import app.bottlenote.support.constant.StatusType;
+import app.bottlenote.support.help.constant.HelpType;
+import app.bottlenote.support.help.dto.request.HelpImageItem;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AdminHelpDetailResponse(
+    Long helpId,
+    Long userId,
+    String userNickname,
+    String title,
+    String content,
+    HelpType type,
+    List<HelpImageItem> imageUrlList,
+    StatusType status,
+    Long adminId,
+    String responseContent,
+    LocalDateTime createAt,
+    LocalDateTime lastModifyAt) {}

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/response/AdminHelpListResponse.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/response/AdminHelpListResponse.java
@@ -1,0 +1,24 @@
+package app.bottlenote.support.help.dto.response;
+
+import app.bottlenote.support.constant.StatusType;
+import app.bottlenote.support.help.constant.HelpType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+public record AdminHelpListResponse(Long totalCount, List<AdminHelpInfo> helpList) {
+
+  public static AdminHelpListResponse of(Long totalCount, List<AdminHelpInfo> helpList) {
+    return new AdminHelpListResponse(totalCount, helpList);
+  }
+
+  @Builder
+  public record AdminHelpInfo(
+      Long helpId,
+      Long userId,
+      String userNickname,
+      String title,
+      HelpType type,
+      StatusType status,
+      LocalDateTime createAt) {}
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/HelpQuerySupporter.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/HelpQuerySupporter.java
@@ -1,7 +1,9 @@
 package app.bottlenote.support.help.repository;
 
 import static app.bottlenote.support.help.domain.QHelp.help;
+import static app.bottlenote.user.domain.QUser.user;
 
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
@@ -11,9 +13,9 @@ import org.springframework.stereotype.Component;
 public class HelpQuerySupporter {
 
   /**
-   * 문의글 목록 조회 API에 사용되는 생성자 Projection 메서드입니다.
+   * 문의글 목록 조회 API에 사용되는 생성자 Projection 메서드입니다. (사용자용)
    *
-   * @return
+   * @return HelpInfo Projection
    */
   public ConstructorExpression<HelpListResponse.HelpInfo> helpResponseConstructor() {
     return Projections.constructor(
@@ -23,5 +25,22 @@ public class HelpQuerySupporter {
         help.content.as("content"),
         help.createAt.as("createdAt"),
         help.status.as("helpStatus"));
+  }
+
+  /**
+   * 문의글 목록 조회 API에 사용되는 생성자 Projection 메서드입니다. (관리자용)
+   *
+   * @return AdminHelpInfo Projection
+   */
+  public ConstructorExpression<AdminHelpListResponse.AdminHelpInfo> adminHelpResponseConstructor() {
+    return Projections.constructor(
+        AdminHelpListResponse.AdminHelpInfo.class,
+        help.id.as("helpId"),
+        help.userId.as("userId"),
+        user.nickName.as("userNickname"),
+        help.title.as("title"),
+        help.type.as("type"),
+        help.status.as("status"),
+        help.createAt.as("createAt"));
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepository.java
@@ -1,18 +1,28 @@
 package app.bottlenote.support.help.repository.custom;
 
 import app.bottlenote.global.service.cursor.PageResponse;
+import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
 import app.bottlenote.support.help.dto.request.HelpPageableRequest;
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
 
 public interface CustomHelpQueryRepository {
 
   /**
-   * 문의글 목록을 조회하는 메서드입니다.
+   * 문의글 목록을 조회하는 메서드입니다. (사용자용)
    *
-   * @param helpPageableRequest
-   * @param currentUserId
-   * @return
+   * @param helpPageableRequest 페이징 요청
+   * @param currentUserId 현재 사용자 ID
+   * @return 문의글 목록
    */
   PageResponse<HelpListResponse> getHelpList(
       HelpPageableRequest helpPageableRequest, Long currentUserId);
+
+  /**
+   * 문의글 목록을 조회하는 메서드입니다. (관리자용)
+   *
+   * @param request 페이징 및 필터링 요청
+   * @return 전체 문의글 목록
+   */
+  PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepositoryImpl.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepositoryImpl.java
@@ -1,12 +1,16 @@
 package app.bottlenote.support.help.repository.custom;
 
 import static app.bottlenote.support.help.domain.QHelp.help;
+import static app.bottlenote.user.domain.QUser.user;
 
 import app.bottlenote.global.service.cursor.CursorPageable;
 import app.bottlenote.global.service.cursor.PageResponse;
+import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
 import app.bottlenote.support.help.dto.request.HelpPageableRequest;
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
 import app.bottlenote.support.help.repository.HelpQuerySupporter;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -66,5 +70,52 @@ public class CustomHelpQueryRepositoryImpl implements CustomHelpQueryRepository 
       fetch.remove(fetch.size() - 1); // Remove the extra record
     }
     return hasNext;
+  }
+
+  @Override
+  public PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request) {
+    BooleanBuilder whereClause = new BooleanBuilder();
+
+    if (request.status() != null) {
+      whereClause.and(help.status.eq(request.status()));
+    }
+    if (request.type() != null) {
+      whereClause.and(help.type.eq(request.type()));
+    }
+
+    List<AdminHelpListResponse.AdminHelpInfo> fetch =
+        queryFactory
+            .select(supporter.adminHelpResponseConstructor())
+            .from(help)
+            .leftJoin(user)
+            .on(help.userId.eq(user.id))
+            .where(whereClause)
+            .orderBy(help.createAt.desc())
+            .offset(request.cursor())
+            .limit(request.pageSize() + 1)
+            .fetch();
+
+    Long totalCount = queryFactory.select(help.id.count()).from(help).where(whereClause).fetchOne();
+
+    CursorPageable cursorPageable = getAdminCursorPageable(request, fetch);
+    log.info("Admin CURSOR Pageable info: {}", cursorPageable.toString());
+
+    return PageResponse.of(AdminHelpListResponse.of(totalCount, fetch), cursorPageable);
+  }
+
+  private CursorPageable getAdminCursorPageable(
+      AdminHelpPageableRequest request, List<AdminHelpListResponse.AdminHelpInfo> fetch) {
+
+    boolean hasNext = fetch.size() > request.pageSize();
+    if (hasNext) {
+      fetch.remove(fetch.size() - 1);
+    }
+
+    return CursorPageable.builder()
+        .cursor(request.cursor() + request.pageSize())
+        .pageSize(request.pageSize())
+        .hasNext(hasNext)
+        .currentCursor(request.cursor())
+        .build();
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/service/AdminHelpService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/service/AdminHelpService.java
@@ -1,0 +1,76 @@
+package app.bottlenote.support.help.service;
+
+import static app.bottlenote.support.help.exception.HelpExceptionCode.HELP_NOT_FOUND;
+
+import app.bottlenote.global.service.cursor.PageResponse;
+import app.bottlenote.support.help.domain.Help;
+import app.bottlenote.support.help.domain.HelpRepository;
+import app.bottlenote.support.help.dto.request.AdminHelpAnswerRequest;
+import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
+import app.bottlenote.support.help.dto.request.HelpImageItem;
+import app.bottlenote.support.help.dto.response.AdminHelpAnswerResponse;
+import app.bottlenote.support.help.dto.response.AdminHelpDetailResponse;
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
+import app.bottlenote.support.help.exception.HelpException;
+import app.bottlenote.user.domain.User;
+import app.bottlenote.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminHelpService {
+
+  private final HelpRepository helpRepository;
+  private final UserRepository userRepository;
+
+  @Transactional(readOnly = true)
+  public PageResponse<AdminHelpListResponse> getHelpList(AdminHelpPageableRequest request) {
+    return helpRepository.getAdminHelpList(request);
+  }
+
+  @Transactional(readOnly = true)
+  public AdminHelpDetailResponse getHelpDetail(Long helpId) {
+    Help help =
+        helpRepository.findById(helpId).orElseThrow(() -> new HelpException(HELP_NOT_FOUND));
+
+    String userNickname =
+        userRepository.findById(help.getUserId()).map(User::getNickName).orElse("탈퇴한 사용자");
+
+    return AdminHelpDetailResponse.builder()
+        .helpId(help.getId())
+        .userId(help.getUserId())
+        .userNickname(userNickname)
+        .title(help.getTitle())
+        .content(help.getContent())
+        .type(help.getType())
+        .imageUrlList(
+            help.getHelpImageList().getHelpImages().stream()
+                .map(
+                    image ->
+                        HelpImageItem.create(
+                            image.getHelpimageInfo().getOrder(),
+                            image.getHelpimageInfo().getImageUrl()))
+                .toList())
+        .status(help.getStatus())
+        .adminId(help.getAdminId())
+        .responseContent(help.getResponseContent())
+        .createAt(help.getCreateAt())
+        .lastModifyAt(help.getLastModifyAt())
+        .build();
+  }
+
+  @Transactional
+  public AdminHelpAnswerResponse answerHelp(
+      Long helpId, Long adminId, AdminHelpAnswerRequest request) {
+    Help help =
+        helpRepository.findById(helpId).orElseThrow(() -> new HelpException(HELP_NOT_FOUND));
+
+    help.answer(adminId, request.responseContent(), request.status());
+
+    return AdminHelpAnswerResponse.of(help.getId(), help.getStatus());
+  }
+}


### PR DESCRIPTION
- AdminHelpController 추가 (목록 조회, 상세 조회, 답변 등록)
- AdminHelpService 및 관련 DTO 생성
- Help 엔티티에 answer() 도메인 메서드 추가
- 관리자용 QueryDSL 쿼리 구현 (상태/유형 필터링 지원)
- 통합 테스트 및 RestDocs 테스트 작성

🤖 Generated with [Claude Code](https://claude.com/claude-code)