### PR TITLE
feat: Admin API 이미지 업로드 PreSigned URL 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,43 @@ flowchart TD
 ### bottlenote-admin-api
 - **역할**: 관리자용 API 서버 모듈 (Kotlin)
 - **특징**:
-  - bottlenote-mono 모듈 의존
-  - 관리자 전용 REST API
+  - bottlenote-mono 모듈 의존 (비즈니스 로직은 mono에서 제공)
+  - 관리자 전용 REST API (프레젠테이션 계층만 담당)
   - context-path: `/admin/api/v1`
+  - Spring REST Docs 기반 API 문서화
+  - JWT 기반 어드민 전용 인증 체계
+  - 루트 어드민 자동 초기화 (`ApplicationReadyEvent`)
+
+**패키지 구조**:
+```
+app/
+├── Application.kt                 # 진입점
+├── bottlenote/{domain}/
+│   ├── presentation/              # 컨트롤러
+│   └── config/                    # 설정 클래스
+└── global/
+    ├── common/                    # 공통 유틸
+    └── security/                  # 보안 설정
+```
+
+**Kotlin 코딩 컨벤션**:
+- `data class`: 요청/응답 DTO, 설정 클래스
+- `object`: 테스트 헬퍼 (싱글톤)
+- `val` 불변성 선호, `lateinit var`는 DI 주입용으로만 사용
+- 생성자 주입: 클래스 선언부에 파라미터로 명시
+- Named parameters 활용으로 가독성 향상
+
+**테스트 구조**:
+- `@Tag("admin_integration")`: 통합 테스트 태그
+- `IntegrationTestSupport`: 테스트 베이스 클래스 (TestContainers, MockMvcTester)
+- `app/docs/`: RestDocs 테스트 (`@WebMvcTest`)
+- `app/integration/`: 통합 테스트
+- `app/helper/`: 테스트 헬퍼 (`object` 싱글톤)
+
+**인증 체계**:
+- `AdminJwtAuthenticationFilter`, `AdminJwtAuthenticationManager` 사용
+- `SecurityContextUtil.getAdminUserIdByContext()`: 현재 어드민 ID 조회
+- RBAC 역할: `ROOT_ADMIN`, `PARTNER`, `COMMUNITY_MANAGER`
 
 ### bottlenote-batch
 - **역할**: 배치 처리 모듈
@@ -94,6 +128,12 @@ git submodule update --init --recursive
 ./gradlew check_rule_test       # 아키텍처 규칙 테스트 (@Tag("rule"))
 ./gradlew asciidoctor           # API 문서 생성
 ./gradlew bootRun               # 애플리케이션 실행
+
+# admin-api 모듈 전용
+./gradlew :bottlenote-admin-api:build           # admin-api 빌드
+./gradlew :bottlenote-admin-api:test            # admin-api 테스트 실행
+./gradlew :bottlenote-admin-api:asciidoctor     # admin-api 문서 생성
+./gradlew :bottlenote-admin-api:bootRun         # admin-api 실행
 ```
 
 ### 서브모듈
@@ -101,6 +141,76 @@ git submodule update --init --recursive
 - **git.environment-variables**: 환경 설정 및 초기화 스크립트 포함
   - `storage/mysql/init/*.sql`: TestContainers용 DB 초기화 스크립트
   - 통합 테스트 실행 전 서브모듈 초기화 필수
+
+## Admin API 구현 규칙
+
+### 컨트롤러 작성 규칙
+
+1. **패키지 위치**: `app.bottlenote.{domain}.presentation`
+2. **클래스명**: `Admin{도메인명}Controller`
+3. **매핑**: `@RequestMapping("/{복수형 리소스}")` (예: `/helps`, `/alcohols`)
+4. **응답 타입**: `ResponseEntity<*>` 또는 `ResponseEntity<GlobalResponse>`
+5. **응답 래핑**: `GlobalResponse.ok(response)` 사용
+
+### API 엔드포인트 설계
+
+| HTTP Method | 용도 | URL 패턴 | 예시 |
+|-------------|------|----------|------|
+| GET | 목록 조회 | `/{resources}` | `GET /helps` |
+| GET | 단건 조회 | `/{resources}/{id}` | `GET /helps/1` |
+| POST | 생성/액션 | `/{resources}` 또는 `/{resources}/{id}/{action}` | `POST /helps/1/answer` |
+| PUT | 전체 수정 | `/{resources}/{id}` | `PUT /helps/1` |
+| PATCH | 부분 수정 | `/{resources}/{id}` | `PATCH /helps/1` |
+| DELETE | 삭제 | `/{resources}/{id}` | `DELETE /helps/1` |
+
+### 요청/응답 처리
+
+1. **목록 조회 요청**: `@ModelAttribute` + Request DTO
+2. **단건 조회**: `@PathVariable`
+3. **생성/수정 요청**: `@RequestBody @Valid` + Request DTO
+4. **페이징 응답**: `PageResponse.of(content, cursorPageable)`
+
+### 인증이 필요한 API
+
+```kotlin
+val adminId = SecurityContextUtil.getAdminUserIdByContext()
+    .orElseThrow { UserException(UserExceptionCode.REQUIRED_USER_ID) }
+```
+
+### 서비스 의존
+
+- 컨트롤러는 mono 모듈의 서비스를 직접 주입받아 사용
+- 비즈니스 로직은 mono 모듈에 구현
+- admin-api는 프레젠테이션 계층만 담당
+
+### 테스트 작성 규칙
+
+**통합 테스트** (`app/integration/{domain}/`):
+- `IntegrationTestSupport` 상속
+- `@Tag("admin_integration")` 태그
+- `@Nested` 클래스로 API별 그룹화
+- `mockMvcTester`로 API 호출 및 검증
+
+**RestDocs 테스트** (`app/docs/{domain}/`):
+- `@WebMvcTest(controllers = [...], excludeAutoConfiguration = [SecurityAutoConfiguration::class])`
+- `@MockitoBean`으로 서비스 목킹
+- `document()` 메서드로 API 문서 스니펫 생성
+
+### 헬퍼 클래스
+
+- **위치**: `app/helper/{domain}/`
+- **형태**: `object` 싱글톤
+- **용도**: 테스트 데이터 생성
+- **네이밍**: `{도메인명}Helper`
+
+```kotlin
+object AlcoholsHelper {
+    fun createAdminAlcoholItem(
+        id: Long = 1L,
+        korName: String = "테스트 위스키"
+    ): AdminAlcoholItem = ...
+}
+```
 
 ## 코드 작성 규칙
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,42 @@ git submodule update --init --recursive
 
 ## Admin API 구현 규칙
 
+### Admin API 구현 체크리스트
+
+새로운 Admin API를 구현할 때 다음 체크리스트를 따르세요:
+
+#### 1. 요구사항 분석 및 설계
+- [ ] product-api에 동일/유사 기능이 있는지 확인
+- [ ] mono 모듈의 기존 서비스/도메인 로직 재사용 가능 여부 확인
+- [ ] 신규 서비스 메서드가 필요한 경우 mono 모듈에 추가 계획
+- [ ] API 엔드포인트 설계 (HTTP Method, URL 패턴)
+
+#### 2. mono 모듈 수정 (필요 시)
+- [ ] 서비스 클래스에 admin 전용 메서드 추가 (예: `xxxForAdmin`)
+- [ ] 인증 방식 분리: admin은 `adminId`를 파라미터로 받도록 설계
+- [ ] 공통 로직 추출 및 리팩토링 (`private` 메서드 분리)
+- [ ] 기존 테스트 영향 확인 및 수정
+
+#### 3. admin-api 컨트롤러 구현
+- [ ] 패키지: `app.bottlenote.{domain}.presentation`
+- [ ] 클래스명: `Admin{도메인명}Controller`
+- [ ] `@RestController`, `@RequestMapping("/{리소스}")` 설정
+- [ ] 인증이 필요한 API: `SecurityContextUtil.getAdminUserIdByContext()` 호출
+- [ ] 응답: `GlobalResponse.ok(response)` 래핑
+
+#### 4. 테스트 작성
+- [ ] 통합 테스트: `app/integration/{domain}/Admin{도메인명}IntegrationTest.kt`
+  - `IntegrationTestSupport` 상속
+  - `@Tag("admin_integration")` 태그
+  - 인증 성공/실패 케이스
+  - 주요 비즈니스 시나리오
+- [ ] RestDocs 테스트 (API 문서화 필요 시): `app/docs/{domain}/Admin{도메인명}ControllerDocsTest.kt`
+
+#### 5. 검증 및 완료
+- [ ] 컴파일 확인: `./gradlew :bottlenote-admin-api:compileKotlin`
+- [ ] 테스트 실행: `./gradlew :bottlenote-admin-api:admin_integration_test`
+- [ ] API 문서 생성: `./gradlew :bottlenote-admin-api:asciidoctor` (RestDocs 테스트 작성 시)
+
 ### 컨트롤러 작성 규칙
 
 1. **패키지 위치**: `app.bottlenote.{domain}.presentation`

--- a/bottlenote-admin-api/build.gradle.kts
+++ b/bottlenote-admin-api/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
 
 	// Test - Testcontainers
 	testImplementation(libs.bundles.testcontainers.complete)
+
+	// Test - AWS S3 (for MinIO integration test)
+	testImplementation(libs.aws.s3)
 }
 
 sourceSets {

--- a/bottlenote-admin-api/src/docs/asciidoc/admin-api.adoc
+++ b/bottlenote-admin-api/src/docs/asciidoc/admin-api.adoc
@@ -41,3 +41,9 @@ include::api/admin-alcohols/alcohols.adoc[]
 == Help API
 
 include::api/admin-help/help.adoc[]
+
+'''
+
+== File API
+
+include::api/admin-file/file.adoc[]

--- a/bottlenote-admin-api/src/docs/asciidoc/api/admin-file/file.adoc
+++ b/bottlenote-admin-api/src/docs/asciidoc/api/admin-file/file.adoc
@@ -1,0 +1,30 @@
+=== PreSigned URL 발급 ===
+
+- S3 업로드용 PreSigned URL을 발급합니다.
+- 발급된 URL은 지정된 시간(기본 5분) 동안 유효합니다.
+- 여러 개의 URL을 한 번에 발급할 수 있습니다.
+
+[source]
+----
+GET /admin/api/v1/s3/presign-url
+----
+
+[discrete]
+==== 요청 헤더 ====
+
+[discrete]
+include::{snippets}/admin/file/presign-url/request-headers.adoc[]
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/file/presign-url/query-parameters.adoc[]
+include::{snippets}/admin/file/presign-url/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/file/presign-url/response-fields.adoc[]
+include::{snippets}/admin/file/presign-url/http-response.adoc[]

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/common/file/presentation/AdminImageUploadController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/common/file/presentation/AdminImageUploadController.kt
@@ -1,0 +1,27 @@
+package app.bottlenote.common.file.presentation
+
+import app.bottlenote.common.file.dto.request.ImageUploadRequest
+import app.bottlenote.common.file.service.ImageUploadService
+import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.security.SecurityContextUtil
+import app.bottlenote.user.exception.UserException
+import app.bottlenote.user.exception.UserExceptionCode
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/s3")
+class AdminImageUploadController(
+	private val imageUploadService: ImageUploadService
+) {
+
+	@GetMapping("/presign-url")
+	fun getPreSignUrl(@ModelAttribute request: ImageUploadRequest): ResponseEntity<*> {
+		val adminId = SecurityContextUtil.getAdminUserIdByContext()
+			.orElseThrow { UserException(UserExceptionCode.REQUIRED_USER_ID) }
+		return GlobalResponse.ok(imageUploadService.getPreSignUrlForAdmin(adminId, request))
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/file/AdminImageUploadControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/file/AdminImageUploadControllerDocsTest.kt
@@ -1,0 +1,116 @@
+package app.docs.file
+
+import app.bottlenote.common.file.dto.request.ImageUploadRequest
+import app.bottlenote.common.file.dto.response.ImageUploadItem
+import app.bottlenote.common.file.dto.response.ImageUploadResponse
+import app.bottlenote.common.file.presentation.AdminImageUploadController
+import app.bottlenote.common.file.service.ImageUploadService
+import app.bottlenote.global.security.SecurityContextUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.BDDMockito.given
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
+import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.operation.preprocess.Preprocessors.*
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.*
+import org.springframework.restdocs.request.RequestDocumentation.*
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.assertj.MockMvcTester
+import java.util.*
+
+@WebMvcTest(
+	controllers = [AdminImageUploadController::class],
+	excludeAutoConfiguration = [SecurityAutoConfiguration::class]
+)
+@AutoConfigureRestDocs
+@DisplayName("Admin 이미지 업로드 컨트롤러 RestDocs 테스트")
+class AdminImageUploadControllerDocsTest {
+
+	@Autowired
+	private lateinit var mvc: MockMvcTester
+
+	@MockitoBean
+	private lateinit var imageUploadService: ImageUploadService
+
+	@Test
+	@DisplayName("PreSigned URL 발급")
+	fun getPreSignUrl() {
+		// given
+		val imageUploadInfo = listOf(
+			ImageUploadItem.builder()
+				.order(1L)
+				.viewUrl("https://cdn.example.com/admin/banner/uuid-1.jpg")
+				.uploadUrl("https://s3.ap-northeast-2.amazonaws.com/bucket/admin/banner/uuid-1.jpg?X-Amz-Algorithm=...")
+				.build(),
+			ImageUploadItem.builder()
+				.order(2L)
+				.viewUrl("https://cdn.example.com/admin/banner/uuid-2.jpg")
+				.uploadUrl("https://s3.ap-northeast-2.amazonaws.com/bucket/admin/banner/uuid-2.jpg?X-Amz-Algorithm=...")
+				.build()
+		)
+
+		val response = ImageUploadResponse.builder()
+			.bucketName("bottlenote-bucket")
+			.expiryTime(5)
+			.uploadSize(2)
+			.imageUploadInfo(imageUploadInfo)
+			.build()
+
+		given(imageUploadService.getPreSignUrlForAdmin(anyLong(), any(ImageUploadRequest::class.java)))
+			.willReturn(response)
+
+		Mockito.mockStatic(SecurityContextUtil::class.java).use { mockedStatic: MockedStatic<SecurityContextUtil> ->
+			mockedStatic.`when`<Optional<Long>> { SecurityContextUtil.getAdminUserIdByContext() }
+				.thenReturn(Optional.of(1L))
+
+			// when & then
+			assertThat(
+				mvc.get().uri("/s3/presign-url")
+					.header("Authorization", "Bearer test_access_token")
+					.param("rootPath", "admin/banner")
+					.param("uploadSize", "2")
+			)
+				.hasStatusOk()
+				.apply(
+					document(
+						"admin/file/presign-url",
+						preprocessRequest(prettyPrint()),
+						preprocessResponse(prettyPrint()),
+						requestHeaders(
+							headerWithName("Authorization").description("Bearer 액세스 토큰")
+						),
+						queryParameters(
+							parameterWithName("rootPath").description("업로드 경로 (예: admin/banner, admin/alcohol)"),
+							parameterWithName("uploadSize").description("발급할 URL 개수")
+						),
+						responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+							fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+							fieldWithPath("data.bucketName").type(JsonFieldType.STRING).description("S3 버킷명"),
+							fieldWithPath("data.expiryTime").type(JsonFieldType.NUMBER).description("URL 만료 시간 (분)"),
+							fieldWithPath("data.uploadSize").type(JsonFieldType.NUMBER).description("발급된 URL 개수"),
+							fieldWithPath("data.imageUploadInfo[].order").type(JsonFieldType.NUMBER).description("이미지 순서"),
+							fieldWithPath("data.imageUploadInfo[].viewUrl").type(JsonFieldType.STRING).description("이미지 조회 URL (CDN)"),
+							fieldWithPath("data.imageUploadInfo[].uploadUrl").type(JsonFieldType.STRING).description("이미지 업로드 URL (PreSigned)"),
+							fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+							fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).ignored()
+						)
+					)
+				)
+		}
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/file/AdminImageUploadIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/file/AdminImageUploadIntegrationTest.kt
@@ -1,16 +1,25 @@
 package app.integration.file
 
 import app.IntegrationTestSupport
+import app.bottlenote.operation.utils.TestContainersConfig
+import com.amazonaws.services.s3.AmazonS3
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URI
 
 @Tag("admin_integration")
 @DisplayName("[integration] Admin Image Upload API 통합 테스트")
 class AdminImageUploadIntegrationTest : IntegrationTestSupport() {
+
+	@Autowired
+	private lateinit var amazonS3: AmazonS3
 
 	private lateinit var accessToken: String
 
@@ -115,6 +124,113 @@ class AdminImageUploadIntegrationTest : IntegrationTestSupport() {
 					.param("uploadSize", "1")
 			)
 				.hasStatus4xxClientError()
+		}
+	}
+
+	@Nested
+	@DisplayName("PreSigned URL 업로드 시나리오")
+	inner class UploadScenarioTest {
+
+		@Test
+		@DisplayName("PreSigned URL로 파일을 업로드하고 S3에서 확인할 수 있다")
+		fun uploadAndVerifyFile() {
+			// given: PreSigned URL 발급
+			val result = mockMvcTester.get().uri("/s3/presign-url")
+				.header("Authorization", "Bearer $accessToken")
+				.param("rootPath", "admin/upload-test")
+				.param("uploadSize", "1")
+				.exchange()
+
+			val response = parseResponse(result)
+			@Suppress("UNCHECKED_CAST")
+			val data = response.data as Map<String, Any>
+			@Suppress("UNCHECKED_CAST")
+			val imageUploadInfo = data["imageUploadInfo"] as List<Map<String, Any>>
+			val uploadUrl = imageUploadInfo[0]["uploadUrl"] as String
+			val viewUrl = imageUploadInfo[0]["viewUrl"] as String
+
+			// viewUrl에서 S3 key 추출 (cloudFrontUrl 이후 부분)
+			val s3Key = viewUrl.substringAfter("fake-cloudfront.net/")
+
+			log.info("uploadUrl = {}", uploadUrl)
+			log.info("s3Key = {}", s3Key)
+
+			// when: PreSigned URL로 파일 업로드
+			val testContent = "test image content"
+			val responseCode = uploadToPreSignedUrl(uploadUrl, testContent)
+
+			// then: 업로드 성공 확인
+			assertThat(responseCode).isEqualTo(200)
+
+			// then: S3에서 파일 존재 확인
+			val bucketName = TestContainersConfig.getTestBucket()
+			val exists = amazonS3.doesObjectExist(bucketName, s3Key)
+			assertThat(exists).isEqualTo(true)
+
+			// then: 업로드된 내용 확인
+			val s3Object = amazonS3.getObject(bucketName, s3Key)
+			val content = s3Object.objectContent.bufferedReader().use { it.readText() }
+			assertThat(content).isEqualTo(testContent)
+
+			log.info("업로드된 파일 내용 확인 완료: {}", content)
+		}
+
+		@Test
+		@DisplayName("여러 파일을 업로드하고 모두 S3에서 확인할 수 있다")
+		fun uploadMultipleFilesAndVerify() {
+			// given: PreSigned URL 3개 발급
+			val result = mockMvcTester.get().uri("/s3/presign-url")
+				.header("Authorization", "Bearer $accessToken")
+				.param("rootPath", "admin/multi-upload")
+				.param("uploadSize", "3")
+				.exchange()
+
+			val response = parseResponse(result)
+			@Suppress("UNCHECKED_CAST")
+			val data = response.data as Map<String, Any>
+			@Suppress("UNCHECKED_CAST")
+			val imageUploadInfo = data["imageUploadInfo"] as List<Map<String, Any>>
+
+			// when: 3개 파일 모두 업로드
+			val uploadResults = imageUploadInfo.mapIndexed { index, info ->
+				val uploadUrl = info["uploadUrl"] as String
+				val viewUrl = info["viewUrl"] as String
+				val s3Key = viewUrl.substringAfter("fake-cloudfront.net/")
+				val content = "content-$index"
+				val responseCode = uploadToPreSignedUrl(uploadUrl, content)
+				Triple(s3Key, content, responseCode)
+			}
+
+			// then: 모든 업로드 성공 확인
+			val bucketName = TestContainersConfig.getTestBucket()
+			uploadResults.forEach { (s3Key, expectedContent, responseCode) ->
+				assertThat(responseCode).isEqualTo(200)
+				assertThat(amazonS3.doesObjectExist(bucketName, s3Key)).isEqualTo(true)
+
+				val actualContent = amazonS3.getObject(bucketName, s3Key)
+					.objectContent.bufferedReader().use { it.readText() }
+				assertThat(actualContent).isEqualTo(expectedContent)
+			}
+
+			log.info("3개 파일 업로드 및 검증 완료")
+		}
+
+		private fun uploadToPreSignedUrl(preSignedUrl: String, content: String): Int {
+			val url = URI(preSignedUrl).toURL()
+			val connection = url.openConnection() as HttpURLConnection
+			return try {
+				connection.doOutput = true
+				connection.requestMethod = "PUT"
+				connection.setRequestProperty("Content-Type", "application/octet-stream")
+
+				OutputStreamWriter(connection.outputStream).use { writer ->
+					writer.write(content)
+				}
+
+				connection.responseCode
+			} finally {
+				connection.disconnect()
+			}
 		}
 	}
 }

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/file/AdminImageUploadIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/file/AdminImageUploadIntegrationTest.kt
@@ -1,0 +1,120 @@
+package app.integration.file
+
+import app.IntegrationTestSupport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("admin_integration")
+@DisplayName("[integration] Admin Image Upload API 통합 테스트")
+class AdminImageUploadIntegrationTest : IntegrationTestSupport() {
+
+	private lateinit var accessToken: String
+
+	@BeforeEach
+	fun setUp() {
+		val admin = adminUserTestFactory.persistRootAdmin()
+		accessToken = getAccessToken(admin)
+	}
+
+	@Nested
+	@DisplayName("PreSigned URL 생성 API")
+	inner class GetPreSignUrlTest {
+
+		@Test
+		@DisplayName("PreSigned URL을 생성할 수 있다")
+		fun getPreSignUrl() {
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/s3/presign-url")
+					.header("Authorization", "Bearer $accessToken")
+					.param("rootPath", "admin/test")
+					.param("uploadSize", "1")
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(true)
+		}
+
+		@Test
+		@DisplayName("여러 개의 PreSigned URL을 생성할 수 있다")
+		fun getMultiplePreSignUrls() {
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/s3/presign-url")
+					.header("Authorization", "Bearer $accessToken")
+					.param("rootPath", "admin/test")
+					.param("uploadSize", "3")
+			)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.uploadSize").isEqualTo(3)
+		}
+
+		@Test
+		@DisplayName("응답에 필요한 정보가 포함되어 있다")
+		fun responseContainsRequiredFields() {
+			// when
+			val result = mockMvcTester.get().uri("/s3/presign-url")
+				.header("Authorization", "Bearer $accessToken")
+				.param("rootPath", "admin/test")
+				.param("uploadSize", "2")
+				.exchange()
+
+			// then
+			assertThat(result)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.bucketName").isNotNull()
+
+			assertThat(result)
+				.bodyJson()
+				.extractingPath("$.data.expiryTime").isEqualTo(5)
+
+			assertThat(result)
+				.bodyJson()
+				.extractingPath("$.data.imageUploadInfo").isNotNull()
+		}
+
+		@Test
+		@DisplayName("생성된 URL 정보가 올바른 형식이다")
+		fun urlFormatIsCorrect() {
+			// when
+			val result = mockMvcTester.get().uri("/s3/presign-url")
+				.header("Authorization", "Bearer $accessToken")
+				.param("rootPath", "admin/test")
+				.param("uploadSize", "1")
+				.exchange()
+
+			val response = parseResponse(result)
+			@Suppress("UNCHECKED_CAST")
+			val data = response.data as Map<String, Any>
+			@Suppress("UNCHECKED_CAST")
+			val imageUploadInfo = data["imageUploadInfo"] as List<Map<String, Any>>
+
+			// then
+			val firstItem = imageUploadInfo[0]
+			assertThat(firstItem["order"]).isEqualTo(1)
+			assertThat(firstItem["viewUrl"] as String).contains("admin/test")
+			assertThat(firstItem["uploadUrl"] as String).isNotEmpty()
+
+			log.info("viewUrl = {}", firstItem["viewUrl"])
+			log.info("uploadUrl = {}", firstItem["uploadUrl"])
+		}
+
+		@Test
+		@DisplayName("인증 없이 요청하면 실패한다")
+		fun getPreSignUrlWithoutAuth() {
+			// when & then
+			assertThat(
+				mockMvcTester.get().uri("/s3/presign-url")
+					.param("rootPath", "admin/test")
+					.param("uploadSize", "1")
+			)
+				.hasStatus4xxClientError()
+		}
+	}
+}

--- a/bottlenote-admin-api/src/test/resources/application-test.yml
+++ b/bottlenote-admin-api/src/test/resources/application-test.yml
@@ -54,7 +54,7 @@ amazon:
     accessKey: fake-access-key
     secretKey: fake-secret-key
     region: ap-northeast-2
-    bucket: fake-bucket
+    bucket: test-bucket
     cloudFrontUrl: https://fake-cloudfront.net
 
 # Profanity Filter


### PR DESCRIPTION
## Summary
- Admin API에 이미지 업로드용 PreSigned URL 생성 엔드포인트 추가
- 어드민 전용 인증 컨텍스트(CustomAdminUserContext)를 통해 리소스 로그 저장
- CLAUDE.md에 Admin API 구현 규칙 문서화

## 변경 사항
| 파일 | 변경 내용 |
|------|----------|
| `ImageUploadService.java` | `getPreSignUrlForAdmin(adminId, request)` 메서드 추가 |
| `AdminImageUploadController.kt` | `GET /s3/presign-url` 엔드포인트 생성 |
| `AdminImageUploadIntegrationTest.kt` | 통합 테스트 5개 추가 |
| `CLAUDE.md` | Admin API 구현 규칙 및 빌드 명령어 추가 |
| `build.gradle.kts` | AWS S3 테스트 의존성 추가 |

## 엔드포인트
```
GET /admin/api/v1/s3/presign-url?rootPath={path}&uploadSize={size}
Authorization: Bearer {accessToken}
```

## Test plan
- [x] `admin_integration_test` 52개 테스트 통과
- [x] `ImageUploadUnitTest` 5개 테스트 통과
- [ ] 실제 환경에서 PreSigned URL로 이미지 업로드 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)