### PR TITLE
feat: PreSigned URL Content-Type 지원 추가

### DIFF
--- a/bottlenote-admin-api/src/test/kotlin/app/docs/file/AdminImageUploadControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/file/AdminImageUploadControllerDocsTest.kt
@@ -80,6 +80,7 @@ class AdminImageUploadControllerDocsTest {
 					.header("Authorization", "Bearer test_access_token")
 					.param("rootPath", "admin/banner")
 					.param("uploadSize", "2")
+					.param("contentType", "image/jpeg")
 			)
 				.hasStatusOk()
 				.apply(
@@ -92,7 +93,8 @@ class AdminImageUploadControllerDocsTest {
 						),
 						queryParameters(
 							parameterWithName("rootPath").description("업로드 경로 (예: admin/banner, admin/alcohol)"),
-							parameterWithName("uploadSize").description("발급할 URL 개수")
+							parameterWithName("uploadSize").description("발급할 URL 개수"),
+							parameterWithName("contentType").description("업로드 파일의 Content-Type (image/jpeg, image/png, image/webp, video/mp4)").optional()
 						),
 						responseFields(
 							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/file/AdminImageUploadControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/file/AdminImageUploadControllerDocsTest.kt
@@ -94,7 +94,7 @@ class AdminImageUploadControllerDocsTest {
 						queryParameters(
 							parameterWithName("rootPath").description("업로드 경로 (예: admin/banner, admin/alcohol)"),
 							parameterWithName("uploadSize").description("발급할 URL 개수"),
-							parameterWithName("contentType").description("업로드 파일의 Content-Type (image/jpeg, image/png, image/webp, video/mp4)").optional()
+							parameterWithName("contentType").description("업로드 파일의 Content-Type (image/jpeg, image/png, image/webp, video/mp4), 업로드(PUT) 요청 시 동일한 Content-Type 헤더 필요").optional()
 						),
 						responseFields(
 							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/file/AdminImageUploadIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/file/AdminImageUploadIntegrationTest.kt
@@ -221,7 +221,7 @@ class AdminImageUploadIntegrationTest : IntegrationTestSupport() {
 			return try {
 				connection.doOutput = true
 				connection.requestMethod = "PUT"
-				connection.setRequestProperty("Content-Type", "application/octet-stream")
+				connection.setRequestProperty("Content-Type", "image/jpeg")
 
 				OutputStreamWriter(connection.outputStream).use { writer ->
 					writer.write(content)

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/PreSignUrlProvider.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/PreSignUrlProvider.java
@@ -57,7 +57,12 @@ public interface PreSignUrlProvider {
       rootPath = rootPath.substring(0, rootPath.length() - 1);
     }
 
-    String extension = ALLOWED_CONTENT_TYPES.get(contentType);
+    String normalized = contentType.strip().toLowerCase();
+    int semicolon = normalized.indexOf(';');
+    if (semicolon > 0) {
+      normalized = normalized.substring(0, semicolon).strip();
+    }
+    String extension = ALLOWED_CONTENT_TYPES.get(normalized);
     if (extension == null) {
       throw new FileException(UNSUPPORTED_CONTENT_TYPE);
     }

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/PreSignUrlProvider.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/PreSignUrlProvider.java
@@ -1,17 +1,25 @@
 package app.bottlenote.common.file;
 
 import static app.bottlenote.common.file.exception.FileExceptionCode.EXPIRY_TIME_RANGE_INVALID;
+import static app.bottlenote.common.file.exception.FileExceptionCode.UNSUPPORTED_CONTENT_TYPE;
 import static java.time.format.DateTimeFormatter.ofPattern;
 
 import app.bottlenote.common.file.exception.FileException;
 import java.time.LocalDate;
 import java.util.Calendar;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
 public interface PreSignUrlProvider {
 
-  String EXTENSION = "jpg";
+  Map<String, String> ALLOWED_CONTENT_TYPES =
+      Map.of(
+          "image/jpeg", "jpg",
+          "image/png", "png",
+          "image/webp", "webp",
+          "video/mp4", "mp4");
+
   String PATH_DELIMITER = "/";
   String KEY_DELIMITER = "-";
 
@@ -19,9 +27,10 @@ public interface PreSignUrlProvider {
    * PreSignUrl을 생성한다.
    *
    * @param imageKey the image key
+   * @param contentType 업로드할 파일의 Content-Type
    * @return the string
    */
-  String generatePreSignUrl(String imageKey);
+  String generatePreSignUrl(String imageKey, String contentType);
 
   /**
    * ViewUrl을 생성한다. cloud front url 에 s3 key를 조합해 반환한다. 실제 오브젝트를 조회하기 위해 사용된다.
@@ -33,20 +42,28 @@ public interface PreSignUrlProvider {
   String generateViewUrl(String cloudFrontUrl, String imageKey);
 
   /**
-   * 루트 경로를 포함한 이미지 키를 생성한다. 확장자의 경우 .jpg로 고정한다.
+   * 루트 경로를 포함한 오브젝트 키를 생성한다. contentType에 따라 확장자를 결정한다.
    *
    * @param rootPath 저장할 루트 경로
-   * @return 생성된 이미지 키
+   * @param index 업로드 순번
+   * @param contentType 업로드할 파일의 Content-Type
+   * @return 생성된 오브젝트 키
    */
-  default String getImageKey(String rootPath, Long index) {
+  default String getImageKey(String rootPath, Long index, String contentType) {
     if (rootPath.startsWith(PATH_DELIMITER)) {
       rootPath = rootPath.substring(1);
     }
     if (rootPath.endsWith(PATH_DELIMITER)) {
       rootPath = rootPath.substring(0, rootPath.length() - 1);
     }
+
+    String extension = ALLOWED_CONTENT_TYPES.get(contentType);
+    if (extension == null) {
+      throw new FileException(UNSUPPORTED_CONTENT_TYPE);
+    }
+
     String uploadAt = LocalDate.now().format(ofPattern("yyyyMMdd"));
-    String imageId = index + KEY_DELIMITER + UUID.randomUUID() + "." + EXTENSION;
+    String imageId = index + KEY_DELIMITER + UUID.randomUUID() + "." + extension;
 
     return rootPath + PATH_DELIMITER + uploadAt + PATH_DELIMITER + imageId;
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/dto/request/ImageUploadRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/dto/request/ImageUploadRequest.java
@@ -1,7 +1,8 @@
 package app.bottlenote.common.file.dto.request;
 
-public record ImageUploadRequest(String rootPath, Long uploadSize) {
+public record ImageUploadRequest(String rootPath, Long uploadSize, String contentType) {
   public ImageUploadRequest {
     uploadSize = uploadSize == null ? 1 : uploadSize;
+    contentType = contentType == null ? "image/jpeg" : contentType;
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/exception/FileExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/exception/FileExceptionCode.java
@@ -4,7 +4,8 @@ import app.bottlenote.global.exception.custom.code.ExceptionCode;
 import org.springframework.http.HttpStatus;
 
 public enum FileExceptionCode implements ExceptionCode {
-  EXPIRY_TIME_RANGE_INVALID(HttpStatus.BAD_REQUEST, "만료 기간의 범위가 적절하지 않습니다.( 최소 1분 ,최대 10분) ");
+  EXPIRY_TIME_RANGE_INVALID(HttpStatus.BAD_REQUEST, "만료 기간의 범위가 적절하지 않습니다.( 최소 1분 ,최대 10분) "),
+  UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 Content-Type입니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/common/file/service/ImageUploadService.java
@@ -9,6 +9,7 @@ import app.bottlenote.common.file.dto.response.ImageUploadResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -64,11 +65,12 @@ public class ImageUploadService implements PreSignUrlProvider {
   private List<ImageUploadItem> generatePreSignUrls(ImageUploadRequest request) {
     String rootPath = request.rootPath();
     Long uploadSize = request.uploadSize();
+    String contentType = request.contentType();
     List<ImageUploadItem> keys = new ArrayList<>();
 
     for (long index = 1; index <= uploadSize; index++) {
-      String imageKey = getImageKey(rootPath, index);
-      String preSignUrl = generatePreSignUrl(imageKey);
+      String imageKey = getImageKey(rootPath, index, contentType);
+      String preSignUrl = generatePreSignUrl(imageKey, contentType);
       String viewUrl = generateViewUrl(cloudFrontUrl, imageKey);
       keys.add(
           ImageUploadItem.builder().order(index).viewUrl(viewUrl).uploadUrl(preSignUrl).build());
@@ -97,11 +99,14 @@ public class ImageUploadService implements PreSignUrlProvider {
   }
 
   @Override
-  public String generatePreSignUrl(String imageKey) {
+  public String generatePreSignUrl(String imageKey, String contentType) {
     Calendar uploadExpiryTime = getUploadExpiryTime(EXPIRY_TIME);
-    return amazonS3
-        .generatePresignedUrl(imageBucketName, imageKey, uploadExpiryTime.getTime(), HttpMethod.PUT)
-        .toString();
+    GeneratePresignedUrlRequest request =
+        new GeneratePresignedUrlRequest(imageBucketName, imageKey)
+            .withMethod(HttpMethod.PUT)
+            .withExpiration(uploadExpiryTime.getTime())
+            .withContentType(contentType);
+    return amazonS3.generatePresignedUrl(request).toString();
   }
 
   private void saveImageUploadLogs(String rootPath, List<ImageUploadItem> items) {

--- a/bottlenote-mono/src/test/java/app/bottlenote/common/file/ImageUploadUnitTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/common/file/ImageUploadUnitTest.java
@@ -101,7 +101,7 @@ class ImageUploadUnitTest {
     @DisplayName("PreSigned URL 생성 시 MinIO에서 유효한 URL을 반환한다")
     void test_1() {
       // given
-      ImageUploadRequest request = new ImageUploadRequest("review", 1L);
+      ImageUploadRequest request = new ImageUploadRequest("review", 1L, null);
 
       // when
       ImageUploadResponse response = imageUploadService.getPreSignUrl(request);
@@ -120,7 +120,7 @@ class ImageUploadUnitTest {
     @DisplayName("PreSigned URL로 실제 파일 업로드가 가능하다")
     void test_2() throws Exception {
       // given
-      ImageUploadRequest request = new ImageUploadRequest("review", 1L);
+      ImageUploadRequest request = new ImageUploadRequest("review", 1L, null);
       ImageUploadResponse response = imageUploadService.getPreSignUrl(request);
       String uploadUrl = response.imageUploadInfo().get(0).uploadUrl();
       byte[] testData = "test image content".getBytes();
@@ -148,7 +148,7 @@ class ImageUploadUnitTest {
     @DisplayName("업로드된 파일이 MinIO에 존재한다")
     void test_3() throws Exception {
       // given
-      ImageUploadRequest request = new ImageUploadRequest("review", 1L);
+      ImageUploadRequest request = new ImageUploadRequest("review", 1L, null);
       ImageUploadResponse response = imageUploadService.getPreSignUrl(request);
       String uploadUrl = response.imageUploadInfo().get(0).uploadUrl();
       String viewUrl = response.imageUploadInfo().get(0).viewUrl();
@@ -186,7 +186,7 @@ class ImageUploadUnitTest {
       Long userId = 1L;
       SecurityContextHolder.getContext()
           .setAuthentication(new TestingAuthenticationToken(userId.toString(), null));
-      ImageUploadRequest request = new ImageUploadRequest("review", 2L);
+      ImageUploadRequest request = new ImageUploadRequest("review", 2L, null);
 
       // when
       imageUploadService.getPreSignUrl(request);
@@ -204,7 +204,7 @@ class ImageUploadUnitTest {
     @DisplayName("비로그인 사용자가 PreSigned URL 생성 시 로그가 저장되지 않는다")
     void test_2() {
       // given
-      ImageUploadRequest request = new ImageUploadRequest("review", 2L);
+      ImageUploadRequest request = new ImageUploadRequest("review", 2L, null);
 
       // when
       imageUploadService.getPreSignUrl(request);

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/upload/ImageUploadServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/upload/ImageUploadServiceTest.java
@@ -10,12 +10,14 @@ import app.bottlenote.common.file.dto.request.ImageUploadRequest;
 import app.bottlenote.common.file.dto.response.ImageUploadItem;
 import app.bottlenote.common.file.dto.response.ImageUploadResponse;
 import app.bottlenote.common.file.exception.FileException;
+import app.bottlenote.common.file.exception.FileExceptionCode;
 import app.bottlenote.common.file.service.ImageUploadService;
 import app.bottlenote.common.file.service.ResourceCommandService;
 import app.bottlenote.common.file.upload.fixture.FakeAmazonS3;
 import app.bottlenote.common.file.upload.fixture.InMemoryResourceLogRepository;
 import java.time.LocalDate;
 import java.util.Calendar;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,14 +50,18 @@ class ImageUploadServiceTest {
         new ImageUploadService(
             resourceCommandService, new FakeAmazonS3(), BUCKET_NAME, CLOUD_FRONT_URL) {
           @Override
-          public String getImageKey(String rootPath, Long index) {
+          public String getImageKey(String rootPath, Long index, String contentType) {
             if (rootPath.startsWith(PATH_DELIMITER)) {
               rootPath = rootPath.substring(1);
             }
             if (rootPath.endsWith(PATH_DELIMITER)) {
               rootPath = rootPath.substring(0, rootPath.length() - 1);
             }
-            String imageId = index + KEY_DELIMITER + FAKE_UUID + "." + EXTENSION;
+            String extension = ALLOWED_CONTENT_TYPES.get(contentType);
+            if (extension == null) {
+              throw new FileException(FileExceptionCode.UNSUPPORTED_CONTENT_TYPE);
+            }
+            String imageId = index + KEY_DELIMITER + FAKE_UUID + "." + extension;
             return rootPath + PATH_DELIMITER + UPLOAD_DATE + PATH_DELIMITER + imageId;
           }
         };
@@ -69,10 +75,10 @@ class ImageUploadServiceTest {
     @DisplayName("PreSignUrl을 생성할 수 있다")
     void test_1() {
       // given
-      String imageKey = imageUploadService.getImageKey("review", 1L);
+      String imageKey = imageUploadService.getImageKey("review", 1L, "image/jpeg");
 
       // when
-      String preSignUrl = imageUploadService.generatePreSignUrl(imageKey);
+      String preSignUrl = imageUploadService.generatePreSignUrl(imageKey, "image/jpeg");
 
       // then
       log.info("PreSignUrl: {}", preSignUrl);
@@ -84,7 +90,7 @@ class ImageUploadServiceTest {
     @DisplayName("업로드용 인증 URL을 생성할 수 있다")
     void test_2() {
       // given
-      ImageUploadRequest request = new ImageUploadRequest("review", 2L);
+      ImageUploadRequest request = new ImageUploadRequest("review", 2L, null);
 
       // when
       ImageUploadResponse response = imageUploadService.getPreSignUrl(request);
@@ -96,8 +102,8 @@ class ImageUploadServiceTest {
       assertEquals(BUCKET_NAME, response.bucketName());
 
       for (Long index = 1L; index <= response.imageUploadInfo().size(); index++) {
-        String imageKey = imageUploadService.getImageKey(request.rootPath(), index);
-        String uploadUrlExpected = imageUploadService.generatePreSignUrl(imageKey);
+        String imageKey = imageUploadService.getImageKey(request.rootPath(), index, "image/jpeg");
+        String uploadUrlExpected = imageUploadService.generatePreSignUrl(imageKey, "image/jpeg");
         String viewUrlExpected = imageUploadService.generateViewUrl(CLOUD_FRONT_URL, imageKey);
 
         ImageUploadItem info = response.imageUploadInfo().get((int) (index - 1));
@@ -113,7 +119,7 @@ class ImageUploadServiceTest {
     @DisplayName("단건 이미지 업로드 URL을 생성할 수 있다")
     void test_3() {
       // given
-      ImageUploadRequest request = new ImageUploadRequest("review", 1L);
+      ImageUploadRequest request = new ImageUploadRequest("review", 1L, null);
 
       // when
       ImageUploadResponse response = imageUploadService.getPreSignUrl(request);
@@ -137,7 +143,7 @@ class ImageUploadServiceTest {
     @DisplayName("조회용 URL을 생성할 수 있다")
     void test_1() {
       // given
-      String imageKey = imageUploadService.getImageKey("review", 1L);
+      String imageKey = imageUploadService.getImageKey("review", 1L, "image/jpeg");
 
       // when
       String viewUrl = imageUploadService.generateViewUrl(CLOUD_FRONT_URL, imageKey);
@@ -157,13 +163,61 @@ class ImageUploadServiceTest {
     @DisplayName("이미지 루트 경로와 인덱스를 제공해 이미지 키를 생성할 수 있다")
     void test_1() {
       // given & when
-      String imageKey = imageUploadService.getImageKey("review", 1L);
+      String imageKey = imageUploadService.getImageKey("review", 1L, "image/jpeg");
       String expected = "review/" + UPLOAD_DATE + "/1-" + FAKE_UUID + ".jpg";
 
       // then
       log.info("ImageKey: {}", imageKey);
       assertNotNull(imageKey);
       assertEquals(expected, imageKey);
+    }
+
+    @Test
+    @DisplayName("video/mp4 contentType으로 키 생성 시 확장자가 .mp4이다")
+    void test_2() {
+      // given & when
+      String imageKey = imageUploadService.getImageKey("review", 1L, "video/mp4");
+
+      // then
+      log.info("ImageKey: {}", imageKey);
+      assertTrue(imageKey.endsWith(".mp4"));
+    }
+
+    @Test
+    @DisplayName("허용된 모든 contentType으로 키를 생성할 수 있다")
+    void test_3() {
+      // given
+      Map<String, String> expectedExtensions =
+          Map.of(
+              "image/jpeg",
+              ".jpg",
+              "image/png",
+              ".png",
+              "image/webp",
+              ".webp",
+              "video/mp4",
+              ".mp4");
+
+      expectedExtensions.forEach(
+          (contentType, extension) -> {
+            // when
+            String imageKey = imageUploadService.getImageKey("review", 1L, contentType);
+
+            // then
+            log.info("contentType: {} -> ImageKey: {}", contentType, imageKey);
+            assertTrue(
+                imageKey.endsWith(extension),
+                "contentType " + contentType + "의 확장자는 " + extension + "이어야 한다");
+          });
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 contentType으로 키 생성 시 예외가 발생한다")
+    void test_4() {
+      // given & when & then
+      assertThrows(
+          FileException.class,
+          () -> imageUploadService.getImageKey("review", 1L, "application/pdf"));
     }
   }
 

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/upload/fixture/FakeAmazonS3.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/upload/fixture/FakeAmazonS3.java
@@ -41,7 +41,6 @@ public class FakeAmazonS3 extends AbstractFakeAmazonS3 {
       String bucketName = generatePresignedUrlRequest.getBucketName();
       String key = generatePresignedUrlRequest.getKey();
       url = new URL("https", bucketName + ".s3.amazonaws.com", "/" + key);
-      System.out.println("Fake url 생성 : " + url);
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/upload/fixture/FakeAmazonS3.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/upload/fixture/FakeAmazonS3.java
@@ -38,7 +38,10 @@ public class FakeAmazonS3 extends AbstractFakeAmazonS3 {
       throws SdkClientException {
     URL url;
     try {
-      url = new URL("http://localhost:8080");
+      String bucketName = generatePresignedUrlRequest.getBucketName();
+      String key = generatePresignedUrlRequest.getKey();
+      url = new URL("https", bucketName + ".s3.amazonaws.com", "/" + key);
+      System.out.println("Fake url 생성 : " + url);
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }

--- a/bottlenote-product-api/src/test/java/app/docs/upload/RestImageUploadControllerTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/upload/RestImageUploadControllerTest.java
@@ -36,7 +36,7 @@ class RestImageUploadControllerTest extends AbstractRestDocs {
   @Test
   void test_1() throws Exception {
     // given
-    ImageUploadRequest request = new ImageUploadRequest("images", 1L);
+    ImageUploadRequest request = new ImageUploadRequest("images", 1L, "image/jpeg");
     ImageUploadResponse response =
         ImageUploadResponse.builder()
             .imageUploadInfo(
@@ -59,14 +59,19 @@ class RestImageUploadControllerTest extends AbstractRestDocs {
         .perform(
             get("/api/v1/s3/presign-url")
                 .param("rootPath", request.rootPath())
-                .param("uploadSize", String.valueOf(request.uploadSize())))
+                .param("uploadSize", String.valueOf(request.uploadSize()))
+                .param("contentType", "image/jpeg"))
         .andExpect(status().isOk())
         .andDo(
             document(
                 "file/image/upload/presign-url",
                 queryParameters(
                     parameterWithName("rootPath").description("업로드 파일 경로 (하단 설명 참조)"),
-                    parameterWithName("uploadSize").description("업로드할 이미지의 사이즈 ( 이미지당 1개 )")),
+                    parameterWithName("uploadSize").description("업로드할 이미지의 사이즈 ( 이미지당 1개 )"),
+                    parameterWithName("contentType")
+                        .description(
+                            "업로드 파일의 Content-Type (image/jpeg, image/png, image/webp, video/mp4)")
+                        .optional()),
                 responseFields(
                     fieldWithPath("success").description("응답 성공 여부"),
                     fieldWithPath("code").description("응답 코드(http status code)"),

--- a/bottlenote-product-api/src/test/java/app/docs/upload/RestImageUploadControllerTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/upload/RestImageUploadControllerTest.java
@@ -70,7 +70,8 @@ class RestImageUploadControllerTest extends AbstractRestDocs {
                     parameterWithName("uploadSize").description("업로드할 이미지의 사이즈 ( 이미지당 1개 )"),
                     parameterWithName("contentType")
                         .description(
-                            "업로드 파일의 Content-Type (image/jpeg, image/png, image/webp, video/mp4)")
+                            "업로드 파일의 Content-Type (image/jpeg, image/png, image/webp, video/mp4). "
+                                + "업로드(PUT) 요청 시 동일한 Content-Type 헤더를 포함해야 합니다.")
                         .optional()),
                 responseFields(
                     fieldWithPath("success").description("응답 성공 여부"),

--- a/plan/banner-media-type.md
+++ b/plan/banner-media-type.md
@@ -1,0 +1,58 @@
+# Banner mediaType 필드 추가
+
+> Issue: https://github.com/bottle-note/workspace/issues/205
+> 관련: [presigned-url-content-type.md](presigned-url-content-type.md)
+
+## 배경
+
+animated WebP는 모바일에서 하드웨어 디코딩 미지원으로 CPU 소프트웨어 디코딩 → 저사양 기기 버벅임.
+mp4는 모바일 VPU 활용으로 부하 없이 재생 가능. Banner에 미디어 유형 구분이 필요하다.
+
+## 작업 범위
+
+1. `MediaType` enum 생성 (`IMAGE`, `VIDEO`)
+2. `Banner` 엔티티에 `mediaType` 필드 추가
+3. 배너 등록/수정 API: `mediaType` 파라미터 수신
+4. 배너 조회 API: 응답에 `mediaType` 포함 (FE에서 `<Image>` vs `<video>` 분기)
+5. DB 스키마: `banners` 테이블에 `media_type` 컬럼 추가
+6. 기존 데이터 마이그레이션: `media_type = 'IMAGE'`
+
+## 현재 구조 분석
+
+### Banner 엔티티 (`Banner.java`)
+- 15개 필드, `mediaType` 없음
+- enum 필드는 `@Enumerated(EnumType.STRING)` 사용 (converter 불필요)
+- 기존 enum 패턴: `BannerType.java`, `TextPosition.java` → `@JsonCreator` + `parsing()` 메서드
+
+### 수정 대상 파일
+
+**신규 (1개)**
+- `bottlenote-mono/.../banner/constant/MediaType.java`
+
+**mono 모듈 (6개)**
+- `banner/domain/Banner.java` - 필드 + `update()` 파라미터 추가
+- `banner/dto/request/AdminBannerCreateRequest.java` - `mediaType` 추가 (기본값 `IMAGE`)
+- `banner/dto/request/AdminBannerUpdateRequest.java` - `mediaType` 추가
+- `banner/dto/response/AdminBannerDetailResponse.java` - `mediaType` 추가
+- `banner/dto/response/BannerResponse.java` - `mediaType` 추가
+- `banner/service/AdminBannerService.java` - create/update/getDetail 반영
+- `banner/service/BannerQueryService.java` - 응답 변환 반영
+
+**서브모듈 (1개)**
+- `git.environment-variables/storage/mysql/init/01-init-core-table.sql` - banners 테이블 (line 587~608)
+
+**테스트**
+- `mono/.../banner/fixture/BannerTestFactory.java`
+- `mono/.../banner/fixture/InMemoryBannerRepository.java`
+- `admin-api/.../helper/banner/BannerHelper.kt`
+- RestDocs 테스트 (admin-api, product-api)
+
+## 검증
+
+```bash
+./gradlew :bottlenote-mono:compileJava        # 컴파일 + Q타입 재생성
+./gradlew :bottlenote-admin-api:compileKotlin  # admin-api 컴파일
+./gradlew :bottlenote-mono:test                # mono 테스트
+./gradlew :bottlenote-product-api:test         # product-api 테스트
+./gradlew :bottlenote-admin-api:admin_integration_test  # admin 통합 테스트
+```

--- a/plan/presigned-url-content-type.md
+++ b/plan/presigned-url-content-type.md
@@ -1,0 +1,69 @@
+# PreSigned URL Content-Type 지원
+
+> Issue: https://github.com/bottle-note/workspace/issues/205
+> 관련: [banner-media-type.md](banner-media-type.md)
+
+## 배경
+
+현재 PreSigned URL 발급 시 확장자가 `.jpg`로 하드코딩되어 있고, Content-Type 제어가 없다.
+배너에 mp4 비디오를 업로드하려면 URL 발급 요청 시 `contentType`을 입력받아 확장자와 Content-Type을 동적으로 처리해야 한다.
+
+## 현재 구조
+
+```
+GET /api/v1/s3/presign-url?rootPath={path}&uploadSize={n}
+  → ImageUploadRequest(rootPath, uploadSize)
+  → PreSignUrlProvider.getImageKey() → 확장자 .jpg 하드코딩
+  → amazonS3.generatePresignedUrl() → Content-Type 미지정
+  → 클라이언트가 S3로 직접 PUT 업로드
+```
+
+### 문제점
+- `PreSignUrlProvider.java:14` → `EXTENSION = "jpg"` 하드코딩
+- `PreSignUrlProvider.java:49` → `UUID + "." + EXTENSION` 으로 S3 키 생성
+- `ImageUploadService.java:102-104` → Content-Type 없이 presigned URL 생성
+
+## 작업 내용
+
+### 1. `ImageUploadRequest` 수정
+- `contentType` 필드 추가 (MIME 문자열, 기본값 `"image/jpeg"`)
+
+### 2. `PreSignUrlProvider` 수정
+- `EXTENSION = "jpg"` 상수 제거
+- MIME → 확장자 허용 목록 추가:
+  | MIME | 확장자 |
+  |------|--------|
+  | image/jpeg | jpg |
+  | image/png | png |
+  | image/webp | webp |
+  | video/mp4 | mp4 |
+- `getImageKey(rootPath, index)` → `getImageKey(rootPath, index, contentType)` 시그니처 변경
+- 허용 목록에 없는 contentType이면 예외
+
+### 3. `FileExceptionCode` 수정
+- `UNSUPPORTED_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 Content-Type입니다.")` 추가
+
+### 4. `ImageUploadService` 수정
+- `generatePreSignUrls()` → contentType 전달
+- `generatePreSignUrl(imageKey)` → `generatePreSignUrl(imageKey, contentType)` 변경
+- `GeneratePresignedUrlRequest`에 `.withContentType(contentType)` 적용
+
+### 컨트롤러 변경 없음
+- `ImageUploadController.java` (product-api): `@ModelAttribute` 자동 바인딩
+- `AdminImageUploadController.kt` (admin-api): 동일
+
+## 수정 대상 파일
+
+**mono 모듈 (4개)**
+- `common/file/dto/request/ImageUploadRequest.java`
+- `common/file/PreSignUrlProvider.java`
+- `common/file/service/ImageUploadService.java`
+- `common/file/exception/FileExceptionCode.java`
+
+## 검증
+
+```bash
+./gradlew :bottlenote-mono:compileJava
+./gradlew :bottlenote-product-api:test
+./gradlew :bottlenote-admin-api:compileKotlin
+```


### PR DESCRIPTION
## Summary
- PreSigned URL 발급 시 `contentType` 파라미터를 입력받아 확장자와 Content-Type을 동적으로 처리
- 허용 목록: `image/jpeg`, `image/png`, `image/webp`, `video/mp4`
- 허용되지 않은 Content-Type 요청 시 400 예외 처리
- product-api, admin-api RestDocs 문서에 `contentType` 파라미터 반영

Related: https://github.com/bottle-note/workspace/issues/205

## Test plan
- [x] contentType별 확장자 매핑 단위 테스트 (image/jpeg->jpg, image/png->png, image/webp->webp, video/mp4->mp4)
- [x] 허용되지 않은 contentType 예외 발생 테스트
- [x] 기존 테스트 전체 통과 확인 (9/9)
- [x] product-api RestDocs 테스트 통과
- [x] admin-api RestDocs 테스트 통과


🤖 Generated with [Claude Code](https://claude.com/claude-code)