### PR TITLE
feat: 리뷰 수정 API에서 별점도 함께 갱신

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/review/domain/Review.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/domain/Review.java
@@ -110,6 +110,7 @@ public class Review extends BaseEntity {
     this.content = reviewModifyRequestWrapperItem.getContent();
     this.sizeType = reviewModifyRequestWrapperItem.getSizeType();
     this.price = reviewModifyRequestWrapperItem.getPrice();
+    this.reviewRating = reviewModifyRequestWrapperItem.getRating();
     LocationInfoRequest locationInfoRequest = reviewModifyRequestWrapperItem.getLocationInfo();
     if (!Objects.isNull(locationInfoRequest)) {
       this.reviewLocation =

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequest.java
@@ -26,4 +26,9 @@ public record ReviewModifyRequest(
     @JsonInclude() @JsonProperty(required = true) List<ReviewImageInfoRequest> imageUrlList,
     @JsonInclude() @JsonProperty(required = true) SizeType sizeType,
     @JsonInclude() @JsonProperty(required = true) List<String> tastingTagList,
-    @Valid @JsonInclude() @JsonProperty(required = true) LocationInfoRequest locationInfo) {}
+    @Valid @JsonInclude() @JsonProperty(required = true) LocationInfoRequest locationInfo,
+    Double rating) {
+  public ReviewModifyRequest {
+    rating = rating == null ? 0.0 : rating;
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequestWrapperItem.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/review/dto/request/ReviewModifyRequestWrapperItem.java
@@ -1,5 +1,6 @@
 package app.bottlenote.review.dto.request;
 
+import app.bottlenote.rating.domain.RatingPoint;
 import app.bottlenote.review.constant.ReviewDisplayStatus;
 import app.bottlenote.review.constant.SizeType;
 import java.math.BigDecimal;
@@ -13,6 +14,7 @@ public class ReviewModifyRequestWrapperItem {
   private final BigDecimal price;
   private final SizeType sizeType;
   private final LocationInfoRequest locationInfo;
+  private final Double rating;
 
   public ReviewModifyRequestWrapperItem(
       app.bottlenote.review.dto.request.ReviewModifyRequest reviewModifyRequest) {
@@ -22,6 +24,7 @@ public class ReviewModifyRequestWrapperItem {
     this.sizeType = reviewModifyRequest.sizeType();
     this.locationInfo =
         Objects.requireNonNullElse(reviewModifyRequest.locationInfo(), LocationInfoRequest.empty());
+    this.rating = RatingPoint.of(reviewModifyRequest.rating()).getRating();
   }
 
   public static ReviewModifyRequestWrapperItem create(

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ImageResourceActivatedEventPublishTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/event/ImageResourceActivatedEventPublishTest.java
@@ -123,7 +123,7 @@ class ImageResourceActivatedEventPublishTest {
           List.of(new ReviewImageInfoRequest(1L, "https://cdn.bottlenote.com/review/new-img.jpg"));
       ReviewModifyRequest modifyRequest =
           new ReviewModifyRequest(
-              "수정된 내용", null, null, newImages, null, null, LocationInfoRequest.empty());
+              "수정된 내용", null, null, newImages, null, null, LocationInfoRequest.empty(), null);
 
       // when
       reviewService.modifyReview(modifyRequest, createResponse.getId(), 1L);

--- a/bottlenote-product-api/src/test/java/app/bottlenote/common/file/integration/ImageUploadIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/common/file/integration/ImageUploadIntegrationTest.java
@@ -521,7 +521,8 @@ class ImageUploadIntegrationTest extends IntegrationTestSupport {
                   new ReviewImageInfoRequest(2L, newImageUrl)),
               null,
               null,
-              createTestLocationInfo());
+              createTestLocationInfo(),
+              null);
 
       // when
       MvcTestResult modifyResult =
@@ -642,7 +643,8 @@ class ImageUploadIntegrationTest extends IntegrationTestSupport {
               List.of(new ReviewImageInfoRequest(1L, imageUrl1)),
               null,
               null,
-              createTestLocationInfo());
+              createTestLocationInfo(),
+              null);
 
       // when
       mockMvcTester
@@ -885,7 +887,8 @@ class ImageUploadIntegrationTest extends IntegrationTestSupport {
               List.of(new ReviewImageInfoRequest(1L, newImageUrl)),
               null,
               null,
-              createTestLocationInfo());
+              createTestLocationInfo(),
+              null);
 
       // when
       mockMvcTester

--- a/bottlenote-product-api/src/test/java/app/bottlenote/review/fixture/ReviewObjectFixture.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/review/fixture/ReviewObjectFixture.java
@@ -126,7 +126,8 @@ public class ReviewObjectFixture {
             "PUB",
             "https://map.naver.com",
             "111.111",
-            "222.222"));
+            "222.222"),
+        3.0);
   }
 
   public static ReviewModifyRequest getReviewModifyRequest(String content) {
@@ -147,15 +148,16 @@ public class ReviewObjectFixture {
             "PUB",
             "https://map.naver.com",
             "111.111",
-            "222.222"));
+            "222.222"),
+        3.0);
   }
 
   public static ReviewModifyRequest getNullableReviewModifyRequest(ReviewDisplayStatus status) {
-    return new ReviewModifyRequest("맛있어요", status, null, null, null, null, null);
+    return new ReviewModifyRequest("맛있어요", status, null, null, null, null, null, null);
   }
 
   public static ReviewModifyRequest getWrongReviewModifyRequest() {
-    return new ReviewModifyRequest(null, null, null, null, null, null, null);
+    return new ReviewModifyRequest(null, null, null, null, null, null, null, null);
   }
 
   /** 기본 ReviewCreateRequest 객체를 생성합니다. */

--- a/bottlenote-product-api/src/test/java/app/bottlenote/review/integration/ReviewIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/review/integration/ReviewIntegrationTest.java
@@ -290,6 +290,7 @@ class ReviewIntegrationTest extends IntegrationTestSupport {
       result.assertThat().hasStatusOk();
       Review savedReview = reviewRepository.findById(reviewId).orElseThrow();
       assertEquals(savedReview.getContent(), request.content());
+      assertEquals(request.rating(), savedReview.getReviewRating());
     }
 
     @DisplayName("content와 status를 제외한 필드에 null이 할당되어도 수정에 성공한다.")

--- a/bottlenote-product-api/src/test/java/app/docs/review/RestReviewControllerDocsTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/review/RestReviewControllerDocsTest.java
@@ -532,7 +532,8 @@ class RestReviewControllerDocsTest extends AbstractRestDocs {
                     fieldWithPath("imageUrlList").type(ARRAY).description("이미지 URL 목록"),
                     fieldWithPath("imageUrlList[].order").type(NUMBER).description("이미지 순서"),
                     fieldWithPath("imageUrlList[].viewUrl").type(STRING).description("이미지 뷰 URL"),
-                    fieldWithPath("tastingTagList").description("테이스팅 태그 목록 (최대 15개)").optional()),
+                    fieldWithPath("tastingTagList").description("테이스팅 태그 목록 (최대 15개)").optional(),
+                    fieldWithPath("rating").type(NUMBER).description("리뷰 시점 별점").optional()),
                 responseFields(
                     fieldWithPath("success").description("응답 성공 여부"),
                     fieldWithPath("code").description("응답 코드(http status code)"),


### PR DESCRIPTION
## Summary

- 리뷰 수정 시 `reviews.review_rating` 컬럼이 갱신되지 않던 문제를 해결 (의사결정: 수정 시점의 별점도 함께 반영)
- 정책: `ratings` 테이블은 건드리지 않고 `reviews.review_rating` 스냅샷만 갱신 (작성 API와 동일 정책)
- `rating` 누락/null 시 `0.0`으로 fallback (작성 API와 동일)

## 변경 내역

### 본 코드 (3)
- `ReviewModifyRequest`: `Double rating` 필드 추가 + null→0.0 fallback
- `ReviewModifyRequestWrapperItem`: 생성자에서 `RatingPoint.of(...)` 검증 후 보관
- `Review#update()`: `this.reviewRating = wrapper.getRating()` 추가

### 테스트 (5)
- `ReviewObjectFixture`: 4개 빌더 시그니처 갱신
- `ReviewIntegrationTest.update.test_1`: 별점 갱신 어서션 추가
- `RestReviewControllerDocsTest.review_modify_test`: `rating` 필드 문서화
- `ImageUploadIntegrationTest`, `ImageResourceActivatedEventPublishTest`: 시그니처 변경 영향 보강

## Test plan

- [x] `./gradlew compileJava compileTestJava`
- [x] `./gradlew :bottlenote-admin-api:compileKotlin :bottlenote-admin-api:compileTestKotlin`
- [x] `./gradlew check_rule_test`
- [x] `./gradlew unit_test`
- [x] `./gradlew build -x test -x asciidoctor`
- [x] `./gradlew integration_test` (3m 23s)
- [x] `./gradlew admin_integration_test` (4m 20s)