### PR TITLE
feat(security): 악성 봇/스캐너 경로 차단 기능 추가

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/global/security/constant/MaliciousPathPattern.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/security/constant/MaliciousPathPattern.java
@@ -1,0 +1,83 @@
+package app.bottlenote.global.security.constant;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 악성 봇/스캐너가 자주 탐색하는 경로 패턴 목록. Spring Security에서 denyAll() 처리에 사용. */
+@Getter
+@RequiredArgsConstructor
+public enum MaliciousPathPattern {
+
+  // 환경 설정 파일
+  ENV_FILE("/.env*", "환경 변수 파일"),
+  ENV_LOCAL("/.env.local", "로컬 환경 변수"),
+  ENV_PRODUCTION("/.env.production", "프로덕션 환경 변수"),
+  ENV_BACKUP("/.env.backup", "환경 변수 백업"),
+
+  // 버전 관리
+  GIT_DIRECTORY("/.git/**", "Git 저장소"),
+  GITIGNORE("/.gitignore", "Git ignore 파일"),
+  SVN_DIRECTORY("/.svn/**", "SVN 저장소"),
+
+  // WordPress
+  WP_ADMIN("/wp-admin/**", "WordPress 관리자"),
+  WP_LOGIN("/wp-login.php", "WordPress 로그인"),
+  WP_CONFIG("/wp-config.php", "WordPress 설정"),
+  WP_INCLUDES("/wp-includes/**", "WordPress 인클루드"),
+  WP_CONTENT("/wp-content/**", "WordPress 컨텐츠"),
+  XMLRPC("/xmlrpc.php", "XML-RPC 엔드포인트"),
+
+  // PHP/DB 관리 도구
+  PHP_MY_ADMIN("/phpmyadmin/**", "phpMyAdmin"),
+  PMA("/pma/**", "phpMyAdmin 별칭"),
+  MYSQL_ADMIN("/mysql/**", "MySQL 관리"),
+  ADMINER("/adminer.php", "Adminer DB 관리"),
+  PHP_INFO("/phpinfo.php", "PHP 정보"),
+  INFO_PHP("/info.php", "서버 정보"),
+
+  // 서버 상태
+  SERVER_STATUS("/server-status", "Apache 서버 상태"),
+  SERVER_INFO("/server-info", "Apache 서버 정보"),
+
+  // 백업/덤프 파일 (루트 경로만 차단, ** 뒤에 패턴 불가)
+  SQL_FILE("/*.sql", "루트 SQL 덤프 파일"),
+  BAK_FILE("/*.bak", "루트 백업 파일"),
+  BACKUP_FILE("/*.backup", "루트 백업 파일"),
+  DUMP_FILE("/*.dump", "루트 덤프 파일"),
+  DB_DUMP("/db.sql", "DB 덤프 파일"),
+  DATABASE_DUMP("/database.sql", "DB 덤프 파일"),
+  BACKUP_DIR("/backup/**", "백업 디렉토리"),
+  BACKUPS_DIR("/backups/**", "백업 디렉토리"),
+
+  // SSL/인증서 관련
+  WELL_KNOWN("/.well-known/**", "ACME 챌린지/인증"),
+
+  // 기타 스캔 대상
+  DS_STORE("/.DS_Store", "macOS 메타데이터"),
+  VSCODE("/.vscode/**", "VSCode 설정"),
+  IDEA("/.idea/**", "IntelliJ 설정"),
+  AWS_CREDENTIALS("/aws/credentials", "AWS 자격증명"),
+  DOCKER_COMPOSE("/docker-compose.yml", "Docker Compose"),
+  CGI_BIN("/cgi-bin/**", "CGI 스크립트"),
+
+  // 관리자 경로 (일반적인 스캔 대상)
+  ADMIN("/admin/**", "관리자 페이지"),
+  ADMINISTRATOR("/administrator/**", "관리자 페이지");
+
+  private final String pattern;
+  private final String description;
+
+  /** 모든 악성 경로 패턴 배열 반환 */
+  public static String[] getAllPatterns() {
+    return Arrays.stream(values()).map(MaliciousPathPattern::getPattern).toArray(String[]::new);
+  }
+
+  /** 특정 카테고리의 패턴만 반환 (패턴 문자열 포함 여부로 필터링) */
+  public static String[] getPatternsContaining(String keyword) {
+    return Arrays.stream(values())
+        .filter(p -> p.pattern.contains(keyword) || p.description.contains(keyword))
+        .map(MaliciousPathPattern::getPattern)
+        .toArray(String[]::new);
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/global/security/constant/MaliciousPathPatternTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/global/security/constant/MaliciousPathPatternTest.java
@@ -1,0 +1,110 @@
+package app.bottlenote.global.security.constant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+@Tag("unit")
+@DisplayName("MaliciousPathPattern 단위 테스트")
+class MaliciousPathPatternTest {
+
+  @Test
+  @DisplayName("getAllPatterns는 모든 악성 경로 패턴을 반환한다")
+  void getAllPatterns_모든_패턴_반환() {
+    // when
+    String[] patterns = MaliciousPathPattern.getAllPatterns();
+
+    // then
+    assertThat(patterns).hasSize(MaliciousPathPattern.values().length);
+    assertThat(patterns).contains("/.env*", "/.git/**", "/wp-admin/**", "/phpmyadmin/**");
+  }
+
+  @Test
+  @DisplayName("getAllPatterns는 빈 배열이 아니다")
+  void getAllPatterns_비어있지_않음() {
+    // when
+    String[] patterns = MaliciousPathPattern.getAllPatterns();
+
+    // then
+    assertThat(patterns).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("getPatternsContaining은 키워드를 포함하는 패턴만 반환한다")
+  void getPatternsContaining_키워드_필터링() {
+    // when
+    String[] wpPatterns = MaliciousPathPattern.getPatternsContaining("WordPress");
+
+    // then
+    assertThat(wpPatterns).contains("/wp-admin/**", "/wp-login.php", "/wp-config.php");
+    assertThat(wpPatterns).doesNotContain("/.env*", "/.git/**");
+  }
+
+  @Test
+  @DisplayName("getPatternsContaining은 패턴 문자열로도 필터링할 수 있다")
+  void getPatternsContaining_패턴_문자열_필터링() {
+    // when
+    String[] envPatterns = MaliciousPathPattern.getPatternsContaining(".env");
+
+    // then
+    assertThat(envPatterns).contains("/.env*", "/.env.local", "/.env.production", "/.env.backup");
+  }
+
+  @Test
+  @DisplayName("모든 패턴은 슬래시로 시작한다")
+  void 모든_패턴_슬래시로_시작() {
+    // when & then
+    for (MaliciousPathPattern pattern : MaliciousPathPattern.values()) {
+      assertThat(pattern.getPattern()).as("패턴 '%s'는 슬래시로 시작해야 한다", pattern.name()).startsWith("/");
+    }
+  }
+
+  @Test
+  @DisplayName("모든 패턴은 설명을 가진다")
+  void 모든_패턴_설명_존재() {
+    // when & then
+    for (MaliciousPathPattern pattern : MaliciousPathPattern.values()) {
+      assertThat(pattern.getDescription()).as("패턴 '%s'는 설명이 있어야 한다", pattern.name()).isNotBlank();
+    }
+  }
+
+  @Test
+  @DisplayName("주요 보안 취약점 경로가 포함되어 있다")
+  void 주요_보안_취약점_경로_포함() {
+    // when
+    String[] patterns = MaliciousPathPattern.getAllPatterns();
+
+    // then - 환경 설정 파일
+    assertThat(patterns).contains("/.env*");
+
+    // then - 버전 관리
+    assertThat(patterns).contains("/.git/**");
+
+    // then - WordPress
+    assertThat(patterns).contains("/wp-admin/**", "/wp-login.php");
+
+    // then - DB 관리 도구
+    assertThat(patterns).contains("/phpmyadmin/**");
+
+    // then - SSL/인증서
+    assertThat(patterns).contains("/.well-known/**");
+  }
+
+  @Test
+  @DisplayName("모든 패턴은 Spring Security PathPattern으로 파싱 가능해야 한다")
+  void 모든_패턴_PathPattern_호환() {
+    // given
+    PathPatternParser parser = new PathPatternParser();
+
+    // when & then
+    for (MaliciousPathPattern pattern : MaliciousPathPattern.values()) {
+      assertThatCode(() -> parser.parse(pattern.getPattern()))
+          .as("패턴 '%s' (%s)는 PathPattern으로 파싱 가능해야 한다", pattern.name(), pattern.getPattern())
+          .doesNotThrowAnyException();
+    }
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/global/security/SecurityConfig.java
+++ b/bottlenote-product-api/src/main/java/app/global/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package app.global.security;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
+import app.bottlenote.global.security.constant.MaliciousPathPattern;
 import app.bottlenote.global.security.jwt.JwtAuthenticationEntryPoint;
 import app.bottlenote.global.security.jwt.JwtAuthenticationFilter;
 import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
@@ -61,7 +62,9 @@ public class SecurityConfig {
         .formLogin(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/api/v1/picks/**")
+                auth.requestMatchers(MaliciousPathPattern.getAllPatterns())
+                    .denyAll()
+                    .requestMatchers("/api/v1/picks/**")
                     .authenticated()
                     .requestMatchers("/api/v1/s3/**")
                     .authenticated()

--- a/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
@@ -1,0 +1,80 @@
+package app.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+import app.bottlenote.IntegrationTestSupport;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.DispatcherServlet;
+
+@Tag("integration")
+@DisplayName("[integration] SecurityConfig 악성 경로 차단 테스트")
+class SecurityConfigIntegrationTest extends IntegrationTestSupport {
+
+  private ListAppender<ILoggingEvent> logAppender;
+  private Logger dispatcherLogger;
+
+  @BeforeEach
+  void setUpLogCapture() {
+    dispatcherLogger = (Logger) LoggerFactory.getLogger(DispatcherServlet.class);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    dispatcherLogger.addAppender(logAppender);
+  }
+
+  @AfterEach
+  void tearDownLogCapture() {
+    dispatcherLogger.detachAppender(logAppender);
+    logAppender.stop();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/.env",
+        "/.git/config",
+        "/wp-admin/test",
+        "/phpmyadmin/test",
+        "/.well-known/acme-challenge/test-token",
+        "/backup/dump",
+        "/.DS_Store"
+      })
+  @DisplayName("악성 경로 요청 시 403 반환 및 NoResourceFoundException 로그 미발생")
+  void 악성_경로_차단_및_로그_미발생(String path) {
+    // when
+    var result = mockMvcTester.get().uri(path).exchange();
+
+    // then - 403 Forbidden 반환
+    result.assertThat().hasStatus(FORBIDDEN);
+
+    // then - NoResourceFoundException 로그가 발생하지 않아야 함
+    assertThat(logAppender.list)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .noneMatch(msg -> msg != null && msg.contains("NoResourceFoundException"));
+  }
+
+  @Test
+  @DisplayName("정상 API 경로는 차단되지 않는다")
+  void 정상_API_경로_허용() {
+    // when
+    var result =
+        mockMvcTester
+            .get()
+            .uri("/api/v1/alcohols/search")
+            .header("Authorization", "Bearer " + getToken())
+            .exchange();
+
+    // then - 200 OK 또는 정상 응답 (403이 아님)
+    result.assertThat().hasStatusOk();
+  }
+}


### PR DESCRIPTION
## Summary
- 악성 봇/스캐너가 자주 탐색하는 경로(`.env`, `.git`, `wp-admin`, `phpmyadmin` 등)를 Spring Security에서 조기 차단
- `NoResourceFoundException` 에러 로그 노이즈 제거
- 40개 악성 경로 패턴을 Enum으로 상수화하여 관리

## Changes
- `MaliciousPathPattern` Enum 추가 (bottlenote-mono)
- `SecurityConfig`에 `denyAll()` 패턴 등록 (bottlenote-product-api)
- 단위 테스트 및 통합 테스트 추가

## Test plan
- [x] unit_test 통과
- [x] integration_test 통과
- [x] check_rule_test 통과 (아키텍처 규칙 준수)
- [x] 악성 경로 요청 시 403 Forbidden 반환 확인
- [x] NoResourceFoundException 로그 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)