### PR TITLE
feat: 어드민 지역 정보 CUD API 추가

### DIFF
--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt
@@ -1,20 +1,60 @@
 package app.bottlenote.alcohols.presentation
 
 import app.bottlenote.alcohols.dto.request.AdminReferenceSearchRequest
+import app.bottlenote.alcohols.dto.request.AdminRegionCreateRequest
+import app.bottlenote.alcohols.dto.request.AdminRegionSortOrderRequest
+import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest
+import app.bottlenote.alcohols.service.AdminRegionService
 import app.bottlenote.alcohols.service.AlcoholReferenceService
+import app.bottlenote.global.data.response.GlobalResponse
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/regions")
 class AdminRegionController(
-	private val alcoholReferenceService: AlcoholReferenceService
+	private val alcoholReferenceService: AlcoholReferenceService,
+	private val adminRegionService: AdminRegionService
 ) {
 	@GetMapping
 	fun getAllRegions(
 		@ModelAttribute request: AdminReferenceSearchRequest
 	): ResponseEntity<*> = ResponseEntity.ok(alcoholReferenceService.findAllRegionsForAdmin(request))
+
+	@GetMapping("/{regionId}")
+	fun detail(
+		@PathVariable regionId: Long
+	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.getDetail(regionId))
+
+	@PostMapping
+	fun create(
+		@RequestBody @Valid request: AdminRegionCreateRequest
+	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.create(request))
+
+	@PutMapping("/{regionId}")
+	fun update(
+		@PathVariable regionId: Long,
+		@RequestBody @Valid request: AdminRegionUpdateRequest
+	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.update(regionId, request))
+
+	@DeleteMapping("/{regionId}")
+	fun delete(
+		@PathVariable regionId: Long
+	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.delete(regionId))
+
+	@PatchMapping("/{regionId}/sort-order")
+	fun updateSortOrder(
+		@PathVariable regionId: Long,
+		@RequestBody @Valid request: AdminRegionSortOrderRequest
+	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.updateSortOrder(regionId, request))
 }

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminRegionControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminRegionControllerDocsTest.kt
@@ -2,6 +2,7 @@ package app.docs.alcohols
 
 import app.bottlenote.alcohols.dto.request.AdminReferenceSearchRequest
 import app.bottlenote.alcohols.presentation.AdminRegionController
+import app.bottlenote.alcohols.service.AdminRegionService
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.global.data.response.GlobalResponse
 import app.helper.alcohols.AlcoholsHelper
@@ -38,6 +39,9 @@ class AdminRegionControllerDocsTest {
 
 	@MockitoBean
 	private lateinit var alcoholReferenceService: AlcoholReferenceService
+
+	@MockitoBean
+	private lateinit var adminRegionService: AdminRegionService
 
 	@Test
 	@DisplayName("지역 목록을 조회할 수 있다")

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/region/AdminRegionIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/region/AdminRegionIntegrationTest.kt
@@ -1,0 +1,193 @@
+package app.integration.region
+
+import app.IntegrationTestSupport
+import app.bottlenote.alcohols.dto.request.AdminRegionCreateRequest
+import app.bottlenote.alcohols.dto.request.AdminRegionSortOrderRequest
+import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest
+import app.bottlenote.alcohols.fixture.RegionTestFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+
+@Tag("admin_integration")
+@DisplayName("[integration] Admin Region API 통합 테스트")
+class AdminRegionIntegrationTest : IntegrationTestSupport() {
+
+	@Autowired
+	private lateinit var regionTestFactory: RegionTestFactory
+
+	private lateinit var accessToken: String
+
+	@BeforeEach
+	fun setUp() {
+		val admin = adminUserTestFactory.persistRootAdmin()
+		accessToken = getAccessToken(admin)
+	}
+
+	@Nested
+	@DisplayName("지역 단건 조회 API")
+	inner class Detail {
+		@Test
+		@DisplayName("지역 상세 정보를 조회할 수 있다")
+		fun detailSuccess() {
+			val region = regionTestFactory.persistRoot("스코틀랜드", "Scotland", 10)
+
+			assertThat(
+				mockMvcTester
+					.get()
+					.uri("/regions/${region.id}")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.success").isEqualTo(true)
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 지역 조회 시 404를 반환한다")
+		fun detailNotFound() {
+			assertThat(
+				mockMvcTester
+					.get()
+					.uri("/regions/999999")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatus(404)
+		}
+	}
+
+	@Nested
+	@DisplayName("지역 생성 API")
+	inner class Create {
+		@Test
+		@DisplayName("지역을 생성할 수 있다")
+		fun createSuccess() {
+			val request = AdminRegionCreateRequest.builder()
+				.korName("아일랜드")
+				.engName("Ireland")
+				.continent("Europe")
+				.description("아일리시")
+				.sortOrder(20)
+				.build()
+
+			assertThat(
+				mockMvcTester
+					.post()
+					.uri("/regions")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.code").isEqualTo("REGION_CREATED")
+		}
+
+		@Test
+		@DisplayName("한글 이름이 중복되면 409를 반환한다")
+		fun createDuplicateKorName() {
+			regionTestFactory.persistRoot("스코틀랜드", "Scotland", 10)
+
+			val request = AdminRegionCreateRequest.builder()
+				.korName("스코틀랜드")
+				.engName("ScotlandUk")
+				.build()
+
+			assertThat(
+				mockMvcTester
+					.post()
+					.uri("/regions")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			).hasStatus(409)
+		}
+	}
+
+	@Nested
+	@DisplayName("지역 수정 API")
+	inner class Update {
+		@Test
+		@DisplayName("지역을 수정할 수 있다")
+		fun updateSuccess() {
+			val region = regionTestFactory.persistRoot("스코트랜드", "ScotlandTypo", 10)
+
+			val request = AdminRegionUpdateRequest.builder()
+				.korName("스코틀랜드")
+				.engName("Scotland")
+				.continent("Europe")
+				.description("정정")
+				.sortOrder(10)
+				.build()
+
+			assertThat(
+				mockMvcTester
+					.put()
+					.uri("/regions/${region.id}")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.code").isEqualTo("REGION_UPDATED")
+		}
+	}
+
+	@Nested
+	@DisplayName("지역 삭제 API")
+	inner class Delete {
+		@Test
+		@DisplayName("지역을 삭제할 수 있다")
+		fun deleteSuccess() {
+			val region = regionTestFactory.persistRoot("스코틀랜드", "Scotland", 10)
+
+			assertThat(
+				mockMvcTester
+					.delete()
+					.uri("/regions/${region.id}")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.code").isEqualTo("REGION_DELETED")
+		}
+
+		@Test
+		@DisplayName("자식이 있는 지역은 삭제할 수 없다")
+		fun deleteHasChildren() {
+			val root = regionTestFactory.persistRoot("스코틀랜드", "Scotland", 10)
+			regionTestFactory.persistRegion("하이랜드", "Highland", root, 20)
+
+			assertThat(
+				mockMvcTester
+					.delete()
+					.uri("/regions/${root.id}")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatus(409)
+		}
+	}
+
+	@Nested
+	@DisplayName("지역 정렬 변경 API")
+	inner class UpdateSortOrder {
+		@Test
+		@DisplayName("정렬 순서를 변경할 수 있다")
+		fun sortOrderSuccess() {
+			val region = regionTestFactory.persistRoot("스코틀랜드", "Scotland", 100)
+
+			val request = AdminRegionSortOrderRequest(50)
+
+			assertThat(
+				mockMvcTester
+					.patch()
+					.uri("/regions/${region.id}/sort-order")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.code").isEqualTo("REGION_SORT_ORDER_UPDATED")
+		}
+	}
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/Region.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/Region.java
@@ -54,4 +54,27 @@ public class Region extends BaseEntity {
   @JoinColumn(name = "parent_id")
   @Comment("상위 지역")
   private Region parent;
+
+  public void update(
+      String korName,
+      String engName,
+      String continent,
+      String description,
+      Integer sortOrder,
+      Region parent) {
+    this.korName = korName;
+    this.engName = engName;
+    this.continent = continent;
+    this.description = description;
+    this.sortOrder = sortOrder != null ? sortOrder : 9999;
+    this.parent = parent;
+  }
+
+  public void updateSortOrder(int sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+
+  public void changeParent(Region parent) {
+    this.parent = parent;
+  }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/RegionRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/RegionRepository.java
@@ -19,4 +19,22 @@ public interface RegionRepository {
   List<Long> findChildRegionIds(Long parentId);
 
   List<Long> findChildRegionIdsIn(Collection<Long> parentIds);
+
+  Region save(Region region);
+
+  void delete(Region region);
+
+  boolean existsByKorName(String korName);
+
+  boolean existsByEngName(String engName);
+
+  boolean existsByKorNameAndIdNot(String korName, Long id);
+
+  boolean existsByEngNameAndIdNot(String engName, Long id);
+
+  List<Region> findAllBySortOrderGreaterThanEqual(int sortOrder);
+
+  boolean existsAlcoholByRegionId(Long regionId);
+
+  long countAlcoholsByRegionId(Long regionId);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminRegionCreateRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminRegionCreateRequest.java
@@ -1,0 +1,19 @@
+package app.bottlenote.alcohols.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+public record AdminRegionCreateRequest(
+    @NotBlank(message = "REGION_KOR_NAME_REQUIRED") String korName,
+    @NotBlank(message = "REGION_ENG_NAME_REQUIRED") String engName,
+    String continent,
+    String description,
+    Long parentId,
+    @Min(value = 0, message = "REGION_SORT_ORDER_MINIMUM") Integer sortOrder) {
+
+  @Builder
+  public AdminRegionCreateRequest {
+    sortOrder = sortOrder != null ? sortOrder : 9999;
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminRegionSortOrderRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminRegionSortOrderRequest.java
@@ -1,0 +1,9 @@
+package app.bottlenote.alcohols.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminRegionSortOrderRequest(
+    @NotNull(message = "REGION_SORT_ORDER_REQUIRED")
+        @Min(value = 0, message = "REGION_SORT_ORDER_MINIMUM")
+        Integer sortOrder) {}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminRegionUpdateRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminRegionUpdateRequest.java
@@ -1,0 +1,19 @@
+package app.bottlenote.alcohols.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+public record AdminRegionUpdateRequest(
+    @NotBlank(message = "REGION_KOR_NAME_REQUIRED") String korName,
+    @NotBlank(message = "REGION_ENG_NAME_REQUIRED") String engName,
+    String continent,
+    String description,
+    Long parentId,
+    @Min(value = 0, message = "REGION_SORT_ORDER_MINIMUM") Integer sortOrder) {
+
+  @Builder
+  public AdminRegionUpdateRequest {
+    sortOrder = sortOrder != null ? sortOrder : 9999;
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/response/AdminRegionDetailResponse.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/response/AdminRegionDetailResponse.java
@@ -1,0 +1,17 @@
+package app.bottlenote.alcohols.dto.response;
+
+import java.time.LocalDateTime;
+
+public record AdminRegionDetailResponse(
+    Long id,
+    String korName,
+    String engName,
+    String continent,
+    String description,
+    Integer sortOrder,
+    Long parentId,
+    String parentKorName,
+    boolean hasChildren,
+    long alcoholCount,
+    LocalDateTime createAt,
+    LocalDateTime lastModifyAt) {}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/exception/AlcoholExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/exception/AlcoholExceptionCode.java
@@ -18,7 +18,14 @@ public enum AlcoholExceptionCode implements ExceptionCode {
   TASTING_TAG_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "태그 계층 구조는 최대 3단계까지 가능합니다."),
   CURATION_NOT_FOUND(HttpStatus.NOT_FOUND, "큐레이션을 찾을 수 없습니다."),
   CURATION_DUPLICATE_NAME(HttpStatus.CONFLICT, "동일한 이름의 큐레이션이 이미 존재합니다."),
-  CURATION_ALCOHOL_NOT_INCLUDED(HttpStatus.BAD_REQUEST, "해당 위스키가 큐레이션에 포함되어 있지 않습니다.");
+  CURATION_ALCOHOL_NOT_INCLUDED(HttpStatus.BAD_REQUEST, "해당 위스키가 큐레이션에 포함되어 있지 않습니다."),
+  REGION_DUPLICATE_KOR_NAME(HttpStatus.CONFLICT, "동일한 한글 이름의 지역이 이미 존재합니다."),
+  REGION_DUPLICATE_ENG_NAME(HttpStatus.CONFLICT, "동일한 영문 이름의 지역이 이미 존재합니다."),
+  REGION_HAS_CHILDREN(HttpStatus.CONFLICT, "자식 지역이 존재하는 지역은 삭제할 수 없습니다."),
+  REGION_HAS_ALCOHOLS(HttpStatus.CONFLICT, "연결된 위스키가 존재하는 지역은 삭제할 수 없습니다."),
+  REGION_PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 지역을 찾을 수 없습니다."),
+  REGION_PARENT_CYCLE(HttpStatus.BAD_REQUEST, "자기 자신 또는 하위 지역을 부모로 지정할 수 없습니다."),
+  REGION_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "지역 계층 구조는 최대 2단계까지 가능합니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaRegionQueryRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaRegionQueryRepository.java
@@ -5,14 +5,13 @@ import app.bottlenote.alcohols.domain.RegionRepository;
 import app.bottlenote.alcohols.dto.response.AdminRegionItem;
 import app.bottlenote.alcohols.dto.response.RegionsItem;
 import app.bottlenote.common.annotation.JpaRepositoryImpl;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
-
-import java.util.Collection;
-import java.util.List;
 
 @JpaRepositoryImpl
 public interface JpaRegionQueryRepository extends RegionRepository, CrudRepository<Region, Long> {
@@ -21,7 +20,7 @@ public interface JpaRegionQueryRepository extends RegionRepository, CrudReposito
   @Query(
       """
       select new app.bottlenote.alcohols.dto.response.RegionsItem(r.id, r.korName, r.engName, r.description, r.parent.id, r.sortOrder)
-      from region r order by r.id asc
+      from region r order by r.sortOrder asc, r.korName asc
       """)
   List<RegionsItem> findAllRegionsResponse();
 
@@ -35,6 +34,7 @@ public interface JpaRegionQueryRepository extends RegionRepository, CrudReposito
       where (:keyword is null or :keyword = ''
         or r.korName like concat('%', :keyword, '%')
         or r.engName like concat('%', :keyword, '%'))
+      order by r.sortOrder asc, r.korName asc
       """)
   Page<AdminRegionItem> findAllRegions(@Param("keyword") String keyword, Pageable pageable);
 
@@ -45,4 +45,29 @@ public interface JpaRegionQueryRepository extends RegionRepository, CrudReposito
   @Override
   @Query("select r.id from region r where r.parent.id in :parentIds")
   List<Long> findChildRegionIdsIn(@Param("parentIds") Collection<Long> parentIds);
+
+  @Override
+  boolean existsByKorName(String korName);
+
+  @Override
+  boolean existsByEngName(String engName);
+
+  @Override
+  boolean existsByKorNameAndIdNot(String korName, Long id);
+
+  @Override
+  boolean existsByEngNameAndIdNot(String engName, Long id);
+
+  @Override
+  @Query("select r from region r where r.sortOrder >= :sortOrder")
+  List<Region> findAllBySortOrderGreaterThanEqual(@Param("sortOrder") int sortOrder);
+
+  @Override
+  @Query(
+      "select case when count(a) > 0 then true else false end from alcohol a where a.region.id = :regionId")
+  boolean existsAlcoholByRegionId(@Param("regionId") Long regionId);
+
+  @Override
+  @Query("select count(a) from alcohol a where a.region.id = :regionId")
+  long countAlcoholsByRegionId(@Param("regionId") Long regionId);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java
@@ -1,0 +1,202 @@
+package app.bottlenote.alcohols.service;
+
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_DUPLICATE_ENG_NAME;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_DUPLICATE_KOR_NAME;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_HAS_ALCOHOLS;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_HAS_CHILDREN;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_MAX_DEPTH_EXCEEDED;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_NOT_FOUND;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_PARENT_CYCLE;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_PARENT_NOT_FOUND;
+import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.REGION_CREATED;
+import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.REGION_DELETED;
+import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.REGION_SORT_ORDER_UPDATED;
+import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.REGION_UPDATED;
+
+import app.bottlenote.alcohols.domain.Region;
+import app.bottlenote.alcohols.domain.RegionRepository;
+import app.bottlenote.alcohols.dto.request.AdminRegionCreateRequest;
+import app.bottlenote.alcohols.dto.request.AdminRegionSortOrderRequest;
+import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest;
+import app.bottlenote.alcohols.dto.response.AdminRegionDetailResponse;
+import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.global.dto.response.AdminResultResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminRegionService {
+
+  private final RegionRepository regionRepository;
+
+  @Transactional(readOnly = true)
+  public AdminRegionDetailResponse getDetail(Long regionId) {
+    Region region =
+        regionRepository
+            .findById(regionId)
+            .orElseThrow(() -> new AlcoholException(REGION_NOT_FOUND));
+
+    Region parent = region.getParent();
+    boolean hasChildren = !regionRepository.findChildRegionIds(regionId).isEmpty();
+    long alcoholCount = regionRepository.countAlcoholsByRegionId(regionId);
+
+    return new AdminRegionDetailResponse(
+        region.getId(),
+        region.getKorName(),
+        region.getEngName(),
+        region.getContinent(),
+        region.getDescription(),
+        region.getSortOrder(),
+        parent != null ? parent.getId() : null,
+        parent != null ? parent.getKorName() : null,
+        hasChildren,
+        alcoholCount,
+        region.getCreateAt(),
+        region.getLastModifyAt());
+  }
+
+  @Transactional
+  public AdminResultResponse create(AdminRegionCreateRequest request) {
+    validateUniqueNames(request.korName(), request.engName(), null);
+
+    Region parent = resolveParent(request.parentId(), null);
+
+    reorderSortOrders(request.sortOrder(), null);
+
+    Region region =
+        Region.builder()
+            .korName(request.korName())
+            .engName(request.engName())
+            .continent(request.continent())
+            .description(request.description())
+            .sortOrder(request.sortOrder())
+            .parent(parent)
+            .build();
+
+    Region saved = regionRepository.save(region);
+    return AdminResultResponse.of(REGION_CREATED, saved.getId());
+  }
+
+  @Transactional
+  public AdminResultResponse update(Long regionId, AdminRegionUpdateRequest request) {
+    Region region =
+        regionRepository
+            .findById(regionId)
+            .orElseThrow(() -> new AlcoholException(REGION_NOT_FOUND));
+
+    validateUniqueNames(request.korName(), request.engName(), regionId);
+
+    Region parent = resolveParent(request.parentId(), regionId);
+
+    if (!region.getSortOrder().equals(request.sortOrder())) {
+      reorderSortOrders(request.sortOrder(), regionId);
+    }
+
+    region.update(
+        request.korName(),
+        request.engName(),
+        request.continent(),
+        request.description(),
+        request.sortOrder(),
+        parent);
+
+    return AdminResultResponse.of(REGION_UPDATED, regionId);
+  }
+
+  @Transactional
+  public AdminResultResponse delete(Long regionId) {
+    Region region =
+        regionRepository
+            .findById(regionId)
+            .orElseThrow(() -> new AlcoholException(REGION_NOT_FOUND));
+
+    if (!regionRepository.findChildRegionIds(regionId).isEmpty()) {
+      throw new AlcoholException(REGION_HAS_CHILDREN);
+    }
+
+    if (regionRepository.existsAlcoholByRegionId(regionId)) {
+      throw new AlcoholException(REGION_HAS_ALCOHOLS);
+    }
+
+    regionRepository.delete(region);
+    return AdminResultResponse.of(REGION_DELETED, regionId);
+  }
+
+  @Transactional
+  public AdminResultResponse updateSortOrder(Long regionId, AdminRegionSortOrderRequest request) {
+    Region region =
+        regionRepository
+            .findById(regionId)
+            .orElseThrow(() -> new AlcoholException(REGION_NOT_FOUND));
+
+    if (!region.getSortOrder().equals(request.sortOrder())) {
+      reorderSortOrders(request.sortOrder(), regionId);
+    }
+
+    region.updateSortOrder(request.sortOrder());
+    return AdminResultResponse.of(REGION_SORT_ORDER_UPDATED, regionId);
+  }
+
+  private void validateUniqueNames(String korName, String engName, Long excludeId) {
+    boolean korDuplicated =
+        excludeId == null
+            ? regionRepository.existsByKorName(korName)
+            : regionRepository.existsByKorNameAndIdNot(korName, excludeId);
+    if (korDuplicated) {
+      throw new AlcoholException(REGION_DUPLICATE_KOR_NAME);
+    }
+
+    boolean engDuplicated =
+        excludeId == null
+            ? regionRepository.existsByEngName(engName)
+            : regionRepository.existsByEngNameAndIdNot(engName, excludeId);
+    if (engDuplicated) {
+      throw new AlcoholException(REGION_DUPLICATE_ENG_NAME);
+    }
+  }
+
+  private Region resolveParent(Long parentId, Long selfId) {
+    if (parentId == null) {
+      return null;
+    }
+    if (selfId != null && parentId.equals(selfId)) {
+      throw new AlcoholException(REGION_PARENT_CYCLE);
+    }
+
+    Region parent =
+        regionRepository
+            .findById(parentId)
+            .orElseThrow(() -> new AlcoholException(REGION_PARENT_NOT_FOUND));
+
+    if (parent.getParent() != null) {
+      throw new AlcoholException(REGION_MAX_DEPTH_EXCEEDED);
+    }
+
+    if (selfId != null) {
+      List<Long> descendants = regionRepository.findChildRegionIds(selfId);
+      if (descendants.contains(parentId)) {
+        throw new AlcoholException(REGION_PARENT_CYCLE);
+      }
+      if (!descendants.isEmpty()) {
+        throw new AlcoholException(REGION_MAX_DEPTH_EXCEEDED);
+      }
+    }
+
+    return parent;
+  }
+
+  private void reorderSortOrders(Integer newSortOrder, Long excludeRegionId) {
+    if (newSortOrder == null) {
+      return;
+    }
+    List<Region> conflicting = regionRepository.findAllBySortOrderGreaterThanEqual(newSortOrder);
+    conflicting.stream()
+        .filter(r -> excludeRegionId == null || !r.getId().equals(excludeRegionId))
+        .forEach(r -> r.updateSortOrder(r.getSortOrder() + 1));
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/dto/response/AdminResultResponse.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/dto/response/AdminResultResponse.java
@@ -37,6 +37,10 @@ public record AdminResultResponse(String code, String message, Long targetId, St
     BANNER_DELETED("배너가 삭제되었습니다."),
     BANNER_STATUS_UPDATED("배너 활성화 상태가 변경되었습니다."),
     BANNER_SORT_ORDER_UPDATED("배너 정렬 순서가 변경되었습니다."),
+    REGION_CREATED("지역이 등록되었습니다."),
+    REGION_UPDATED("지역이 수정되었습니다."),
+    REGION_DELETED("지역이 삭제되었습니다."),
+    REGION_SORT_ORDER_UPDATED("지역 정렬 순서가 변경되었습니다."),
     ;
 
     private final String message;

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/exception/custom/code/ValidExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/exception/custom/code/ValidExceptionCode.java
@@ -90,7 +90,13 @@ public enum ValidExceptionCode implements ExceptionCode {
   BANNER_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "배너 유형은 필수입니다."),
   BANNER_SORT_ORDER_REQUIRED(HttpStatus.BAD_REQUEST, "정렬 순서는 필수입니다."),
   BANNER_SORT_ORDER_MINIMUM(HttpStatus.BAD_REQUEST, "정렬 순서는 0 이상이어야 합니다."),
-  BANNER_IS_ACTIVE_REQUIRED(HttpStatus.BAD_REQUEST, "활성화 상태는 필수입니다.");
+  BANNER_IS_ACTIVE_REQUIRED(HttpStatus.BAD_REQUEST, "활성화 상태는 필수입니다."),
+
+  // REGION
+  REGION_KOR_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "지역 한글명은 필수입니다."),
+  REGION_ENG_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "지역 영문명은 필수입니다."),
+  REGION_SORT_ORDER_REQUIRED(HttpStatus.BAD_REQUEST, "정렬 순서는 필수입니다."),
+  REGION_SORT_ORDER_MINIMUM(HttpStatus.BAD_REQUEST, "정렬 순서는 0 이상이어야 합니다.");
 
   private final HttpStatus httpStatus;
   private String message;

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryRegionRepository.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryRegionRepository.java
@@ -1,0 +1,161 @@
+package app.bottlenote.alcohols.fixture;
+
+import app.bottlenote.alcohols.domain.Region;
+import app.bottlenote.alcohols.domain.RegionRepository;
+import app.bottlenote.alcohols.dto.response.AdminRegionItem;
+import app.bottlenote.alcohols.dto.response.RegionsItem;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class InMemoryRegionRepository implements RegionRepository {
+
+  private final List<Region> regions = new ArrayList<>();
+  private final Map<Long, Long> alcoholCountByRegion = new HashMap<>();
+
+  @Override
+  public Optional<Region> findById(Long id) {
+    return regions.stream().filter(r -> Objects.equals(r.getId(), id)).findFirst();
+  }
+
+  @Override
+  public List<RegionsItem> findAllRegionsResponse() {
+    return regions.stream()
+        .sorted(
+            Comparator.comparingInt(Region::getSortOrder)
+                .thenComparing(Region::getKorName, Comparator.nullsLast(Comparator.naturalOrder())))
+        .map(
+            r ->
+                RegionsItem.of(
+                    r.getId(),
+                    r.getKorName(),
+                    r.getEngName(),
+                    r.getDescription(),
+                    r.getParent() != null ? r.getParent().getId() : null,
+                    r.getSortOrder()))
+        .toList();
+  }
+
+  @Override
+  public Page<AdminRegionItem> findAllRegions(String keyword, Pageable pageable) {
+    List<AdminRegionItem> filtered =
+        regions.stream()
+            .filter(
+                r ->
+                    keyword == null
+                        || keyword.isEmpty()
+                        || (r.getKorName() != null && r.getKorName().contains(keyword))
+                        || (r.getEngName() != null && r.getEngName().contains(keyword)))
+            .sorted(
+                Comparator.comparingInt(Region::getSortOrder)
+                    .thenComparing(
+                        Region::getKorName, Comparator.nullsLast(Comparator.naturalOrder())))
+            .map(
+                r ->
+                    new AdminRegionItem(
+                        r.getId(),
+                        r.getKorName(),
+                        r.getEngName(),
+                        r.getContinent(),
+                        r.getDescription(),
+                        r.getCreateAt(),
+                        r.getLastModifyAt(),
+                        r.getParent() != null ? r.getParent().getId() : null,
+                        r.getSortOrder()))
+            .toList();
+
+    int start = (int) pageable.getOffset();
+    int end = Math.min(start + pageable.getPageSize(), filtered.size());
+    List<AdminRegionItem> pageContent =
+        start < filtered.size() ? filtered.subList(start, end) : List.of();
+    return new PageImpl<>(pageContent, pageable, filtered.size());
+  }
+
+  @Override
+  public List<Long> findChildRegionIds(Long parentId) {
+    return regions.stream()
+        .filter(r -> r.getParent() != null && Objects.equals(r.getParent().getId(), parentId))
+        .map(Region::getId)
+        .toList();
+  }
+
+  @Override
+  public List<Long> findChildRegionIdsIn(Collection<Long> parentIds) {
+    return regions.stream()
+        .filter(r -> r.getParent() != null && parentIds.contains(r.getParent().getId()))
+        .map(Region::getId)
+        .toList();
+  }
+
+  @Override
+  public Region save(Region region) {
+    if (region.getId() == null) {
+      Long newId = (long) (regions.size() + 1);
+      ReflectionTestUtils.setField(region, "id", newId);
+    }
+    final Long rid = region.getId();
+    regions.removeIf(r -> Objects.equals(r.getId(), rid));
+    regions.add(region);
+    return region;
+  }
+
+  @Override
+  public void delete(Region region) {
+    regions.removeIf(r -> Objects.equals(r.getId(), region.getId()));
+  }
+
+  @Override
+  public boolean existsByKorName(String korName) {
+    return regions.stream().anyMatch(r -> Objects.equals(r.getKorName(), korName));
+  }
+
+  @Override
+  public boolean existsByEngName(String engName) {
+    return regions.stream().anyMatch(r -> Objects.equals(r.getEngName(), engName));
+  }
+
+  @Override
+  public boolean existsByKorNameAndIdNot(String korName, Long id) {
+    return regions.stream()
+        .anyMatch(r -> Objects.equals(r.getKorName(), korName) && !Objects.equals(r.getId(), id));
+  }
+
+  @Override
+  public boolean existsByEngNameAndIdNot(String engName, Long id) {
+    return regions.stream()
+        .anyMatch(r -> Objects.equals(r.getEngName(), engName) && !Objects.equals(r.getId(), id));
+  }
+
+  @Override
+  public List<Region> findAllBySortOrderGreaterThanEqual(int sortOrder) {
+    return regions.stream().filter(r -> r.getSortOrder() >= sortOrder).toList();
+  }
+
+  @Override
+  public boolean existsAlcoholByRegionId(Long regionId) {
+    return alcoholCountByRegion.getOrDefault(regionId, 0L) > 0;
+  }
+
+  @Override
+  public long countAlcoholsByRegionId(Long regionId) {
+    return alcoholCountByRegion.getOrDefault(regionId, 0L);
+  }
+
+  public void setAlcoholCount(Long regionId, long count) {
+    alcoholCountByRegion.put(regionId, count);
+  }
+
+  public void clear() {
+    regions.clear();
+    alcoholCountByRegion.clear();
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/RegionTestFactory.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/RegionTestFactory.java
@@ -1,0 +1,38 @@
+package app.bottlenote.alcohols.fixture;
+
+import app.bottlenote.alcohols.domain.Region;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RegionTestFactory {
+
+  @PersistenceContext private EntityManager em;
+
+  @Transactional
+  @NotNull
+  public Region persistRegion(
+      @NotNull String korName, @NotNull String engName, Region parent, int sortOrder) {
+    Region region =
+        Region.builder()
+            .korName(korName)
+            .engName(engName)
+            .continent("Europe")
+            .description(korName + " 설명")
+            .sortOrder(sortOrder)
+            .parent(parent)
+            .build();
+    em.persist(region);
+    em.flush();
+    return region;
+  }
+
+  @Transactional
+  @NotNull
+  public Region persistRoot(@NotNull String korName, @NotNull String engName, int sortOrder) {
+    return persistRegion(korName, engName, null, sortOrder);
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
@@ -1,0 +1,293 @@
+package app.bottlenote.alcohols.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.bottlenote.alcohols.domain.Region;
+import app.bottlenote.alcohols.dto.request.AdminRegionCreateRequest;
+import app.bottlenote.alcohols.dto.request.AdminRegionSortOrderRequest;
+import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest;
+import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.alcohols.exception.AlcoholExceptionCode;
+import app.bottlenote.alcohols.fixture.InMemoryRegionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("AdminRegionService 단위 테스트")
+class AdminRegionServiceTest {
+
+  private InMemoryRegionRepository regionRepository;
+  private AdminRegionService service;
+
+  @BeforeEach
+  void setUp() {
+    regionRepository = new InMemoryRegionRepository();
+    service = new AdminRegionService(regionRepository);
+  }
+
+  private Region saveRegion(String korName, String engName, Region parent, int sortOrder) {
+    Region region =
+        Region.builder()
+            .korName(korName)
+            .engName(engName)
+            .continent(null)
+            .description(null)
+            .sortOrder(sortOrder)
+            .parent(parent)
+            .build();
+    return regionRepository.save(region);
+  }
+
+  @Nested
+  @DisplayName("create")
+  class Create {
+
+    @Test
+    @DisplayName("정상 케이스에서 지역을 생성할 수 있다")
+    void create_whenValid_savesRegion() {
+      AdminRegionCreateRequest request =
+          AdminRegionCreateRequest.builder()
+              .korName("스코틀랜드")
+              .engName("Scotland")
+              .continent("Europe")
+              .description("스카치")
+              .sortOrder(10)
+              .build();
+
+      var result = service.create(request);
+
+      assertThat(result.code()).isEqualTo("REGION_CREATED");
+      assertThat(result.targetId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("한글 이름이 중복되면 REGION_DUPLICATE_KOR_NAME 예외가 발생한다")
+    void create_whenKorNameDuplicated_throws() {
+      saveRegion("스코틀랜드", "Scotland", null, 10);
+
+      AdminRegionCreateRequest request =
+          AdminRegionCreateRequest.builder().korName("스코틀랜드").engName("ScotlandUk").build();
+
+      assertThatThrownBy(() -> service.create(request))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_DUPLICATE_KOR_NAME);
+    }
+
+    @Test
+    @DisplayName("영문 이름이 중복되면 REGION_DUPLICATE_ENG_NAME 예외가 발생한다")
+    void create_whenEngNameDuplicated_throws() {
+      saveRegion("스코틀랜드", "Scotland", null, 10);
+
+      AdminRegionCreateRequest request =
+          AdminRegionCreateRequest.builder().korName("스코틀랜드영국").engName("Scotland").build();
+
+      assertThatThrownBy(() -> service.create(request))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_DUPLICATE_ENG_NAME);
+    }
+
+    @Test
+    @DisplayName("부모 지역이 존재하지 않으면 REGION_PARENT_NOT_FOUND 예외가 발생한다")
+    void create_whenParentNotFound_throws() {
+      AdminRegionCreateRequest request =
+          AdminRegionCreateRequest.builder().korName("아일라").engName("Islay").parentId(999L).build();
+
+      assertThatThrownBy(() -> service.create(request))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_PARENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("부모가 이미 자식 지역(2단계)일 때 REGION_MAX_DEPTH_EXCEEDED 예외가 발생한다")
+    void create_whenParentIsChild_throws() {
+      Region root = saveRegion("스코틀랜드", "Scotland", null, 10);
+      Region child = saveRegion("하이랜드", "Highland", root, 20);
+
+      AdminRegionCreateRequest request =
+          AdminRegionCreateRequest.builder()
+              .korName("아일라")
+              .engName("Islay")
+              .parentId(child.getId())
+              .build();
+
+      assertThatThrownBy(() -> service.create(request))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_MAX_DEPTH_EXCEEDED);
+    }
+  }
+
+  @Nested
+  @DisplayName("update")
+  class Update {
+
+    @Test
+    @DisplayName("정상 케이스에서 지역을 수정한다")
+    void update_whenValid_modifiesRegion() {
+      Region region = saveRegion("스코트랜드", "ScotlandTypo", null, 10);
+
+      AdminRegionUpdateRequest request =
+          AdminRegionUpdateRequest.builder()
+              .korName("스코틀랜드")
+              .engName("Scotland")
+              .continent("Europe")
+              .description("정정")
+              .sortOrder(10)
+              .build();
+
+      var result = service.update(region.getId(), request);
+
+      assertThat(result.code()).isEqualTo("REGION_UPDATED");
+      assertThat(regionRepository.findById(region.getId()).orElseThrow().getKorName())
+          .isEqualTo("스코틀랜드");
+    }
+
+    @Test
+    @DisplayName("자기 자신을 부모로 지정하면 REGION_PARENT_CYCLE 예외가 발생한다")
+    void update_whenParentIsSelf_throws() {
+      Region region = saveRegion("스코틀랜드", "Scotland", null, 10);
+
+      AdminRegionUpdateRequest request =
+          AdminRegionUpdateRequest.builder()
+              .korName("스코틀랜드")
+              .engName("Scotland")
+              .parentId(region.getId())
+              .sortOrder(10)
+              .build();
+
+      assertThatThrownBy(() -> service.update(region.getId(), request))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_PARENT_CYCLE);
+    }
+
+    @Test
+    @DisplayName("자식이 있는 지역을 다른 지역의 자식으로 변경하면 REGION_MAX_DEPTH_EXCEEDED 예외가 발생한다")
+    void update_whenSelfHasChildren_throws() {
+      Region root = saveRegion("스코틀랜드", "Scotland", null, 10);
+      Region another = saveRegion("아일랜드", "Ireland", null, 20);
+      saveRegion("하이랜드", "Highland", root, 30);
+
+      AdminRegionUpdateRequest request =
+          AdminRegionUpdateRequest.builder()
+              .korName("스코틀랜드")
+              .engName("Scotland")
+              .parentId(another.getId())
+              .sortOrder(10)
+              .build();
+
+      assertThatThrownBy(() -> service.update(root.getId(), request))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_MAX_DEPTH_EXCEEDED);
+    }
+  }
+
+  @Nested
+  @DisplayName("delete")
+  class Delete {
+
+    @Test
+    @DisplayName("자식과 위스키가 없으면 삭제할 수 있다")
+    void delete_whenNoChildAndNoAlcohol_removesRegion() {
+      Region region = saveRegion("스코틀랜드", "Scotland", null, 10);
+
+      var result = service.delete(region.getId());
+
+      assertThat(result.code()).isEqualTo("REGION_DELETED");
+      assertThat(regionRepository.findById(region.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("자식 지역이 존재하면 REGION_HAS_CHILDREN 예외가 발생한다")
+    void delete_whenHasChildren_throws() {
+      Region root = saveRegion("스코틀랜드", "Scotland", null, 10);
+      saveRegion("하이랜드", "Highland", root, 20);
+
+      assertThatThrownBy(() -> service.delete(root.getId()))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_HAS_CHILDREN);
+    }
+
+    @Test
+    @DisplayName("연결된 위스키가 존재하면 REGION_HAS_ALCOHOLS 예외가 발생한다")
+    void delete_whenHasAlcohols_throws() {
+      Region region = saveRegion("스코틀랜드", "Scotland", null, 10);
+      regionRepository.setAlcoholCount(region.getId(), 5L);
+
+      assertThatThrownBy(() -> service.delete(region.getId()))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_HAS_ALCOHOLS);
+    }
+  }
+
+  @Nested
+  @DisplayName("updateSortOrder")
+  class UpdateSortOrder {
+
+    @Test
+    @DisplayName("정렬 변경 시 같은 sortOrder 이상인 다른 지역을 +1 밀어낸다")
+    void updateSortOrder_reordersOtherRegions() {
+      Region a = saveRegion("A", "A", null, 10);
+      Region b = saveRegion("B", "B", null, 20);
+      Region target = saveRegion("T", "T", null, 100);
+
+      service.updateSortOrder(target.getId(), new AdminRegionSortOrderRequest(20));
+
+      assertThat(regionRepository.findById(target.getId()).orElseThrow().getSortOrder())
+          .isEqualTo(20);
+      assertThat(regionRepository.findById(b.getId()).orElseThrow().getSortOrder()).isEqualTo(21);
+      assertThat(regionRepository.findById(a.getId()).orElseThrow().getSortOrder()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("동일한 sortOrder로 변경하면 변경 없음(no-op)이다")
+    void updateSortOrder_whenSameValue_noChange() {
+      Region target = saveRegion("T", "T", null, 50);
+
+      service.updateSortOrder(target.getId(), new AdminRegionSortOrderRequest(50));
+
+      assertThat(regionRepository.findById(target.getId()).orElseThrow().getSortOrder())
+          .isEqualTo(50);
+    }
+  }
+
+  @Nested
+  @DisplayName("getDetail")
+  class GetDetail {
+
+    @Test
+    @DisplayName("지역과 부모, 자식 여부, 위스키 카운트를 함께 반환한다")
+    void getDetail_returnsAggregatedInfo() {
+      Region root = saveRegion("스코틀랜드", "Scotland", null, 10);
+      Region child = saveRegion("하이랜드", "Highland", root, 20);
+      regionRepository.setAlcoholCount(child.getId(), 7L);
+
+      var detail = service.getDetail(child.getId());
+
+      assertThat(detail.id()).isEqualTo(child.getId());
+      assertThat(detail.parentId()).isEqualTo(root.getId());
+      assertThat(detail.parentKorName()).isEqualTo("스코틀랜드");
+      assertThat(detail.hasChildren()).isFalse();
+      assertThat(detail.alcoholCount()).isEqualTo(7L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 지역 조회 시 REGION_NOT_FOUND 예외가 발생한다")
+    void getDetail_whenNotFound_throws() {
+      assertThatThrownBy(() -> service.getDetail(999L))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_NOT_FOUND);
+    }
+  }
+}

--- a/plan/admin-region-cud.md
+++ b/plan/admin-region-cud.md
@@ -1,0 +1,178 @@
+# Plan: 지역 정보 관리(Region) 어드민 CUD
+
+## Overview
+
+어드민이 위스키의 원산지(`Region`)를 관리할 수 있도록 생성/수정/삭제/단건 조회/정렬 변경 기능을 추가한다. 현재는 목록 조회(`GET /regions`)만 노출되어 있어, 어드민에서 신규 지역을 등록하거나 기존 지역의 정보·정렬 순서를 변경할 수 없다. 다른 어드민 도메인(Banner, Curation)과 동일한 표준(Controller=admin-api·Kotlin / Service=mono·Java, `AdminResultResponse` 반환, 필드별 PATCH 분리, offset 페이징)을 따른다.
+
+### Assumptions
+
+운영 비즈니스 룰은 사용자 확인을 통해 다음과 같이 확정되었다.
+
+1. **모듈 구조**: admin-api(Kotlin)에는 컨트롤러만, 비즈니스 로직과 DTO는 mono(Java)에 작성한다.
+2. **이름 중복 정책**: `korName`, `engName` 각각 **전역 유니크**. 같은 부모 하 유니크가 아니다.
+3. **계층 깊이 제한**: `Region.parent` self-reference는 **최대 2단계**까지 허용 (루트 + 1단계 자식, 손자 금지).
+4. **삭제 정책**: 자식 지역이 존재하거나(`REGION_HAS_CHILDREN`), 해당 지역을 참조하는 위스키(`Alcohol.region_id`)가 존재하면(`REGION_HAS_ALCOHOLS`) **삭제 금지**.
+5. **sortOrder 정책**: Banner와 동일한 **자동 reorder(밀어내기)** 방식을 적용한다. 같은 `sortOrder` 값이 잔존하는 경우 보조 정렬키로 **`korName ASC`** 를 적용한다 (기존 default `9999` 다수 케이스 대비).
+6. **`continent` 타입**: 자유 문자열 유지. enum화하지 않는다.
+7. **PATCH 분리 범위**: `sort-order` 한 가지만 별도 PATCH로 분리. `parent` 변경은 PUT(전체 수정)에 흡수한다.
+8. **부모 변경 검증**: 자기 자신 또는 자신의 하위 트리를 부모로 지정하는 사이클을 금지한다 (`REGION_PARENT_CYCLE`). 2단계 제한과 결합해 실질적으로 "이미 자식이 있는 지역은 다른 지역의 자식이 될 수 없다".
+9. **인증/권한**: 기존 어드민 컨트롤러와 동일하게 admin JWT 기반. 별도의 RBAC 차등은 두지 않는다 (관리 페이지 진입 가능자면 모두 허용).
+10. **API 문서화**: 통합 테스트에서 RestDocs 스니펫을 생성한다(`asciidoctor`).
+
+### Success Criteria
+
+| # | 기준 | 검증 방법 |
+|---|------|-----------|
+| SC1 | `GET /admin/api/v1/regions/{regionId}` 가 단건 상세(부모 id, 자식 여부, 위스키 연결 카운트 포함)를 반환한다 | RestDocs 통합 테스트 200 OK |
+| SC2 | `POST /admin/api/v1/regions` 로 신규 지역을 생성하면 `AdminResultResponse(REGION_CREATED, savedId)` 와 201/200 응답을 받는다 | 통합 테스트 + DB 저장 검증 |
+| SC3 | `korName` 또는 `engName` 중복 시 `409 CONFLICT` (`REGION_DUPLICATE_KOR_NAME` / `REGION_DUPLICATE_ENG_NAME`) | 통합 테스트 |
+| SC4 | `parent` 가 이미 자식을 가진 지역을 가리키거나(2단계 초과) 자기/하위 트리를 가리킬 때 각각 `REGION_MAX_DEPTH_EXCEEDED`, `REGION_PARENT_CYCLE` 발생 | 단위 + 통합 테스트 |
+| SC5 | `PUT /admin/api/v1/regions/{id}` 로 전체 수정 시 도메인 메서드(`region.update(...)`)로 상태 변경, `AdminResultResponse(REGION_UPDATED, id)` 반환 | 통합 테스트 + Reflection-free 도메인 단위 테스트 |
+| SC6 | `DELETE /admin/api/v1/regions/{id}` 시 자식 또는 연결 위스키 존재하면 `409`, 없으면 `200` + `REGION_DELETED` | 통합 테스트 (3개 시나리오) |
+| SC7 | `PATCH /admin/api/v1/regions/{id}/sort-order` 로 정렬 변경 시 동일 `sortOrder` 이상 모든 지역이 +1 밀려나고, 변경 대상의 새 값이 적용된다 | 단위 + 통합 테스트 |
+| SC8 | 목록(`GET /regions`)이 `sortOrder ASC, korName ASC` 정렬을 반환한다 | JPQL 변경 후 통합 테스트 검증 |
+| SC9 | 모든 응답이 `GlobalResponse` 표준을 따른다(목록은 `fromPage`, 그 외는 `GlobalResponse.ok`) | 응답 JSON shape 단언 |
+| SC10 | `/verify full` (compile + unit + integration + rule) 통과 | 로컬 CI 결과 |
+
+### Impact Scope
+
+**모듈/컴포넌트 변경 범위**
+
+- **모듈**: `bottlenote-mono` (도메인/서비스/DTO/예외/리포지토리), `bottlenote-admin-api` (컨트롤러)
+- **도메인**: `alcohols` (Region 단일 도메인). 크로스 도메인 Facade 불필요.
+- **엔티티**: `Region` 스키마 변경 없음 — 컬럼·테이블 수정 없음, **Liquibase 마이그레이션 불요**. 다만 도메인 메서드(`update/updateSortOrder/changeParent`) 추가.
+- **이벤트**: 신규 도메인 이벤트 없음.
+- **캐시**: Region을 캐시하는 기존 항목 없음(필요 시 추후). 이번 범위에선 캐시 작업 없음.
+
+**파일 변경/생성 목록 (요약)**
+
+mono:
+- `domain/Region.java` (도메인 메서드 추가)
+- `domain/RegionRepository.java` (CUD/exists/reorder용 IF 추가)
+- `repository/JpaRegionQueryRepository.java` (메서드 추가, 정렬 ORDER BY 보정)
+- `dto/request/AdminRegionCreateRequest.java` (신규)
+- `dto/request/AdminRegionUpdateRequest.java` (신규)
+- `dto/request/AdminRegionSortOrderRequest.java` (신규)
+- `dto/response/AdminRegionDetailResponse.java` (신규)
+- `service/AdminRegionService.java` (신규)
+- `exception/AlcoholExceptionCode.java` (코드 추가: DUPLICATE_KOR/ENG_NAME, HAS_CHILDREN, HAS_ALCOHOLS, PARENT_NOT_FOUND, PARENT_CYCLE, MAX_DEPTH_EXCEEDED)
+- `global/dto/response/AdminResultResponse.java` (ResultCode: REGION_CREATED/UPDATED/DELETED/SORT_ORDER_UPDATED 추가)
+
+admin-api:
+- `presentation/AdminRegionController.kt` (단건/POST/PUT/DELETE/PATCH 추가, `AdminRegionService` 의존성 주입)
+
+테스트:
+- `bottlenote-mono/src/test/java/.../alcohols/service/AdminRegionServiceTest.java` (단위, Fake `RegionRepository`)
+- `bottlenote-admin-api/src/test/kotlin/.../integration/region/AdminRegionIntegrationTest.kt` (통합 + RestDocs)
+
+**테스트 종류**: 단위(`@Tag("unit")`), 통합(`@Tag("integration")`), 아키텍처 규칙(`@Tag("rule")`) 자동 검증 통과.
+
+**보안/권한**: 기존 admin JWT 필터 그대로 적용. 추가 작업 없음.
+
+---
+
+## Tasks
+
+각 Task 종료 시 `/self-review` 게이트 통과 후 다음 Task로 이동한다.
+
+### T1. 예외 코드 + ResultCode enum 추가
+- **파일**: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/exception/AlcoholExceptionCode.java`, `bottlenote-mono/src/main/java/app/bottlenote/global/dto/response/AdminResultResponse.java`
+- **내용**:
+  - `AlcoholExceptionCode`: `REGION_DUPLICATE_KOR_NAME(409)`, `REGION_DUPLICATE_ENG_NAME(409)`, `REGION_HAS_CHILDREN(409)`, `REGION_HAS_ALCOHOLS(409)`, `REGION_PARENT_NOT_FOUND(404)`, `REGION_PARENT_CYCLE(400)`, `REGION_MAX_DEPTH_EXCEEDED(400)`
+  - `AdminResultResponse.ResultCode`: `REGION_CREATED`, `REGION_UPDATED`, `REGION_DELETED`, `REGION_SORT_ORDER_UPDATED` 추가 (한국어 메시지 포함)
+- **검증**: 컴파일 통과 (`./gradlew :bottlenote-mono:compileJava`)
+
+### T2. Region 도메인 메서드 추가
+- **파일**: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/Region.java`
+- **내용**:
+  - `update(String korName, String engName, String continent, String description, Integer sortOrder, Region parent)` — 모든 필드 일괄 갱신
+  - `updateSortOrder(int sortOrder)` — 정렬값만 갱신
+  - `changeParent(Region parent)` — 부모 교체 (null 허용)
+  - 검증 헬퍼: 자기/하위 사이클 검증은 Service에서 수행 (도메인은 단일 엔티티 책임만)
+- **검증**: 도메인 단위 테스트 (T7에 포함)
+
+### T3. RegionRepository / JpaRegionQueryRepository 확장
+- **파일**: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/RegionRepository.java`, `bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaRegionQueryRepository.java`
+- **내용**:
+  - IF 추가: `Region save(Region)`, `void delete(Region)`, `boolean existsByKorName(String)`, `boolean existsByEngName(String)`, `boolean existsByKorNameAndIdNot(String, Long)`, `boolean existsByEngNameAndIdNot(String, Long)`, `List<Region> findAllBySortOrderGreaterThanEqual(int)`, `boolean existsAlcoholByRegionId(Long)`
+  - 기존 `findAllRegions(keyword, pageable)` JPQL ORDER BY 추가: `r.sortOrder ASC, r.korName ASC`
+  - `existsAlcoholByRegionId`: `Alcohol` 엔티티 존재 여부 확인 — JPQL `select count(a)>0 from alcohol a where a.region.id = :regionId`
+- **검증**: 컴파일 통과 + 기존 통합 테스트 회귀 없음
+
+### T4. Request/Response DTO 추가
+- **파일** (신규):
+  - `bottlenote-mono/.../alcohols/dto/request/AdminRegionCreateRequest.java`
+  - `bottlenote-mono/.../alcohols/dto/request/AdminRegionUpdateRequest.java`
+  - `bottlenote-mono/.../alcohols/dto/request/AdminRegionSortOrderRequest.java`
+  - `bottlenote-mono/.../alcohols/dto/response/AdminRegionDetailResponse.java`
+- **내용**:
+  - Create: `@NotBlank korName, engName`, optional `continent, description, parentId`, `@Min(0) sortOrder` (default 9999)
+  - Update: Create와 동일 필드 (전체 수정)
+  - SortOrder: `@Min(0) sortOrder`
+  - Detail: `id, korName, engName, continent, description, sortOrder, parentId, parentKorName, hasChildren(boolean), alcoholCount(long), createAt, lastModifyAt`
+
+### T5. AdminRegionService 신설
+- **파일**: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java`
+- **메서드**:
+  - `getDetail(Long regionId)` → `AdminRegionDetailResponse` (`@Transactional(readOnly=true)`)
+  - `create(AdminRegionCreateRequest)` → `AdminResultResponse(REGION_CREATED, id)`
+  - `update(Long, AdminRegionUpdateRequest)` → `AdminResultResponse(REGION_UPDATED, id)`
+  - `delete(Long)` → 자식/위스키 검증 후 `AdminResultResponse(REGION_DELETED, id)`
+  - `updateSortOrder(Long, AdminRegionSortOrderRequest)` → reorder 후 `AdminResultResponse(REGION_SORT_ORDER_UPDATED, id)`
+- **검증 로직 (private)**:
+  - `validateUniqueNames(korName, engName, excludeId=null)`
+  - `resolveParent(Long parentId, Long selfId)` — null 허용, 자기 자신 금지, 부모 존재, **부모가 이미 자식인 경우(2단계 초과) 거부**, 사이클 방지(자기 하위 트리 = `findChildRegionIds(selfId)`에 포함되면 거부)
+  - `reorderSortOrders(int newSortOrder, Long excludeId)` — Banner 패턴 동일
+
+### T6. AdminRegionController CUD 엔드포인트 추가
+- **파일**: `bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt`
+- **내용**:
+  - `AdminRegionService` 의존성 주입 추가
+  - 기존 `GET /regions` 유지 (`alcoholReferenceService` 위임)
+  - 신규 endpoint: `GET /{id}`, `POST /`, `PUT /{id}`, `DELETE /{id}`, `PATCH /{id}/sort-order`
+  - 응답 래핑: 단순 위임 + `GlobalResponse.ok(...)`
+
+### T7. 단위 테스트 (Service)
+- **파일**: `bottlenote-mono/src/test/java/.../alcohols/service/AdminRegionServiceTest.java` (`@Tag("unit")`)
+- **테스트 더블**: `InMemoryRegionRepository` Fake (`bottlenote-mono/src/test/.../alcohols/fixture/InMemoryRegionRepository.java`)
+- **시나리오**:
+  - 생성: 정상 / korName 중복 / engName 중복 / parent 없음 / 깊이 초과 / 사이클
+  - 수정: 정상 / 자기 자신 부모 / 다른 지역 이름 중복
+  - 삭제: 정상 / 자식 존재 / 위스키 존재
+  - sortOrder: 정상 reorder / 같은 값 변경시 no-op / 더 큰 값으로 이동 시 다른 항목 영향 없음
+
+### T8. 통합 테스트 (Controller + RestDocs)
+- **파일**: `bottlenote-admin-api/src/test/kotlin/.../integration/region/AdminRegionIntegrationTest.kt` (`@Tag("integration")`)
+- **베이스**: `IntegrationTestSupport`, `MockMvcTester`
+- **시나리오**: 6개 엔드포인트별 happy path + 주요 실패 케이스 (RestDocs 스니펫 생성)
+- **데이터**: `RegionTestFactory` 신설 또는 기존 fixture 활용, `init-script/regions.sql` 확장 (필요 시)
+
+### T9. /verify full 검증
+- `./gradlew clean compileJava compileTestJava unit_test integration_test check_rule_test asciidoctor`
+- 모든 그린 확인 후 커밋
+
+## Progress Log
+
+- **T1 ✅** 예외 코드 7건(`REGION_DUPLICATE_KOR_NAME`, `REGION_DUPLICATE_ENG_NAME`, `REGION_HAS_CHILDREN`, `REGION_HAS_ALCOHOLS`, `REGION_PARENT_NOT_FOUND`, `REGION_PARENT_CYCLE`, `REGION_MAX_DEPTH_EXCEEDED`) + ResultCode 4건(`REGION_CREATED/UPDATED/DELETED/SORT_ORDER_UPDATED`) 추가. 컴파일 통과.
+- **T2 ✅** `Region.update / updateSortOrder / changeParent` 도메인 메서드 추가. setter 미사용, 캡슐화 유지.
+- **T3 ✅** `RegionRepository` IF + `JpaRegionQueryRepository` 확장. `existsByKor/EngName(+IdNot)`, `findAllBySortOrderGreaterThanEqual`, `existsAlcoholByRegionId`, `countAlcoholsByRegionId` 추가. JPQL ORDER BY를 `sortOrder ASC, korName ASC` 로 보정.
+- **T4 ✅** `AdminRegionCreateRequest`, `AdminRegionUpdateRequest`, `AdminRegionSortOrderRequest`, `AdminRegionDetailResponse` 신설.
+- **T5 ✅** `AdminRegionService` 신설. 검증 로직(`validateUniqueNames`, `resolveParent`, `reorderSortOrders`) 캡슐화. 부모 확인 시 2단계 제한 + 사이클 방지(자기 하위 트리 + 자식 보유 검사).
+- **T6 ✅** `AdminRegionController.kt` 에 단건/POST/PUT/DELETE/PATCH(sort-order) 추가. 기존 GET 유지.
+- **T7 ✅** `InMemoryRegionRepository` Fake + `AdminRegionServiceTest` 단위 테스트 15개 작성 — `./gradlew :bottlenote-mono:test --tests AdminRegionServiceTest` 15/15 PASSED.
+- **T8 ✅** `RegionTestFactory` + `AdminRegionIntegrationTest` 통합 테스트 8개 작성 (Detail 2 / Create 2 / Update 1 / Delete 2 / SortOrder 1).
+- **T9 ✅** 검증 결과
+  - `./gradlew unit_test` BUILD SUCCESSFUL
+  - `./gradlew check_rule_test` BUILD SUCCESSFUL
+  - `./gradlew integration_test` BUILD SUCCESSFUL
+  - `./gradlew :bottlenote-admin-api:admin_integration_test` 159/159 PASSED, 실패 0, 회귀 없음
+
+스키마 변경 없음 → Liquibase 마이그레이션 불요.
+
+
+Summary:
+- Assumptions: 10개 항목 명시(사용자 결정사항 반영)
+- Success criteria: 10개 검증 가능 조건
+- Impact: mono(8 파일 수정/신설) + admin-api(1 파일 수정) + 테스트 2종
+
+다음 단계 `/plan` 으로 Task 분해 진행 가능 여부 확인 부탁드립니다.


### PR DESCRIPTION
## Summary

- 어드민이 위스키 원산지(`Region`)를 관리할 수 있도록 CUD API 추가 (기존엔 목록 조회만 노출)
- Banner/Curation과 동일한 어드민 표준 적용: admin-api(Kotlin) 위임 / mono(Java) 비즈니스 로직, `AdminResultResponse` 반환, offset 페이징, 필드별 PATCH 분리
- 결정된 비즈니스 룰: `korName`/`engName` 각 전역 유니크, 계층 2단계 제한, 자식·연결 위스키 보유 시 삭제 금지, sortOrder 자동 reorder + `korName ASC` 보조 정렬, `continent` 자유문자열, `sort-order`만 PATCH 분리

## 신규/변경 API (`/admin/api/v1` context-path)

| Method | URL | 설명 |
|--------|-----|------|
| GET | `/regions/{regionId}` | 단건 상세 (부모 정보, 자식 보유 여부, 위스키 카운트 포함) |
| POST | `/regions` | 생성 |
| PUT | `/regions/{regionId}` | 전체 수정 |
| DELETE | `/regions/{regionId}` | 삭제 (자식·위스키 가드) |
| PATCH | `/regions/{regionId}/sort-order` | 정렬 변경 (Banner-style reorder) |
| GET | `/regions` | 기존 유지, 정렬키 `sortOrder ASC, korName ASC` 로 보정 |

## 도메인 룰

- **이름 중복 금지**: `REGION_DUPLICATE_KOR_NAME`, `REGION_DUPLICATE_ENG_NAME`
- **계층 깊이 2단계 제한**: `REGION_MAX_DEPTH_EXCEEDED` (이미 자식인 지역을 부모로 지정하거나, 자식 보유 지역을 다른 지역의 자식으로 변경 시)
- **사이클 방지**: `REGION_PARENT_CYCLE` (자기 자신 또는 자기 하위 트리를 부모로 지정 시)
- **삭제 가드**: `REGION_HAS_CHILDREN`, `REGION_HAS_ALCOHOLS`
- **정렬 reorder**: 같은 `sortOrder` 이상 모든 지역을 +1 밀어내기. 잔존 동률은 `korName ASC` 로 보조 정렬

## Test plan

- [x] `./gradlew :bottlenote-mono:test --tests AdminRegionServiceTest` — 단위 테스트 15/15 PASSED
- [x] `./gradlew :bottlenote-admin-api:admin_integration_test` — 통합 테스트 159/159 PASSED (신규 8개 + 회귀 0)
- [x] `./gradlew unit_test` — BUILD SUCCESSFUL
- [x] `./gradlew check_rule_test` — 아키텍처 규칙 통과
- [x] `./gradlew integration_test` — BUILD SUCCESSFUL
- [ ] 어드민 콘솔 연동 시 6개 엔드포인트 수동 호출 검증

## 변경 파일

- mono: 도메인 메서드(`Region.update/updateSortOrder/changeParent`), `RegionRepository`/`JpaRegionQueryRepository` CUD·exists 메서드, DTO 4종, `AdminRegionService`, 예외 코드 7건, `AdminResultResponse.ResultCode` 4건
- admin-api: `AdminRegionController.kt` 5개 엔드포인트 추가, 통합 테스트
- 테스트: `InMemoryRegionRepository`, `RegionTestFactory`
- 스키마 변경 없음 → Liquibase 마이그레이션 불요

## 계획 문서

`plan/admin-region-cud.md` 에 Assumptions·Success Criteria·Tasks·Progress Log 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)