### PR TITLE
fix(batch): 일일 데이터 리포트 환경 기반 스킵 로직으로 변경

### DIFF
--- a/bottlenote-batch/src/main/java/app/batch/bottlenote/schedule/DailyDataReportQuartzJob.java
+++ b/bottlenote-batch/src/main/java/app/batch/bottlenote/schedule/DailyDataReportQuartzJob.java
@@ -19,13 +19,13 @@ import org.springframework.stereotype.Component;
  * <p>이 클래스는 BatchQuartzJob을 상속받아 일일 데이터 리포트 배치 작업에 특화된 Quartz Job을 구현합니다. Spring의 @Component 어노테이션을
  * 통해 스프링 빈으로 등록되며, QuartzConfig에서 이 클래스를 사용하여 JobDetail과 Trigger를 설정합니다.
  *
- * <p>dev 브랜치에서는 실행되지 않습니다.
+ * <p>dev 환경에서는 실행되지 않습니다.
  */
 @Slf4j
 @Component
 public class DailyDataReportQuartzJob extends BatchQuartzJob {
 
-  private static final String DEV_BRANCH = "dev";
+  private static final String DEV_ENVIRONMENT = "dev";
   private final AppInfoConfig appInfoConfig;
 
   /**
@@ -44,9 +44,9 @@ public class DailyDataReportQuartzJob extends BatchQuartzJob {
   @Override
   protected void executeInternal(@NonNull JobExecutionContext context)
       throws JobExecutionException {
-    String gitBranch = Objects.requireNonNullElse(appInfoConfig.getGitBranch(), "unknown");
-    if (DEV_BRANCH.equals(gitBranch)) {
-      log.info("[BATCH SKIP] dailyDataReportJob skipped on dev branch at: {}", now());
+    String environment = Objects.requireNonNullElse(appInfoConfig.getEnvironment(), "unknown");
+    if (DEV_ENVIRONMENT.equals(environment)) {
+      log.info("[BATCH SKIP] dailyDataReportJob skipped on dev environment at: {}", now());
       return;
     }
     super.executeInternal(context);


### PR DESCRIPTION
## Summary
- 기존 git 브랜치 기반 스킵 로직을 환경(environment) 기반으로 변경
- dev 환경에서만 디스코드 리포트 발송 스킵되도록 수정
- 환경별 스킵 동작 검증 테스트 추가

## 문제
- dev 환경 배포가 `main` 브랜치에서 트리거됨
- 기존 로직은 `gitBranch == "dev"`를 체크하여 스킵 조건에 걸리지 않음
- 결과적으로 dev 환경에서도 디스코드 리포트가 발송됨

## 해결
- `gitBranch` 대신 `environment` (`SPRING_PROFILES_ACTIVE`) 값으로 판단
- dev 환경(`environment == "dev"`)에서만 스킵

## 변경 파일
- `DailyDataReportQuartzJob.java`: 환경 기반 스킵 로직으로 변경
- `DailyDataReportQuartzJobTest.java`: dev/prod 환경 테스트 케이스 추가

## Test plan
- [x] 기존 단위 테스트 통과
- [x] dev 환경 스킵 테스트 추가
- [x] prod 환경 실행 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)