### PR TITLE
feat: 이미지 리소스 활성화 이벤트 기반 ResourceLog 로깅 구현

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/event/listener/ResourceEventListener.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/event/listener/ResourceEventListener.java
@@ -1,0 +1,37 @@
+package app.bottlenote.common.file.event.listener;
+
+import static app.bottlenote.common.annotation.DomainEventListener.ProcessingType.ASYNCHRONOUS;
+
+import app.bottlenote.common.annotation.DomainEventListener;
+import app.bottlenote.common.file.event.payload.ImageResourceActivatedEvent;
+import app.bottlenote.common.file.service.ResourceCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@DomainEventListener(type = ASYNCHRONOUS)
+public class ResourceEventListener {
+
+  private final ResourceCommandService resourceCommandService;
+
+  @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @TransactionalEventListener
+  public void handleImageResourceActivated(ImageResourceActivatedEvent event) {
+    log.info(
+        "이미지 리소스 활성화 이벤트 수신 - referenceId: {}, referenceType: {}, resourceKeys: {}",
+        event.referenceId(),
+        event.referenceType(),
+        event.resourceKeys().size());
+
+    for (String resourceKey : event.resourceKeys()) {
+      resourceCommandService.activateImageResource(
+          resourceKey, event.referenceId(), event.referenceType());
+    }
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/event/payload/ImageResourceActivatedEvent.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/event/payload/ImageResourceActivatedEvent.java
@@ -1,0 +1,24 @@
+package app.bottlenote.common.file.event.payload;
+
+import java.util.List;
+import java.util.Objects;
+
+public record ImageResourceActivatedEvent(
+    List<String> resourceKeys, Long referenceId, String referenceType) {
+
+  public ImageResourceActivatedEvent {
+    Objects.requireNonNull(resourceKeys, "resourceKeys must not be null");
+    Objects.requireNonNull(referenceId, "referenceId must not be null");
+    Objects.requireNonNull(referenceType, "referenceType must not be null");
+  }
+
+  public static ImageResourceActivatedEvent of(
+      List<String> resourceKeys, Long referenceId, String referenceType) {
+    return new ImageResourceActivatedEvent(resourceKeys, referenceId, referenceType);
+  }
+
+  public static ImageResourceActivatedEvent of(
+      String resourceKey, Long referenceId, String referenceType) {
+    return new ImageResourceActivatedEvent(List.of(resourceKey), referenceId, referenceType);
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/image/ImageUtil.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/image/ImageUtil.java
@@ -23,4 +23,19 @@ public class ImageUtil {
     String[] split = splitPath(imageUrl);
     return split[2];
   }
+
+  public static String extractResourceKey(String viewUrl) {
+    if (viewUrl == null || viewUrl.isBlank()) {
+      return null;
+    }
+    int protocolEnd = viewUrl.indexOf("://");
+    if (protocolEnd == -1) {
+      return viewUrl;
+    }
+    int firstSlashAfterHost = viewUrl.indexOf("/", protocolEnd + 3);
+    if (firstSlashAfterHost == -1) {
+      return "";
+    }
+    return viewUrl.substring(firstSlashAfterHost + 1);
+  }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/user/service/UserBasicService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/user/service/UserBasicService.java
@@ -6,6 +6,8 @@ import static app.bottlenote.user.exception.UserExceptionCode.MYBOTTLE_NOT_ACCES
 import static app.bottlenote.user.exception.UserExceptionCode.MYPAGE_NOT_ACCESSIBLE;
 import static app.bottlenote.user.exception.UserExceptionCode.USER_NOT_FOUND;
 
+import app.bottlenote.common.file.event.payload.ImageResourceActivatedEvent;
+import app.bottlenote.common.image.ImageUtil;
 import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.user.constant.MyBottleType;
 import app.bottlenote.user.domain.User;
@@ -22,6 +24,7 @@ import app.bottlenote.user.exception.UserException;
 import app.bottlenote.user.exception.UserExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,8 +33,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class UserBasicService {
 
+  private static final String REFERENCE_TYPE_PROFILE = "PROFILE";
+
   private final UserRepository userRepository;
   private final UserFilterManager userFilterManager;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public NicknameChangeResponse nicknameChange(Long userId, NicknameChangeRequest request) {
@@ -72,6 +78,12 @@ public class UserBasicService {
               userRepository.findById(userId).orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
           user.changeProfileImage(viewUrl);
+
+          String resourceKey = ImageUtil.extractResourceKey(viewUrl);
+          if (resourceKey != null && user.getId() != null) {
+            eventPublisher.publishEvent(
+                ImageResourceActivatedEvent.of(resourceKey, user.getId(), REFERENCE_TYPE_PROFILE));
+          }
 
           return new ProfileImageChangeResponse(user.getId(), user.getImageUrl());
         });

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/event/fixture/FakeApplicationEventPublisher.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/event/fixture/FakeApplicationEventPublisher.java
@@ -1,0 +1,41 @@
+package app.bottlenote.common.event.fixture;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+public class FakeApplicationEventPublisher implements ApplicationEventPublisher {
+
+  private final List<Object> publishedEvents = new ArrayList<>();
+
+  @Override
+  public void publishEvent(ApplicationEvent event) {
+    publishedEvents.add(event);
+  }
+
+  @Override
+  public void publishEvent(Object event) {
+    publishedEvents.add(event);
+  }
+
+  public List<Object> getPublishedEvents() {
+    return List.copyOf(publishedEvents);
+  }
+
+  public <T> List<T> getPublishedEventsOfType(Class<T> eventType) {
+    return publishedEvents.stream().filter(eventType::isInstance).map(eventType::cast).toList();
+  }
+
+  public void clear() {
+    publishedEvents.clear();
+  }
+
+  public int getPublishedEventCount() {
+    return publishedEvents.size();
+  }
+
+  public boolean hasPublishedEventOfType(Class<?> eventType) {
+    return publishedEvents.stream().anyMatch(eventType::isInstance);
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ImageResourceActivatedEventPublishTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ImageResourceActivatedEventPublishTest.java
@@ -1,0 +1,486 @@
+package app.bottlenote.common.file.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import app.bottlenote.alcohols.fixture.FakeAlcoholFacade;
+import app.bottlenote.common.event.fixture.FakeApplicationEventPublisher;
+import app.bottlenote.common.file.constant.ResourceEventType;
+import app.bottlenote.common.file.domain.ResourceLog;
+import app.bottlenote.common.file.dto.request.ResourceLogRequest;
+import app.bottlenote.common.file.event.listener.ResourceEventListener;
+import app.bottlenote.common.file.event.payload.ImageResourceActivatedEvent;
+import app.bottlenote.common.file.service.ResourceCommandService;
+import app.bottlenote.common.file.upload.fixture.InMemoryResourceLogRepository;
+import app.bottlenote.common.profanity.FakeProfanityClient;
+import app.bottlenote.history.fixture.FakeHistoryEventPublisher;
+import app.bottlenote.observability.service.LocalTracingService;
+import app.bottlenote.review.dto.request.LocationInfoRequest;
+import app.bottlenote.review.dto.request.ReviewCreateRequest;
+import app.bottlenote.review.dto.request.ReviewImageInfoRequest;
+import app.bottlenote.review.dto.request.ReviewModifyRequest;
+import app.bottlenote.review.dto.response.ReviewCreateResponse;
+import app.bottlenote.review.fixture.InMemoryReviewRepository;
+import app.bottlenote.review.service.ReviewService;
+import app.bottlenote.support.business.constant.BusinessSupportType;
+import app.bottlenote.support.business.dto.request.BusinessImageItem;
+import app.bottlenote.support.business.dto.request.BusinessSupportUpsertRequest;
+import app.bottlenote.support.business.dto.response.BusinessSupportResultResponse;
+import app.bottlenote.support.business.fixture.InMemoryBusinessSupportRepository;
+import app.bottlenote.support.business.service.BusinessSupportService;
+import app.bottlenote.support.help.constant.HelpType;
+import app.bottlenote.support.help.dto.request.HelpImageItem;
+import app.bottlenote.support.help.dto.request.HelpUpsertRequest;
+import app.bottlenote.support.help.dto.response.HelpResultResponse;
+import app.bottlenote.support.help.fixture.InMemoryHelpRepository;
+import app.bottlenote.support.help.service.HelpService;
+import app.bottlenote.user.facade.payload.UserProfileItem;
+import app.bottlenote.user.fixture.FakeUserFacade;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("[unit] [service] 이미지 리소스 활성화 이벤트 발행 테스트")
+class ImageResourceActivatedEventPublishTest {
+
+  @Nested
+  @DisplayName("ReviewService 리뷰 이미지")
+  class ReviewServiceTest {
+
+    private ReviewService reviewService;
+    private InMemoryReviewRepository reviewRepository;
+    private FakeApplicationEventPublisher eventPublisher;
+
+    @BeforeEach
+    void setUp() {
+      reviewRepository = new InMemoryReviewRepository();
+      eventPublisher = new FakeApplicationEventPublisher();
+
+      reviewService =
+          new ReviewService(
+              new FakeAlcoholFacade(),
+              new FakeUserFacade(UserProfileItem.create(1L, "user1", "")),
+              reviewRepository,
+              new FakeHistoryEventPublisher(),
+              new LocalTracingService(),
+              eventPublisher);
+    }
+
+    @Test
+    @DisplayName("이미지가 포함된 리뷰를 생성할 때 ImageResourceActivatedEvent가 발행된다")
+    void test_create_review_with_images_publishes_event() {
+      // given
+      List<ReviewImageInfoRequest> images =
+          List.of(
+              new ReviewImageInfoRequest(1L, "https://cdn.bottlenote.com/review/img1.jpg"),
+              new ReviewImageInfoRequest(2L, "https://cdn.bottlenote.com/review/img2.jpg"));
+      ReviewCreateRequest request = createReviewRequest(images);
+
+      // when
+      ReviewCreateResponse response = reviewService.createReview(request, 1L);
+
+      // then
+      List<ImageResourceActivatedEvent> events =
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class);
+      assertEquals(1, events.size());
+
+      ImageResourceActivatedEvent event = events.get(0);
+      assertEquals(2, event.resourceKeys().size());
+      assertEquals("review/img1.jpg", event.resourceKeys().get(0));
+      assertEquals("review/img2.jpg", event.resourceKeys().get(1));
+      assertEquals(response.getId(), event.referenceId());
+      assertEquals("REVIEW", event.referenceType());
+    }
+
+    @Test
+    @DisplayName("이미지 없이 리뷰를 생성할 때 이벤트가 발행되지 않는다")
+    void test_create_review_without_images_does_not_publish_event() {
+      // given
+      ReviewCreateRequest request = createReviewRequest(List.of());
+
+      // when
+      reviewService.createReview(request, 1L);
+
+      // then
+      assertTrue(
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class).isEmpty());
+    }
+
+    @Test
+    @DisplayName("이미지가 포함된 리뷰를 수정할 때 ImageResourceActivatedEvent가 발행된다")
+    void test_modify_review_with_images_publishes_event() {
+      // given
+      ReviewCreateRequest createRequest = createReviewRequest(List.of());
+      ReviewCreateResponse createResponse = reviewService.createReview(createRequest, 1L);
+      eventPublisher.clear();
+
+      List<ReviewImageInfoRequest> newImages =
+          List.of(new ReviewImageInfoRequest(1L, "https://cdn.bottlenote.com/review/new-img.jpg"));
+      ReviewModifyRequest modifyRequest =
+          new ReviewModifyRequest(
+              "수정된 내용", null, null, newImages, null, null, LocationInfoRequest.empty());
+
+      // when
+      reviewService.modifyReview(modifyRequest, createResponse.getId(), 1L);
+
+      // then
+      List<ImageResourceActivatedEvent> events =
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class);
+      assertEquals(1, events.size());
+
+      ImageResourceActivatedEvent event = events.get(0);
+      assertEquals("review/new-img.jpg", event.resourceKeys().get(0));
+      assertEquals(createResponse.getId(), event.referenceId());
+      assertEquals("REVIEW", event.referenceType());
+    }
+
+    private ReviewCreateRequest createReviewRequest(List<ReviewImageInfoRequest> images) {
+      return new ReviewCreateRequest(
+          1L, null, "테스트 리뷰 내용", null, null, LocationInfoRequest.empty(), images, List.of(), 4.5);
+    }
+  }
+
+  @Nested
+  @DisplayName("HelpService 문의 이미지")
+  class HelpServiceTest {
+
+    private HelpService helpService;
+    private InMemoryHelpRepository helpRepository;
+    private FakeApplicationEventPublisher eventPublisher;
+
+    @BeforeEach
+    void setUp() {
+      helpRepository = new InMemoryHelpRepository();
+      eventPublisher = new FakeApplicationEventPublisher();
+
+      helpService =
+          new HelpService(
+              new FakeUserFacade(UserProfileItem.create(1L, "user1", "")),
+              helpRepository,
+              eventPublisher);
+    }
+
+    @Test
+    @DisplayName("이미지가 포함된 문의를 등록할 때 ImageResourceActivatedEvent가 발행된다")
+    void test_register_help_with_images_publishes_event() {
+      // given
+      List<HelpImageItem> images =
+          List.of(
+              new HelpImageItem(1L, "https://cdn.bottlenote.com/help/img1.jpg"),
+              new HelpImageItem(2L, "https://cdn.bottlenote.com/help/img2.jpg"));
+      HelpUpsertRequest request = new HelpUpsertRequest("제목", "내용", HelpType.USER, images);
+
+      // when
+      HelpResultResponse response = helpService.registerHelp(request, 1L);
+
+      // then
+      List<ImageResourceActivatedEvent> events =
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class);
+      assertEquals(1, events.size());
+
+      ImageResourceActivatedEvent event = events.get(0);
+      assertEquals(2, event.resourceKeys().size());
+      assertEquals("help/img1.jpg", event.resourceKeys().get(0));
+      assertEquals("help/img2.jpg", event.resourceKeys().get(1));
+      assertEquals(response.helpId(), event.referenceId());
+      assertEquals("HELP", event.referenceType());
+    }
+
+    @Test
+    @DisplayName("이미지 없이 문의를 등록할 때 이벤트가 발행되지 않는다")
+    void test_register_help_without_images_does_not_publish_event() {
+      // given
+      HelpUpsertRequest request = new HelpUpsertRequest("제목", "내용", HelpType.USER, List.of());
+
+      // when
+      helpService.registerHelp(request, 1L);
+
+      // then
+      assertTrue(
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class).isEmpty());
+    }
+
+    @Test
+    @DisplayName("이미지가 포함된 문의를 수정할 때 ImageResourceActivatedEvent가 발행된다")
+    void test_modify_help_with_images_publishes_event() {
+      // given
+      HelpUpsertRequest createRequest = new HelpUpsertRequest("제목", "내용", HelpType.USER, List.of());
+      HelpResultResponse createResponse = helpService.registerHelp(createRequest, 1L);
+      eventPublisher.clear();
+
+      List<HelpImageItem> newImages =
+          List.of(new HelpImageItem(1L, "https://cdn.bottlenote.com/help/new-img.jpg"));
+      HelpUpsertRequest modifyRequest =
+          new HelpUpsertRequest("수정 제목", "수정 내용", HelpType.USER, newImages);
+
+      // when
+      helpService.modifyHelp(modifyRequest, 1L, createResponse.helpId());
+
+      // then
+      List<ImageResourceActivatedEvent> events =
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class);
+      assertEquals(1, events.size());
+
+      ImageResourceActivatedEvent event = events.get(0);
+      assertEquals("help/new-img.jpg", event.resourceKeys().get(0));
+      assertEquals(createResponse.helpId(), event.referenceId());
+      assertEquals("HELP", event.referenceType());
+    }
+  }
+
+  @Nested
+  @DisplayName("BusinessSupportService 사업 제휴 이미지")
+  class BusinessSupportServiceTest {
+
+    private BusinessSupportService businessSupportService;
+    private InMemoryBusinessSupportRepository businessSupportRepository;
+    private FakeApplicationEventPublisher eventPublisher;
+
+    @BeforeEach
+    void setUp() {
+      businessSupportRepository = new InMemoryBusinessSupportRepository();
+      eventPublisher = new FakeApplicationEventPublisher();
+
+      businessSupportService =
+          new BusinessSupportService(
+              businessSupportRepository,
+              new FakeUserFacade(UserProfileItem.create(1L, "user1", "")),
+              new FakeProfanityClient(),
+              eventPublisher);
+    }
+
+    @Test
+    @DisplayName("이미지가 포함된 사업 제휴를 등록할 때 ImageResourceActivatedEvent가 발행된다")
+    void test_register_business_with_images_publishes_event() {
+      // given
+      List<BusinessImageItem> images =
+          List.of(
+              BusinessImageItem.create(1L, "https://cdn.bottlenote.com/business/img1.jpg"),
+              BusinessImageItem.create(2L, "https://cdn.bottlenote.com/business/img2.jpg"));
+      BusinessSupportUpsertRequest request =
+          new BusinessSupportUpsertRequest(
+              "제목", "내용", "test@test.com", BusinessSupportType.EVENT, images);
+
+      // when
+      BusinessSupportResultResponse response = businessSupportService.register(request, 1L);
+
+      // then
+      List<ImageResourceActivatedEvent> events =
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class);
+      assertEquals(1, events.size());
+
+      ImageResourceActivatedEvent event = events.get(0);
+      assertEquals(2, event.resourceKeys().size());
+      assertEquals("business/img1.jpg", event.resourceKeys().get(0));
+      assertEquals("business/img2.jpg", event.resourceKeys().get(1));
+      assertEquals(response.id(), event.referenceId());
+      assertEquals("BUSINESS", event.referenceType());
+    }
+
+    @Test
+    @DisplayName("이미지 없이 사업 제휴를 등록할 때 이벤트가 발행되지 않는다")
+    void test_register_business_without_images_does_not_publish_event() {
+      // given
+      BusinessSupportUpsertRequest request =
+          new BusinessSupportUpsertRequest(
+              "제목", "내용", "test@test.com", BusinessSupportType.EVENT, List.of());
+
+      // when
+      businessSupportService.register(request, 1L);
+
+      // then
+      assertTrue(
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class).isEmpty());
+    }
+
+    @Test
+    @DisplayName("이미지가 포함된 사업 제휴를 수정할 때 ImageResourceActivatedEvent가 발행된다")
+    void test_modify_business_with_images_publishes_event() {
+      // given
+      BusinessSupportUpsertRequest createRequest =
+          new BusinessSupportUpsertRequest(
+              "제목", "내용", "test@test.com", BusinessSupportType.EVENT, List.of());
+      BusinessSupportResultResponse createResponse =
+          businessSupportService.register(createRequest, 1L);
+      eventPublisher.clear();
+
+      List<BusinessImageItem> newImages =
+          List.of(BusinessImageItem.create(1L, "https://cdn.bottlenote.com/business/new-img.jpg"));
+      BusinessSupportUpsertRequest modifyRequest =
+          new BusinessSupportUpsertRequest(
+              "수정 제목", "수정 내용", "test@test.com", BusinessSupportType.EVENT, newImages);
+
+      // when
+      businessSupportService.modify(createResponse.id(), modifyRequest, 1L);
+
+      // then
+      List<ImageResourceActivatedEvent> events =
+          eventPublisher.getPublishedEventsOfType(ImageResourceActivatedEvent.class);
+      assertEquals(1, events.size());
+
+      ImageResourceActivatedEvent event = events.get(0);
+      assertEquals("business/new-img.jpg", event.resourceKeys().get(0));
+      assertEquals(createResponse.id(), event.referenceId());
+      assertEquals("BUSINESS", event.referenceType());
+    }
+  }
+
+  @Nested
+  @DisplayName("이벤트 발행 후 ResourceLog 상태 변경 검증")
+  class ResourceLogActivationTest {
+
+    private InMemoryResourceLogRepository resourceLogRepository;
+    private ResourceCommandService resourceCommandService;
+    private ResourceEventListener resourceEventListener;
+
+    @BeforeEach
+    void setUp() {
+      resourceLogRepository = new InMemoryResourceLogRepository();
+      resourceCommandService = new ResourceCommandService(resourceLogRepository);
+      resourceEventListener = new ResourceEventListener(resourceCommandService);
+    }
+
+    @Test
+    @DisplayName("이벤트를 수신할 때 ResourceLog에 ACTIVATED 상태로 로그가 저장된다")
+    void test_event_listener_creates_activated_log() {
+      // given
+      String resourceKey = "review/test-image.jpg";
+      Long referenceId = 100L;
+      String referenceType = "REVIEW";
+
+      resourceCommandService
+          .saveImageResourceCreated(
+              new ResourceLogRequest(
+                  1L,
+                  resourceKey,
+                  "https://cdn.bottlenote.com/" + resourceKey,
+                  "review",
+                  "test-bucket"))
+          .join();
+
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(resourceKey, referenceId, referenceType);
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs = resourceLogRepository.findByResourceKey(resourceKey);
+      assertFalse(logs.isEmpty());
+
+      ResourceLog activatedLog =
+          logs.stream()
+              .filter(log -> log.getEventType() == ResourceEventType.ACTIVATED)
+              .findFirst()
+              .orElse(null);
+
+      assertNotNull(activatedLog);
+      assertEquals(ResourceEventType.ACTIVATED, activatedLog.getEventType());
+      assertEquals(referenceId, activatedLog.getReferenceId());
+      assertEquals(referenceType, activatedLog.getReferenceType());
+      assertEquals(resourceKey, activatedLog.getResourceKey());
+    }
+
+    @Test
+    @DisplayName("여러 이미지 리소스 활성화 이벤트를 수신할 때 각각 ACTIVATED 로그가 저장된다")
+    void test_multiple_resources_create_multiple_activated_logs() {
+      // given
+      String resourceKey1 = "help/image1.jpg";
+      String resourceKey2 = "help/image2.jpg";
+      Long referenceId = 200L;
+      String referenceType = "HELP";
+
+      resourceCommandService
+          .saveImageResourceCreated(
+              new ResourceLogRequest(
+                  1L,
+                  resourceKey1,
+                  "https://cdn.bottlenote.com/" + resourceKey1,
+                  "help",
+                  "test-bucket"))
+          .join();
+      resourceCommandService
+          .saveImageResourceCreated(
+              new ResourceLogRequest(
+                  1L,
+                  resourceKey2,
+                  "https://cdn.bottlenote.com/" + resourceKey2,
+                  "help",
+                  "test-bucket"))
+          .join();
+
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(
+              List.of(resourceKey1, resourceKey2), referenceId, referenceType);
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs1 = resourceLogRepository.findByResourceKey(resourceKey1);
+      List<ResourceLog> logs2 = resourceLogRepository.findByResourceKey(resourceKey2);
+
+      ResourceLog activated1 =
+          logs1.stream()
+              .filter(log -> log.getEventType() == ResourceEventType.ACTIVATED)
+              .findFirst()
+              .orElse(null);
+      ResourceLog activated2 =
+          logs2.stream()
+              .filter(log -> log.getEventType() == ResourceEventType.ACTIVATED)
+              .findFirst()
+              .orElse(null);
+
+      assertNotNull(activated1);
+      assertNotNull(activated2);
+      assertEquals(referenceId, activated1.getReferenceId());
+      assertEquals(referenceId, activated2.getReferenceId());
+      assertEquals(referenceType, activated1.getReferenceType());
+      assertEquals(referenceType, activated2.getReferenceType());
+    }
+
+    @Test
+    @DisplayName("CREATED 로그가 있는 리소스를 활성화할 때 CREATED와 ACTIVATED 로그가 모두 존재한다")
+    void test_resource_log_sequence_created_to_activated() {
+      // given
+      String resourceKey = "business/document.pdf";
+      Long userId = 1L;
+      Long referenceId = 300L;
+      String referenceType = "BUSINESS";
+
+      resourceCommandService
+          .saveImageResourceCreated(
+              new ResourceLogRequest(
+                  userId,
+                  resourceKey,
+                  "https://cdn.bottlenote.com/" + resourceKey,
+                  "business",
+                  "test-bucket"))
+          .join();
+
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(resourceKey, referenceId, referenceType);
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs = resourceLogRepository.findByResourceKey(resourceKey);
+      assertEquals(2, logs.size());
+
+      boolean hasCreated =
+          logs.stream().anyMatch(log -> log.getEventType() == ResourceEventType.CREATED);
+      boolean hasActivated =
+          logs.stream().anyMatch(log -> log.getEventType() == ResourceEventType.ACTIVATED);
+
+      assertTrue(hasCreated);
+      assertTrue(hasActivated);
+    }
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ImageResourceActivatedEventTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ImageResourceActivatedEventTest.java
@@ -1,0 +1,126 @@
+package app.bottlenote.common.file.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import app.bottlenote.common.file.event.payload.ImageResourceActivatedEvent;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("[unit] [event] ImageResourceActivatedEvent")
+class ImageResourceActivatedEventTest {
+
+  @Nested
+  @DisplayName("이벤트 생성 테스트")
+  class CreateEventTest {
+
+    @Test
+    @DisplayName("단일 리소스 키로 이벤트를 생성할 수 있다")
+    void test_create_with_single_key() {
+      // given
+      String resourceKey = "review/20251231/1-uuid.jpg";
+      Long referenceId = 100L;
+      String referenceType = "REVIEW";
+
+      // when
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(resourceKey, referenceId, referenceType);
+
+      // then
+      assertEquals(1, event.resourceKeys().size());
+      assertEquals(resourceKey, event.resourceKeys().get(0));
+      assertEquals(referenceId, event.referenceId());
+      assertEquals(referenceType, event.referenceType());
+    }
+
+    @Test
+    @DisplayName("여러 리소스 키로 이벤트를 생성할 수 있다")
+    void test_create_with_multiple_keys() {
+      // given
+      List<String> resourceKeys =
+          List.of(
+              "review/20251231/1-uuid1.jpg",
+              "review/20251231/2-uuid2.jpg",
+              "review/20251231/3-uuid3.jpg");
+      Long referenceId = 200L;
+      String referenceType = "REVIEW";
+
+      // when
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(resourceKeys, referenceId, referenceType);
+
+      // then
+      assertEquals(3, event.resourceKeys().size());
+      assertEquals(resourceKeys, event.resourceKeys());
+      assertEquals(referenceId, event.referenceId());
+      assertEquals(referenceType, event.referenceType());
+    }
+
+    @Test
+    @DisplayName("resourceKeys가 null이면 NullPointerException이 발생한다")
+    void test_null_resource_keys() {
+      // when & then
+      assertThrows(
+          NullPointerException.class,
+          () -> ImageResourceActivatedEvent.of((List<String>) null, 100L, "REVIEW"));
+    }
+
+    @Test
+    @DisplayName("referenceId가 null이면 NullPointerException이 발생한다")
+    void test_null_reference_id() {
+      // when & then
+      assertThrows(
+          NullPointerException.class, () -> ImageResourceActivatedEvent.of("key", null, "REVIEW"));
+    }
+
+    @Test
+    @DisplayName("referenceType이 null이면 NullPointerException이 발생한다")
+    void test_null_reference_type() {
+      // when & then
+      assertThrows(
+          NullPointerException.class, () -> ImageResourceActivatedEvent.of("key", 100L, null));
+    }
+  }
+
+  @Nested
+  @DisplayName("참조 타입별 이벤트 생성 테스트")
+  class ReferenceTypeTest {
+
+    @Test
+    @DisplayName("PROFILE 타입의 이벤트를 생성할 수 있다")
+    void test_profile_type() {
+      // when
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of("profile/user/avatar.jpg", 1L, "PROFILE");
+
+      // then
+      assertEquals("PROFILE", event.referenceType());
+    }
+
+    @Test
+    @DisplayName("HELP 타입의 이벤트를 생성할 수 있다")
+    void test_help_type() {
+      // when
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of("help/20251231/image.jpg", 50L, "HELP");
+
+      // then
+      assertEquals("HELP", event.referenceType());
+    }
+
+    @Test
+    @DisplayName("BUSINESS 타입의 이벤트를 생성할 수 있다")
+    void test_business_type() {
+      // when
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of("business/20251231/doc.jpg", 30L, "BUSINESS");
+
+      // then
+      assertEquals("BUSINESS", event.referenceType());
+    }
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ResourceEventListenerTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ResourceEventListenerTest.java
@@ -1,0 +1,160 @@
+package app.bottlenote.common.file.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import app.bottlenote.common.file.constant.ResourceEventType;
+import app.bottlenote.common.file.domain.ResourceLog;
+import app.bottlenote.common.file.dto.request.ResourceLogRequest;
+import app.bottlenote.common.file.event.listener.ResourceEventListener;
+import app.bottlenote.common.file.event.payload.ImageResourceActivatedEvent;
+import app.bottlenote.common.file.service.ResourceCommandService;
+import app.bottlenote.common.file.upload.fixture.InMemoryResourceLogRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("[unit] [event] ResourceEventListener")
+class ResourceEventListenerTest {
+
+  private ResourceEventListener resourceEventListener;
+  private ResourceCommandService resourceCommandService;
+  private InMemoryResourceLogRepository resourceLogRepository;
+
+  @BeforeEach
+  void setUp() {
+    resourceLogRepository = new InMemoryResourceLogRepository();
+    resourceCommandService = new ResourceCommandService(resourceLogRepository);
+    resourceEventListener = new ResourceEventListener(resourceCommandService);
+  }
+
+  private void createResourceLog(String resourceKey, Long userId) {
+    ResourceLogRequest request =
+        ResourceLogRequest.builder()
+            .userId(userId)
+            .resourceKey(resourceKey)
+            .viewUrl("https://cdn.example.com/" + resourceKey)
+            .rootPath("review")
+            .bucketName("test-bucket")
+            .build();
+    resourceCommandService.saveImageResourceCreated(request).join();
+  }
+
+  @Nested
+  @DisplayName("이미지 리소스 활성화 이벤트 처리 테스트")
+  class HandleImageResourceActivatedTest {
+
+    @Test
+    @DisplayName("단일 리소스 키에 대해 ACTIVATED 로그가 저장된다")
+    void test_single_resource_key() {
+      // given
+      String resourceKey = "review/20251231/1-uuid.jpg";
+      createResourceLog(resourceKey, 1L);
+
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(resourceKey, 100L, "REVIEW");
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs =
+          resourceLogRepository.findByReferenceIdAndReferenceType(100L, "REVIEW");
+      assertEquals(1, logs.size());
+      assertEquals(ResourceEventType.ACTIVATED, logs.get(0).getEventType());
+      assertEquals(100L, logs.get(0).getReferenceId());
+      assertEquals("REVIEW", logs.get(0).getReferenceType());
+    }
+
+    @Test
+    @DisplayName("여러 리소스 키에 대해 각각 ACTIVATED 로그가 저장된다")
+    void test_multiple_resource_keys() {
+      // given
+      String resourceKey1 = "review/20251231/1-uuid1.jpg";
+      String resourceKey2 = "review/20251231/2-uuid2.jpg";
+      String resourceKey3 = "review/20251231/3-uuid3.jpg";
+      createResourceLog(resourceKey1, 1L);
+      createResourceLog(resourceKey2, 1L);
+      createResourceLog(resourceKey3, 1L);
+
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(
+              List.of(resourceKey1, resourceKey2, resourceKey3), 200L, "REVIEW");
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs =
+          resourceLogRepository.findByReferenceIdAndReferenceType(200L, "REVIEW");
+      assertEquals(3, logs.size());
+      logs.forEach(
+          log -> {
+            assertEquals(ResourceEventType.ACTIVATED, log.getEventType());
+            assertEquals(200L, log.getReferenceId());
+            assertEquals("REVIEW", log.getReferenceType());
+          });
+    }
+
+    @Test
+    @DisplayName("PROFILE 타입의 리소스에 대해 ACTIVATED 로그가 저장된다")
+    void test_profile_reference_type() {
+      // given
+      String resourceKey = "profile/20251231/1-uuid.jpg";
+      createResourceLog(resourceKey, 1L);
+
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(resourceKey, 1L, "PROFILE");
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs =
+          resourceLogRepository.findByReferenceIdAndReferenceType(1L, "PROFILE");
+      assertEquals(1, logs.size());
+      assertEquals("PROFILE", logs.get(0).getReferenceType());
+    }
+
+    @Test
+    @DisplayName("HELP 타입의 리소스에 대해 ACTIVATED 로그가 저장된다")
+    void test_help_reference_type() {
+      // given
+      String resourceKey = "help/20251231/1-uuid.jpg";
+      createResourceLog(resourceKey, 1L);
+
+      ImageResourceActivatedEvent event = ImageResourceActivatedEvent.of(resourceKey, 50L, "HELP");
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs = resourceLogRepository.findByReferenceIdAndReferenceType(50L, "HELP");
+      assertEquals(1, logs.size());
+      assertEquals("HELP", logs.get(0).getReferenceType());
+    }
+
+    @Test
+    @DisplayName("BUSINESS 타입의 리소스에 대해 ACTIVATED 로그가 저장된다")
+    void test_business_reference_type() {
+      // given
+      String resourceKey = "business/20251231/1-uuid.jpg";
+      createResourceLog(resourceKey, 1L);
+
+      ImageResourceActivatedEvent event =
+          ImageResourceActivatedEvent.of(resourceKey, 30L, "BUSINESS");
+
+      // when
+      resourceEventListener.handleImageResourceActivated(event);
+
+      // then
+      List<ResourceLog> logs =
+          resourceLogRepository.findByReferenceIdAndReferenceType(30L, "BUSINESS");
+      assertEquals(1, logs.size());
+      assertEquals("BUSINESS", logs.get(0).getReferenceType());
+    }
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/image/ImageUtilTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/image/ImageUtilTest.java
@@ -1,0 +1,128 @@
+package app.bottlenote.common.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("[unit] [util] ImageUtil")
+class ImageUtilTest {
+
+  @Nested
+  @DisplayName("extractResourceKey 메서드 테스트")
+  class ExtractResourceKeyTest {
+
+    @Test
+    @DisplayName("CloudFront URL에서 리소스 키를 추출한다")
+    void test_cloudfront_url() {
+      // given
+      String viewUrl = "https://cdn.bottlenote.com/review/20251231/1-uuid.jpg";
+
+      // when
+      String resourceKey = ImageUtil.extractResourceKey(viewUrl);
+
+      // then
+      assertEquals("review/20251231/1-uuid.jpg", resourceKey);
+    }
+
+    @Test
+    @DisplayName("S3 URL에서 리소스 키를 추출한다")
+    void test_s3_url() {
+      // given
+      String viewUrl =
+          "https://bottlenote.s3.ap-northeast-2.amazonaws.com/profile/20251231/user-avatar.png";
+
+      // when
+      String resourceKey = ImageUtil.extractResourceKey(viewUrl);
+
+      // then
+      assertEquals("profile/20251231/user-avatar.png", resourceKey);
+    }
+
+    @Test
+    @DisplayName("HTTP URL에서도 리소스 키를 추출한다")
+    void test_http_url() {
+      // given
+      String viewUrl = "http://localhost:8080/help/20251231/image.jpg";
+
+      // when
+      String resourceKey = ImageUtil.extractResourceKey(viewUrl);
+
+      // then
+      assertEquals("help/20251231/image.jpg", resourceKey);
+    }
+
+    @Test
+    @DisplayName("프로토콜이 없는 경로는 그대로 반환한다")
+    void test_path_without_protocol() {
+      // given
+      String viewUrl = "review/20251231/1-uuid.jpg";
+
+      // when
+      String resourceKey = ImageUtil.extractResourceKey(viewUrl);
+
+      // then
+      assertEquals("review/20251231/1-uuid.jpg", resourceKey);
+    }
+
+    @Test
+    @DisplayName("null 입력시 null을 반환한다")
+    void test_null_input() {
+      // when
+      String resourceKey = ImageUtil.extractResourceKey(null);
+
+      // then
+      assertNull(resourceKey);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 입력시 null을 반환한다")
+    void test_empty_string() {
+      // when
+      String resourceKey = ImageUtil.extractResourceKey("");
+
+      // then
+      assertNull(resourceKey);
+    }
+
+    @Test
+    @DisplayName("공백 문자열 입력시 null을 반환한다")
+    void test_blank_string() {
+      // when
+      String resourceKey = ImageUtil.extractResourceKey("   ");
+
+      // then
+      assertNull(resourceKey);
+    }
+
+    @Test
+    @DisplayName("호스트만 있는 URL은 빈 문자열을 반환한다")
+    void test_host_only_url() {
+      // given
+      String viewUrl = "https://cdn.bottlenote.com";
+
+      // when
+      String resourceKey = ImageUtil.extractResourceKey(viewUrl);
+
+      // then
+      assertEquals("", resourceKey);
+    }
+
+    @Test
+    @DisplayName("깊은 경로의 URL에서 리소스 키를 추출한다")
+    void test_deep_path_url() {
+      // given
+      String viewUrl = "https://cdn.bottlenote.com/a/b/c/d/e/image.jpg";
+
+      // when
+      String resourceKey = ImageUtil.extractResourceKey(viewUrl);
+
+      // then
+      assertEquals("a/b/c/d/e/image.jpg", resourceKey);
+    }
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/review/fixture/InMemoryReviewRepository.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/review/fixture/InMemoryReviewRepository.java
@@ -66,7 +66,9 @@ public class InMemoryReviewRepository implements ReviewRepository {
 
   @Override
   public Optional<Review> findByIdAndUserId(Long reviewId, Long userId) {
-    return Optional.empty();
+    return database.values().stream()
+        .filter(r -> r.getId().equals(reviewId) && r.getUserId().equals(userId))
+        .findFirst();
   }
 
   @Override

--- a/bottlenote-product-api/src/test/java/app/bottlenote/support/business/service/BusinessSupportServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/support/business/service/BusinessSupportServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import app.bottlenote.common.event.fixture.FakeApplicationEventPublisher;
 import app.bottlenote.common.profanity.FakeProfanityClient;
 import app.bottlenote.common.profanity.ProfanityClient;
 import app.bottlenote.global.data.response.CollectionResponse;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 
 @Tag("unit")
 @DisplayName("[unit] [service] BusinessSupport")
@@ -41,6 +43,7 @@ class BusinessSupportServiceTest {
   private InMemoryBusinessSupportRepository repository;
   private UserFacade userFacade;
   private ProfanityClient profanityClient;
+  private ApplicationEventPublisher eventPublisher;
 
   @BeforeEach
   void setUp() {
@@ -51,7 +54,8 @@ class BusinessSupportServiceTest {
             UserProfileItem.create(3L, "user3", ""));
     repository = new InMemoryBusinessSupportRepository();
     profanityClient = new FakeProfanityClient();
-    service = new BusinessSupportService(repository, userFacade, profanityClient);
+    eventPublisher = new FakeApplicationEventPublisher();
+    service = new BusinessSupportService(repository, userFacade, profanityClient, eventPublisher);
   }
 
   @Test

--- a/bottlenote-product-api/src/test/java/app/bottlenote/support/help/fixture/InMemoryHelpRepository.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/support/help/fixture/InMemoryHelpRepository.java
@@ -1,0 +1,78 @@
+package app.bottlenote.support.help.fixture;
+
+import app.bottlenote.global.service.cursor.PageResponse;
+import app.bottlenote.support.help.constant.HelpType;
+import app.bottlenote.support.help.domain.Help;
+import app.bottlenote.support.help.domain.HelpRepository;
+import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
+import app.bottlenote.support.help.dto.request.HelpPageableRequest;
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
+import app.bottlenote.support.help.dto.response.HelpListResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class InMemoryHelpRepository implements HelpRepository {
+
+  private final Map<Long, Help> database = new HashMap<>();
+  private long sequence = 1L;
+
+  @Override
+  public Help save(Help help) {
+    Long id = help.getId();
+    if (Objects.isNull(id)) {
+      id = sequence++;
+      ReflectionTestUtils.setField(help, "id", id);
+    }
+    database.put(id, help);
+    return help;
+  }
+
+  @Override
+  public Optional<Help> findById(Long id) {
+    return Optional.ofNullable(database.get(id));
+  }
+
+  @Override
+  public List<Help> findAll() {
+    return List.copyOf(database.values());
+  }
+
+  @Override
+  public List<Help> findAllByUserId(Long userId) {
+    return database.values().stream().filter(h -> h.getUserId().equals(userId)).toList();
+  }
+
+  @Override
+  public List<Help> findAllByUserIdAndType(Long userId, HelpType helpType) {
+    return database.values().stream()
+        .filter(h -> h.getUserId().equals(userId) && h.getType().equals(helpType))
+        .toList();
+  }
+
+  @Override
+  public Optional<Help> findByIdAndUserId(Long id, Long userId) {
+    return database.values().stream()
+        .filter(h -> h.getId().equals(id) && h.getUserId().equals(userId))
+        .findFirst();
+  }
+
+  @Override
+  public PageResponse<HelpListResponse> getHelpList(
+      HelpPageableRequest helpPageableRequest, Long currentUserId) {
+    return null;
+  }
+
+  @Override
+  public PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request) {
+    return null;
+  }
+
+  public void clear() {
+    database.clear();
+    sequence = 1L;
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/support/help/service/HelpServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/support/help/service/HelpServiceTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @Tag("unit")
 @DisplayName("[unit] [service] HelpService")
@@ -51,6 +52,7 @@ class HelpServiceTest {
   @InjectMocks private HelpService helpService;
   @Mock private HelpRepository helpRepository;
   @Mock private UserFacade userDomainSupport;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @DisplayName("회원은 문의글을 작성할 수 있다.")
   @Test

--- a/bottlenote-product-api/src/test/java/app/bottlenote/user/fixture/InMemoryUserRepository.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/user/fixture/InMemoryUserRepository.java
@@ -1,0 +1,76 @@
+package app.bottlenote.user.fixture;
+
+import app.bottlenote.global.service.cursor.PageResponse;
+import app.bottlenote.user.domain.User;
+import app.bottlenote.user.domain.UserRepository;
+import app.bottlenote.user.dto.dsl.MyBottlePageableCriteria;
+import app.bottlenote.user.dto.response.MyBottleResponse;
+import app.bottlenote.user.dto.response.MyPageResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class InMemoryUserRepository implements UserRepository {
+
+  private final Map<Long, User> database = new HashMap<>();
+  private long sequence = 1L;
+
+  @Override
+  public User save(User user) {
+    Long id = user.getId();
+    if (Objects.isNull(id)) {
+      id = sequence++;
+      ReflectionTestUtils.setField(user, "id", id);
+    }
+    database.put(id, user);
+    return user;
+  }
+
+  @Override
+  public Optional<User> findById(Long userId) {
+    return Optional.ofNullable(database.get(userId));
+  }
+
+  @Override
+  public List<User> findAll() {
+    return List.copyOf(database.values());
+  }
+
+  @Override
+  public boolean existsByUserId(Long userId) {
+    return database.containsKey(userId);
+  }
+
+  @Override
+  public boolean existsByNickName(String nickname) {
+    return database.values().stream().anyMatch(u -> u.getNickName().equals(nickname));
+  }
+
+  @Override
+  public MyPageResponse getMyPage(Long userId, Long currentUserId) {
+    return null;
+  }
+
+  @Override
+  public PageResponse<MyBottleResponse> getReviewMyBottle(MyBottlePageableCriteria criteria) {
+    return null;
+  }
+
+  @Override
+  public PageResponse<MyBottleResponse> getRatingMyBottle(MyBottlePageableCriteria criteria) {
+    return null;
+  }
+
+  @Override
+  public PageResponse<MyBottleResponse> getPicksMyBottle(MyBottlePageableCriteria criteria) {
+    return null;
+  }
+
+  public void clear() {
+    database.clear();
+    sequence = 1L;
+  }
+}


### PR DESCRIPTION
## Summary
- 이미지가 실제 엔티티에 저장될 때 ResourceLog에 ACTIVATED 상태로 로깅하는 이벤트 기반 구현
- ImageResourceActivatedEvent 발행 및 ResourceEventListener에서 수신 처리
- ReviewService, HelpService, BusinessSupportService, UserBasicService에 이벤트 발행 로직 추가

## Changes
- `ImageResourceActivatedEvent`: 이미지 리소스 활성화 이벤트 record
- `ResourceEventListener`: 이벤트 수신 후 ResourceCommandService.activateImageResource() 호출
- `ImageUtil.extractResourceKey()`: viewUrl에서 resourceKey 추출 유틸리티 메서드
- 각 서비스에서 이미지 저장 시 이벤트 발행

## Test plan
- [x] ImageResourceActivatedEventPublishTest: 서비스별 이벤트 발행 검증 (12개 테스트)
- [x] ResourceEventListenerTest: 이벤트 수신 및 ResourceLog 저장 검증
- [x] ImageUtilTest: extractResourceKey 메서드 검증
- [x] 기존 단위 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)