### PR TITLE
feat(tag): 태그 추출 시 부분 매칭 허용

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
@@ -39,7 +39,7 @@ public class TastingTagService {
   }
 
   /**
-   * 문장에서 태그 이름 목록을 추출한다.
+   * 문장에서 태그 이름 목록을 추출한다. (부분 매칭 허용)
    *
    * @param text 분석할 문장
    * @return 매칭된 태그 이름 목록
@@ -51,27 +51,8 @@ public class TastingTagService {
     }
 
     return trie.parseText(text).stream()
-        .filter(emit -> isWholeWord(text, emit))
         .map(Emit::getKeyword)
         .distinct()
         .toList();
-  }
-
-  private boolean isWholeWord(String text, Emit emit) {
-    int start = emit.getStart();
-    int end = emit.getEnd() + 1;
-
-    if (start > 0 && isKorean(text.charAt(start - 1))) {
-      return false;
-    }
-    if (end < text.length() && isKorean(text.charAt(end))) {
-      return false;
-    }
-
-    return true;
-  }
-
-  private boolean isKorean(char c) {
-    return (c >= 0xAC00 && c <= 0xD7A3) || (c >= 0x1100 && c <= 0x11FF);
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
@@ -50,9 +50,6 @@ public class TastingTagService {
       return List.of();
     }
 
-    return trie.parseText(text).stream()
-        .map(Emit::getKeyword)
-        .distinct()
-        .toList();
+    return trie.parseText(text).stream().map(Emit::getKeyword).distinct().toList();
   }
 }

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/TastingTagServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/TastingTagServiceTest.java
@@ -72,19 +72,20 @@ class TastingTagServiceTest {
       assertThat(result).containsExactlyInAnyOrderElementsOf(expectedTags);
     }
 
-    static Stream<Arguments> 부분_매칭_제외_케이스() {
+    static Stream<Arguments> 부분_매칭_허용_케이스() {
       return Stream.of(
-          Arguments.of("바닐라빈 향이 좋아요", List.of()),
-          Arguments.of("꿀물처럼 달콤해요", List.of()),
-          Arguments.of("스모키한 느낌", List.of()),
-          Arguments.of("카라멜라이즈된 설탕 맛", List.of()),
-          Arguments.of("초콜릿케이크 같은 맛", List.of()));
+          Arguments.of("바닐라빈 향이 좋아요", List.of("바닐라")),
+          Arguments.of("꿀물처럼 달콤해요", List.of("꿀")),
+          Arguments.of("스모키한 느낌", List.of("스모키")),
+          Arguments.of("카라멜라이즈된 설탕 맛", List.of("카라멜")),
+          Arguments.of("초콜릿케이크 같은 맛", List.of("초콜릿")),
+          Arguments.of("초콜릿향이 남니다", List.of("초콜릿")));
     }
 
     @ParameterizedTest(name = "\"{0}\" → {1}")
-    @MethodSource("부분_매칭_제외_케이스")
-    @DisplayName("부분 매칭은 제외한다")
-    void 부분_매칭_제외(String text, List<String> expectedTags) {
+    @MethodSource("부분_매칭_허용_케이스")
+    @DisplayName("부분 매칭을 허용한다")
+    void 부분_매칭_허용(String text, List<String> expectedTags) {
       // when
       List<String> result = tastingTagService.extractTagNames(text);
 

--- a/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/integration/TastingTagIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/alcohols/integration/TastingTagIntegrationTest.java
@@ -74,8 +74,8 @@ class TastingTagIntegrationTest extends IntegrationTestSupport {
   }
 
   @Test
-  @DisplayName("부분 매칭은 제외된다")
-  void excludePartialMatch() throws Exception {
+  @DisplayName("부분 매칭을 허용한다")
+  void allowPartialMatch() throws Exception {
     // given
     String text = "바닐라빈 향이 좋고 꿀물처럼 달콤해요";
 
@@ -92,7 +92,7 @@ class TastingTagIntegrationTest extends IntegrationTestSupport {
 
     // then
     List<String> tags = extractDataAsList(result);
-    assertThat(tags).isEmpty();
+    assertThat(tags).containsExactlyInAnyOrder("바닐라", "꿀");
   }
 
   @Test


### PR DESCRIPTION
- TastingTagService에서 isWholeWord 필터 제거
- "초콜릿향", "바닐라빈" 등에서도 태그 추출 가능
- 단위/통합 테스트 케이스 수정