### PR TITLE
feat: 어드민 bulk reorder API 추가

### DIFF
--- a/bottlenote-admin-api/src/docs/asciidoc/api/admin-banners/banners.adoc
+++ b/bottlenote-admin-api/src/docs/asciidoc/api/admin-banners/banners.adoc
@@ -203,3 +203,55 @@ include::{snippets}/admin/banners/update-sort-order/http-request.adoc[]
 [discrete]
 include::{snippets}/admin/banners/update-sort-order/response-fields.adoc[]
 include::{snippets}/admin/banners/update-sort-order/http-response.adoc[]
+
+'''
+
+=== 배너 bulk reorder ===
+
+- 여러 배너를 한 번에 정렬 목록의 맨 앞으로 재배치합니다.
+- 기존 단건 API는 특정 배너 1개의 `sortOrder`를 지정 값으로 변경합니다.
+- bulk reorder API는 요청한 `ids`를 배열 순서대로 앞쪽 정렬 슬롯에 배정합니다.
+- 요청 ID는 1개 이상 100개 이하입니다.
+- 비활성 배너도 정렬값은 유지됩니다. `isActive=true`로 조회하면 화면에는 보이지 않아도 bulk reorder 결과로 뒤로 밀릴 수 있습니다.
+
+[source]
+----
+PATCH /admin/api/v1/banners/bulk/reorder
+----
+
+[source,json]
+----
+{ "ids": [3, 1, 6, 5] }
+----
+
+[source,text]
+----
+변경 전
+
+정렬 슬롯:   1    10    20    30    40
+          +----+-----+-----+-----+-----+
+배너 ID:  | 11 |  1  |  3  |  5  |  6  |
+          +----+-----+-----+-----+-----+
+
+변경 후
+
+정렬 슬롯:   1    10    20    30    40
+          +----+-----+-----+-----+-----+
+배너 ID:  |  3 |  1  |  6  |  5  | 11  |
+          +----+-----+-----+-----+-----+
+----
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/banners/bulk-reorder/request-fields.adoc[]
+include::{snippets}/admin/banners/bulk-reorder/curl-request.adoc[]
+include::{snippets}/admin/banners/bulk-reorder/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/banners/bulk-reorder/response-fields.adoc[]
+include::{snippets}/admin/banners/bulk-reorder/http-response.adoc[]

--- a/bottlenote-admin-api/src/docs/asciidoc/api/admin-curations/curations.adoc
+++ b/bottlenote-admin-api/src/docs/asciidoc/api/admin-curations/curations.adoc
@@ -203,6 +203,58 @@ include::{snippets}/admin/curations/update-display-order/http-response.adoc[]
 
 '''
 
+=== 큐레이션 bulk reorder ===
+
+- 여러 큐레이션을 한 번에 정렬 목록의 맨 앞으로 재배치합니다.
+- 기존 단건 API는 특정 큐레이션 1개의 `displayOrder`를 지정 값으로 변경합니다.
+- bulk reorder API는 요청한 `ids`를 배열 순서대로 앞쪽 정렬 슬롯에 배정합니다.
+- 요청 ID는 1개 이상 100개 이하입니다.
+- 비활성 또는 미노출 큐레이션도 정렬값은 유지됩니다. 활성 큐레이션만 조회하면 `displayOrder`가 `1,3,5`처럼 연속되지 않아 보일 수 있습니다.
+
+[source]
+----
+PATCH /admin/api/v1/curations/bulk/reorder
+----
+
+[source,json]
+----
+{ "ids": [3, 1, 6, 5] }
+----
+
+[source,text]
+----
+변경 전
+
+정렬 슬롯:      1    10    20    30    40
+             +----+-----+-----+-----+-----+
+큐레이션 ID: | 11 |  1  |  3  |  5  |  6  |
+             +----+-----+-----+-----+-----+
+
+변경 후
+
+정렬 슬롯:      1    10    20    30    40
+             +----+-----+-----+-----+-----+
+큐레이션 ID: |  3 |  1  |  6  |  5  | 11  |
+             +----+-----+-----+-----+-----+
+----
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/curations/bulk-reorder/request-fields.adoc[]
+include::{snippets}/admin/curations/bulk-reorder/curl-request.adoc[]
+include::{snippets}/admin/curations/bulk-reorder/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/curations/bulk-reorder/response-fields.adoc[]
+include::{snippets}/admin/curations/bulk-reorder/http-response.adoc[]
+
+'''
+
 === 큐레이션에 위스키 추가 ===
 
 - 큐레이션에 위스키를 벌크로 추가합니다.

--- a/bottlenote-admin-api/src/docs/asciidoc/api/admin-reference/reference.adoc
+++ b/bottlenote-admin-api/src/docs/asciidoc/api/admin-reference/reference.adoc
@@ -24,6 +24,95 @@ include::{snippets}/admin/regions/list/http-response.adoc[]
 
 '''
 
+=== 지역 bulk reorder ===
+
+- 전체 지역 목록에서 요청한 지역을 맨 앞 정렬 슬롯으로 재배치합니다.
+- 요청 ID는 1개 이상 100개 이하입니다.
+- 전체 지역 정렬과 특정 부모의 자식 지역 정렬은 scope가 다르므로 API를 분리합니다.
+
+[source]
+----
+PATCH /admin/api/v1/regions/bulk/reorder
+----
+
+[source,json]
+----
+{ "ids": [3, 1, 6, 5] }
+----
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/regions/bulk-reorder/request-fields.adoc[]
+include::{snippets}/admin/regions/bulk-reorder/curl-request.adoc[]
+include::{snippets}/admin/regions/bulk-reorder/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/regions/bulk-reorder/response-fields.adoc[]
+include::{snippets}/admin/regions/bulk-reorder/http-response.adoc[]
+
+'''
+
+=== 자식 지역 bulk reorder ===
+
+- 특정 부모 지역의 직접 자식 지역만 맨 앞 정렬 슬롯으로 재배치합니다.
+- `{parentId}`의 직접 자식이 아닌 지역 ID가 포함되면 실패합니다.
+
+[source]
+----
+PATCH /admin/api/v1/regions/{parentId}/children/bulk/reorder
+----
+
+[source,text]
+----
+부모 지역 ID = 1
+
+변경 전
+
+정렬 슬롯:       1    10    20    30
+              +----+-----+-----+-----+
+자식 지역 ID: | 11 |  1  |  3  |  5  |
+              +----+-----+-----+-----+
+
+요청
+
+{ "ids": [3, 1] }
+
+변경 후
+
+정렬 슬롯:       1    10    20    30
+              +----+-----+-----+-----+
+자식 지역 ID: |  3 |  1  | 11  |  5  |
+              +----+-----+-----+-----+
+----
+
+[discrete]
+==== 경로 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/regions/children-bulk-reorder/path-parameters.adoc[]
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/regions/children-bulk-reorder/request-fields.adoc[]
+include::{snippets}/admin/regions/children-bulk-reorder/curl-request.adoc[]
+include::{snippets}/admin/regions/children-bulk-reorder/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/regions/children-bulk-reorder/response-fields.adoc[]
+include::{snippets}/admin/regions/children-bulk-reorder/http-response.adoc[]
+
+'''
+
 === 증류소 목록 조회 ===
 
 - 전체 증류소 목록을 조회합니다.
@@ -47,3 +136,53 @@ include::{snippets}/admin/distilleries/list/http-request.adoc[]
 [discrete]
 include::{snippets}/admin/distilleries/list/response-fields.adoc[]
 include::{snippets}/admin/distilleries/list/http-response.adoc[]
+
+'''
+
+=== 증류소 bulk reorder ===
+
+- 전체 증류소 목록에서 요청한 증류소를 맨 앞 정렬 슬롯으로 재배치합니다.
+- 요청 ID는 1개 이상 100개 이하입니다.
+- 기존 단건 정렬 API는 특정 증류소 1개의 `sortOrder`를 지정 값으로 변경하고, bulk reorder는 여러 증류소의 상대 순서를 한 번에 저장합니다.
+
+[source]
+----
+PATCH /admin/api/v1/distilleries/bulk/reorder
+----
+
+[source,json]
+----
+{ "ids": [3, 1, 6, 5] }
+----
+
+[source,text]
+----
+변경 전
+
+정렬 슬롯:    1    10    20    30    40
+           +----+-----+-----+-----+-----+
+증류소 ID: | 11 |  1  |  3  |  5  |  6  |
+           +----+-----+-----+-----+-----+
+
+변경 후
+
+정렬 슬롯:    1    10    20    30    40
+           +----+-----+-----+-----+-----+
+증류소 ID: |  3 |  1  |  6  |  5  | 11  |
+           +----+-----+-----+-----+-----+
+----
+
+[discrete]
+==== 요청 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/distilleries/bulk-reorder/request-fields.adoc[]
+include::{snippets}/admin/distilleries/bulk-reorder/curl-request.adoc[]
+include::{snippets}/admin/distilleries/bulk-reorder/http-request.adoc[]
+
+[discrete]
+==== 응답 파라미터 ====
+
+[discrete]
+include::{snippets}/admin/distilleries/bulk-reorder/response-fields.adoc[]
+include::{snippets}/admin/distilleries/bulk-reorder/http-response.adoc[]

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminCurationController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminCurationController.kt
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.presentation
 import app.bottlenote.alcohols.dto.request.*
 import app.bottlenote.alcohols.service.AdminCurationService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -49,6 +50,11 @@ class AdminCurationController(
 		@PathVariable curationId: Long,
 		@RequestBody @Valid request: AdminCurationDisplayOrderRequest
 	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.updateDisplayOrder(curationId, request))
+
+	@PatchMapping("/bulk/reorder")
+	fun reorder(
+		@RequestBody @Valid request: AdminBulkReorderRequest
+	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.reorder(request))
 
 	@PostMapping("/{curationId}/alcohols")
 	fun addAlcohols(

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminDistilleryController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminDistilleryController.kt
@@ -6,6 +6,7 @@ import app.bottlenote.alcohols.dto.request.AdminReferenceSearchRequest
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.alcohols.service.DistilleryService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -56,4 +57,9 @@ class AdminDistilleryController(
 		@PathVariable distilleryId: Long,
 		@RequestBody @Valid request: AdminDistillerySortOrderRequest
 	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.updateSortOrder(distilleryId, request))
+
+	@PatchMapping("/bulk/reorder")
+	fun reorder(
+		@RequestBody @Valid request: AdminBulkReorderRequest
+	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.reorder(request))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt
@@ -7,6 +7,7 @@ import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest
 import app.bottlenote.alcohols.service.AdminRegionService
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -57,4 +58,15 @@ class AdminRegionController(
 		@PathVariable regionId: Long,
 		@RequestBody @Valid request: AdminRegionSortOrderRequest
 	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.updateSortOrder(regionId, request))
+
+	@PatchMapping("/bulk/reorder")
+	fun reorder(
+		@RequestBody @Valid request: AdminBulkReorderRequest
+	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.reorder(request))
+
+	@PatchMapping("/{parentId}/children/bulk/reorder")
+	fun reorderChildren(
+		@PathVariable parentId: Long,
+		@RequestBody @Valid request: AdminBulkReorderRequest
+	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.reorderChildren(parentId, request))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/banner/presentation/AdminBannerController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/banner/presentation/AdminBannerController.kt
@@ -3,6 +3,7 @@ package app.bottlenote.banner.presentation
 import app.bottlenote.banner.dto.request.*
 import app.bottlenote.banner.service.AdminBannerService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -49,4 +50,9 @@ class AdminBannerController(
 		@PathVariable bannerId: Long,
 		@RequestBody @Valid request: AdminBannerSortOrderRequest
 	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.updateSortOrder(bannerId, request))
+
+	@PatchMapping("/bulk/reorder")
+	fun reorder(
+		@RequestBody @Valid request: AdminBulkReorderRequest
+	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.reorder(request))
 }

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminDistilleryControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminDistilleryControllerDocsTest.kt
@@ -8,6 +8,7 @@ import app.bottlenote.alcohols.presentation.AdminDistilleryController
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.alcohols.service.DistilleryService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
 import app.bottlenote.global.dto.response.AdminResultResponse
 import app.bottlenote.global.dto.response.AdminResultResponse.ResultCode
 import app.helper.alcohols.AlcoholsHelper
@@ -246,6 +247,31 @@ class AdminDistilleryControllerDocsTest {
 	}
 
 	@Test
+	@DisplayName("증류소 목록을 bulk reorder 할 수 있다")
+	fun reorderDistilleries() {
+		val result = AdminResultResponse.of(ResultCode.DISTILLERY_SORT_ORDER_UPDATED, null)
+		given(distilleryService.reorder(any(AdminBulkReorderRequest::class.java))).willReturn(result)
+		val request = mapOf("ids" to listOf(3L, 1L, 6L, 5L))
+
+		assertThat(
+			mvc.patch().uri("/v1/distilleries/bulk/reorder")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request))
+		).hasStatusOk()
+			.apply(
+				document(
+					"admin/distilleries/bulk-reorder",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestFields(
+						fieldWithPath("ids").type(JsonFieldType.ARRAY).description("맨 앞 구간으로 올릴 증류소 ID 목록 (1~100개). 배열 순서가 최종 상대 순서입니다")
+					),
+					responseFields(bulkReorderResponseFields())
+				)
+			)
+	}
+
+	@Test
 	@DisplayName("증류소를 삭제할 수 있다")
 	fun deleteDistillery() {
 		val result = AdminResultResponse.of(ResultCode.DISTILLERY_DELETED, 1L)
@@ -271,6 +297,21 @@ class AdminDistilleryControllerDocsTest {
 		fieldWithPath("data.code").type(JsonFieldType.STRING).description("처리 결과 코드"),
 		fieldWithPath("data.message").type(JsonFieldType.STRING).description("처리 결과 메시지"),
 		fieldWithPath("data.targetId").type(JsonFieldType.NUMBER).description("대상 증류소 ID"),
+		fieldWithPath("data.responseAt").type(JsonFieldType.STRING).description("응답 시각"),
+		fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+		fieldWithPath("meta").type(JsonFieldType.OBJECT).description("메타 정보").ignored(),
+		fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).description("서버 버전").ignored(),
+		fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).description("서버 인코딩").ignored(),
+		fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).description("서버 응답 시간").ignored(),
+		fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).description("API 경로 버전").ignored()
+	)
+
+	private fun bulkReorderResponseFields() = listOf(
+		fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+		fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+		fieldWithPath("data.code").type(JsonFieldType.STRING).description("처리 결과 코드"),
+		fieldWithPath("data.message").type(JsonFieldType.STRING).description("처리 결과 메시지"),
+		fieldWithPath("data.targetId").type(JsonFieldType.NULL).description("bulk reorder는 단일 대상 ID를 반환하지 않습니다").optional(),
 		fieldWithPath("data.responseAt").type(JsonFieldType.STRING).description("응답 시각"),
 		fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
 		fieldWithPath("meta").type(JsonFieldType.OBJECT).description("메타 정보").ignored(),

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminRegionControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminRegionControllerDocsTest.kt
@@ -5,24 +5,31 @@ import app.bottlenote.alcohols.presentation.AdminRegionController
 import app.bottlenote.alcohols.service.AdminRegionService
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
+import app.bottlenote.global.dto.response.AdminResultResponse
 import app.helper.alcohols.AlcoholsHelper
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.data.domain.PageImpl
+import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.operation.preprocess.Preprocessors.*
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.assertj.MockMvcTester
@@ -38,6 +45,9 @@ class AdminRegionControllerDocsTest {
 
 	@Autowired
 	private lateinit var mvc: MockMvcTester
+
+	@Autowired
+	private lateinit var mapper: ObjectMapper
 
 	@MockitoBean
 	private lateinit var alcoholReferenceService: AlcoholReferenceService
@@ -100,4 +110,70 @@ class AdminRegionControllerDocsTest {
 				)
 			)
 	}
+
+	@Test
+	@DisplayName("전체 지역 목록을 bulk reorder 할 수 있다")
+	fun reorderRegions() {
+		val result = AdminResultResponse.of(AdminResultResponse.ResultCode.REGION_SORT_ORDER_UPDATED, null)
+		given(adminRegionService.reorder(any(AdminBulkReorderRequest::class.java))).willReturn(result)
+		val request = mapOf("ids" to listOf(3L, 1L, 6L, 5L))
+
+		assertThat(
+			mvc.patch().uri("/v1/regions/bulk/reorder")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request))
+		).hasStatusOk()
+			.apply(
+				document(
+					"admin/regions/bulk-reorder",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestFields(
+						fieldWithPath("ids").type(JsonFieldType.ARRAY).description("맨 앞 구간으로 올릴 지역 ID 목록 (1~100개). 배열 순서가 최종 상대 순서입니다")
+					),
+					responseFields(bulkReorderResponseFields())
+				)
+			)
+	}
+
+	@Test
+	@DisplayName("자식 지역 목록을 bulk reorder 할 수 있다")
+	fun reorderChildRegions() {
+		val result = AdminResultResponse.of(AdminResultResponse.ResultCode.REGION_SORT_ORDER_UPDATED, 1L)
+		given(adminRegionService.reorderChildren(anyLong(), any(AdminBulkReorderRequest::class.java))).willReturn(result)
+		val request = mapOf("ids" to listOf(30L, 10L, 60L, 50L))
+
+		assertThat(
+			mvc.patch().uri("/v1/regions/{parentId}/children/bulk/reorder", 1L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(mapper.writeValueAsString(request))
+		).hasStatusOk()
+			.apply(
+				document(
+					"admin/regions/children-bulk-reorder",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					pathParameters(parameterWithName("parentId").description("부모 지역 ID")),
+					requestFields(
+						fieldWithPath("ids").type(JsonFieldType.ARRAY).description("맨 앞 구간으로 올릴 직접 자식 지역 ID 목록 (1~100개). 배열 순서가 최종 상대 순서입니다")
+					),
+					responseFields(bulkReorderResponseFields())
+				)
+			)
+	}
+
+	private fun bulkReorderResponseFields() = listOf(
+		fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+		fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+		fieldWithPath("data.code").type(JsonFieldType.STRING).description("처리 결과 코드"),
+		fieldWithPath("data.message").type(JsonFieldType.STRING).description("처리 결과 메시지"),
+		fieldWithPath("data.targetId").type(JsonFieldType.VARIES).description("대상 ID. 전체 bulk reorder는 null, 자식 지역 bulk reorder는 parentId"),
+		fieldWithPath("data.responseAt").type(JsonFieldType.STRING).description("응답 시각"),
+		fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+		fieldWithPath("meta").type(JsonFieldType.OBJECT).description("메타 정보").ignored(),
+		fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).description("서버 버전").ignored(),
+		fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).description("서버 인코딩").ignored(),
+		fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).description("서버 응답 시간").ignored(),
+		fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).description("API 경로 버전").ignored()
+	)
 }

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/banner/AdminBannerControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/banner/AdminBannerControllerDocsTest.kt
@@ -8,6 +8,7 @@ import app.bottlenote.banner.dto.request.AdminBannerUpdateRequest
 import app.bottlenote.banner.presentation.AdminBannerController
 import app.bottlenote.banner.service.AdminBannerService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
 import app.bottlenote.global.dto.response.AdminResultResponse
 import app.helper.banner.BannerHelper
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -432,6 +433,53 @@ class AdminBannerControllerDocsTest {
 							fieldWithPath("data.code").type(JsonFieldType.STRING).description("결과 코드"),
 							fieldWithPath("data.message").type(JsonFieldType.STRING).description("결과 메시지"),
 							fieldWithPath("data.targetId").type(JsonFieldType.NUMBER).description("배너 ID"),
+							fieldWithPath("data.responseAt").type(JsonFieldType.STRING).description("응답 시간"),
+							fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+							fieldWithPath("meta").type(JsonFieldType.OBJECT).description("메타 정보"),
+							fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).ignored(),
+							fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).ignored()
+						)
+					)
+				)
+		}
+	}
+
+	@Nested
+	@DisplayName("배너 bulk reorder")
+	inner class ReorderBanners {
+
+		@Test
+		@DisplayName("배너 목록을 bulk reorder 할 수 있다")
+		fun reorder() {
+			val request = mapOf("ids" to listOf(3L, 1L, 6L, 5L))
+			val response = AdminResultResponse.of(AdminResultResponse.ResultCode.BANNER_SORT_ORDER_UPDATED, null)
+
+			given(adminBannerService.reorder(any(AdminBulkReorderRequest::class.java)))
+				.willReturn(response)
+
+			assertThat(
+				mvc.patch().uri("/v1/banners/bulk/reorder")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+				.hasStatusOk()
+				.apply(
+					document(
+						"admin/banners/bulk-reorder",
+						preprocessRequest(prettyPrint()),
+						preprocessResponse(prettyPrint()),
+						requestFields(
+							fieldWithPath("ids").type(JsonFieldType.ARRAY).description("맨 앞 구간으로 올릴 배너 ID 목록 (1~100개). 배열 순서가 최종 상대 순서입니다")
+						),
+						responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+							fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+							fieldWithPath("data").type(JsonFieldType.OBJECT).description("결과 정보"),
+							fieldWithPath("data.code").type(JsonFieldType.STRING).description("결과 코드"),
+							fieldWithPath("data.message").type(JsonFieldType.STRING).description("결과 메시지"),
+							fieldWithPath("data.targetId").type(JsonFieldType.NULL).description("bulk reorder는 단일 대상 ID를 반환하지 않습니다").optional(),
 							fieldWithPath("data.responseAt").type(JsonFieldType.STRING).description("응답 시간"),
 							fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
 							fieldWithPath("meta").type(JsonFieldType.OBJECT).description("메타 정보"),

--- a/bottlenote-admin-api/src/test/kotlin/app/docs/curation/AdminCurationControllerDocsTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/docs/curation/AdminCurationControllerDocsTest.kt
@@ -4,6 +4,7 @@ import app.bottlenote.alcohols.dto.request.*
 import app.bottlenote.alcohols.presentation.AdminCurationController
 import app.bottlenote.alcohols.service.AdminCurationService
 import app.bottlenote.global.data.response.GlobalResponse
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest
 import app.bottlenote.global.dto.response.AdminResultResponse
 import app.helper.curation.CurationHelper
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -46,6 +47,22 @@ class AdminCurationControllerDocsTest {
 
 	@MockitoBean
 	private lateinit var adminCurationService: AdminCurationService
+
+	private fun bulkReorderResponseFields() = responseFields(
+		fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+		fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+		fieldWithPath("data").type(JsonFieldType.OBJECT).description("결과 정보"),
+		fieldWithPath("data.code").type(JsonFieldType.STRING).description("결과 코드"),
+		fieldWithPath("data.message").type(JsonFieldType.STRING).description("결과 메시지"),
+		fieldWithPath("data.targetId").type(JsonFieldType.NULL).description("bulk reorder는 단일 대상 ID를 반환하지 않습니다").optional(),
+		fieldWithPath("data.responseAt").type(JsonFieldType.STRING).description("응답 시간"),
+		fieldWithPath("errors").type(JsonFieldType.ARRAY).description("에러 목록"),
+		fieldWithPath("meta").type(JsonFieldType.OBJECT).description("메타 정보"),
+		fieldWithPath("meta.serverVersion").type(JsonFieldType.STRING).ignored(),
+		fieldWithPath("meta.serverEncoding").type(JsonFieldType.STRING).ignored(),
+		fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).ignored(),
+		fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).ignored()
+	)
 
 	@Nested
 	@DisplayName("큐레이션 목록 조회")
@@ -100,6 +117,39 @@ class AdminCurationControllerDocsTest {
 							fieldWithPath("meta.serverResponseTime").type(JsonFieldType.STRING).ignored(),
 							fieldWithPath("meta.serverPathVersion").type(JsonFieldType.STRING).ignored()
 						)
+					)
+				)
+		}
+	}
+
+	@Nested
+	@DisplayName("큐레이션 bulk reorder")
+	inner class ReorderCurations {
+
+		@Test
+		@DisplayName("큐레이션 목록을 bulk reorder 할 수 있다")
+		fun reorder() {
+			val request = mapOf("ids" to listOf(3L, 1L, 6L, 5L))
+			val response = AdminResultResponse.of(AdminResultResponse.ResultCode.CURATION_DISPLAY_ORDER_UPDATED, null)
+
+			given(adminCurationService.reorder(any(AdminBulkReorderRequest::class.java)))
+				.willReturn(response)
+
+			assertThat(
+				mvc.patch().uri("/v1/curations/bulk/reorder")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			)
+				.hasStatusOk()
+				.apply(
+					document(
+						"admin/curations/bulk-reorder",
+						preprocessRequest(prettyPrint()),
+						preprocessResponse(prettyPrint()),
+						requestFields(
+							fieldWithPath("ids").type(JsonFieldType.ARRAY).description("맨 앞 구간으로 올릴 큐레이션 ID 목록 (1~100개). 배열 순서가 최종 상대 순서입니다")
+						),
+						bulkReorderResponseFields()
 					)
 				)
 		}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/CurationKeywordRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/CurationKeywordRepository.java
@@ -5,6 +5,7 @@ import app.bottlenote.alcohols.dto.response.AdminCurationListResponse;
 import app.bottlenote.alcohols.dto.response.AlcoholsSearchItem;
 import app.bottlenote.alcohols.dto.response.CurationKeywordResponse;
 import app.bottlenote.global.service.cursor.CursorResponse;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.domain.Page;
@@ -31,6 +32,8 @@ public interface CurationKeywordRepository {
   void delete(CurationKeyword curationKeyword);
 
   boolean existsByName(String name);
+
+  List<CurationKeyword> findAllOrderByDisplayOrderAsc();
 
   Page<AdminCurationListResponse> searchForAdmin(
       AdminCurationSearchRequest request, Pageable pageable);

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/DistilleryRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/DistilleryRepository.java
@@ -25,4 +25,6 @@ public interface DistilleryRepository {
   boolean existsByEngNameAndIdNot(String engName, Long id);
 
   List<Distillery> findAllBySortOrderGreaterThanEqual(int sortOrder);
+
+  List<Distillery> findAllOrderBySortOrderAsc();
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/RegionRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/RegionRepository.java
@@ -34,6 +34,10 @@ public interface RegionRepository {
 
   List<Region> findAllBySortOrderGreaterThanEqual(int sortOrder);
 
+  List<Region> findAllOrderBySortOrderAsc();
+
+  List<Region> findAllByParentIdOrderBySortOrderAsc(Long parentId);
+
   boolean existsAlcoholByRegionId(Long regionId);
 
   long countAlcoholsByRegionId(Long regionId);

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/exception/AlcoholExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/exception/AlcoholExceptionCode.java
@@ -21,13 +21,17 @@ public enum AlcoholExceptionCode implements ExceptionCode {
   CURATION_NOT_FOUND(HttpStatus.NOT_FOUND, "큐레이션을 찾을 수 없습니다."),
   CURATION_DUPLICATE_NAME(HttpStatus.CONFLICT, "동일한 이름의 큐레이션이 이미 존재합니다."),
   CURATION_ALCOHOL_NOT_INCLUDED(HttpStatus.BAD_REQUEST, "해당 위스키가 큐레이션에 포함되어 있지 않습니다."),
+  CURATION_REORDER_DUPLICATE_ID(HttpStatus.BAD_REQUEST, "중복된 큐레이션 ID로 정렬을 요청할 수 없습니다."),
+  DISTILLERY_REORDER_DUPLICATE_ID(HttpStatus.BAD_REQUEST, "중복된 증류소 ID로 정렬을 요청할 수 없습니다."),
   REGION_DUPLICATE_KOR_NAME(HttpStatus.CONFLICT, "동일한 한글 이름의 지역이 이미 존재합니다."),
   REGION_DUPLICATE_ENG_NAME(HttpStatus.CONFLICT, "동일한 영문 이름의 지역이 이미 존재합니다."),
   REGION_HAS_CHILDREN(HttpStatus.CONFLICT, "자식 지역이 존재하는 지역은 삭제할 수 없습니다."),
   REGION_HAS_ALCOHOLS(HttpStatus.CONFLICT, "연결된 위스키가 존재하는 지역은 삭제할 수 없습니다."),
   REGION_PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 지역을 찾을 수 없습니다."),
   REGION_PARENT_CYCLE(HttpStatus.BAD_REQUEST, "자기 자신 또는 하위 지역을 부모로 지정할 수 없습니다."),
-  REGION_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "지역 계층 구조는 최대 2단계까지 가능합니다.");
+  REGION_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "지역 계층 구조는 최대 2단계까지 가능합니다."),
+  REGION_REORDER_DUPLICATE_ID(HttpStatus.BAD_REQUEST, "중복된 지역 ID로 정렬을 요청할 수 없습니다."),
+  REGION_REORDER_SCOPE_MISMATCH(HttpStatus.BAD_REQUEST, "부모 지역이 다른 지역은 함께 정렬할 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaCurationKeywordRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaCurationKeywordRepository.java
@@ -2,7 +2,9 @@ package app.bottlenote.alcohols.repository;
 
 import app.bottlenote.alcohols.domain.CurationKeyword;
 import app.bottlenote.alcohols.domain.CurationKeywordRepository;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +14,8 @@ public interface JpaCurationKeywordRepository
         CustomCurationKeywordRepository {
 
   boolean existsByName(String name);
+
+  @Override
+  @Query("select c from curation_keyword c order by c.displayOrder asc, c.id asc")
+  List<CurationKeyword> findAllOrderByDisplayOrderAsc();
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaDistilleryRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaDistilleryRepository.java
@@ -33,4 +33,8 @@ public interface JpaDistilleryRepository
   @Override
   @Query("select d from distillery d where d.sortOrder >= :sortOrder")
   List<Distillery> findAllBySortOrderGreaterThanEqual(@Param("sortOrder") int sortOrder);
+
+  @Override
+  @Query("select d from distillery d order by d.sortOrder asc, d.id asc")
+  List<Distillery> findAllOrderBySortOrderAsc();
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaRegionQueryRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaRegionQueryRepository.java
@@ -63,6 +63,14 @@ public interface JpaRegionQueryRepository extends RegionRepository, CrudReposito
   List<Region> findAllBySortOrderGreaterThanEqual(@Param("sortOrder") int sortOrder);
 
   @Override
+  @Query("select r from region r order by r.sortOrder asc, r.id asc")
+  List<Region> findAllOrderBySortOrderAsc();
+
+  @Override
+  @Query("select r from region r where r.parent.id = :parentId order by r.sortOrder asc, r.id asc")
+  List<Region> findAllByParentIdOrderBySortOrderAsc(@Param("parentId") Long parentId);
+
+  @Override
   @Query(
       "select case when count(a) > 0 then true else false end from alcohol a where a.region.id = :regionId")
   boolean existsAlcoholByRegionId(@Param("regionId") Long regionId);

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminCurationService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminCurationService.java
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.service;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.CURATION_ALCOHOL_NOT_INCLUDED;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.CURATION_DUPLICATE_NAME;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.CURATION_NOT_FOUND;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.CURATION_REORDER_DUPLICATE_ID;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.CURATION_ALCOHOL_ADDED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.CURATION_ALCOHOL_REMOVED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.CURATION_CREATED;
@@ -24,10 +25,15 @@ import app.bottlenote.alcohols.dto.response.AdminAlcoholItem;
 import app.bottlenote.alcohols.dto.response.AdminCurationDetailResponse;
 import app.bottlenote.alcohols.exception.AlcoholException;
 import app.bottlenote.global.data.response.GlobalResponse;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
 import app.bottlenote.global.dto.response.AdminResultResponse;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -154,6 +160,33 @@ public class AdminCurationService {
   }
 
   @Transactional
+  public AdminResultResponse reorder(AdminBulkReorderRequest request) {
+    validateReorderIds(request.ids());
+
+    List<CurationKeyword> orderedCurations =
+        curationKeywordRepository.findAllOrderByDisplayOrderAsc();
+    Map<Long, CurationKeyword> curationById =
+        orderedCurations.stream()
+            .collect(Collectors.toMap(CurationKeyword::getId, Function.identity()));
+
+    Set<Long> requestedIds = new HashSet<>(request.ids());
+    List<CurationKeyword> reordered =
+        new ArrayList<>(
+            request.ids().stream().map(id -> findReorderTarget(curationById, id)).toList());
+    reordered.addAll(
+        orderedCurations.stream()
+            .filter(curation -> !requestedIds.contains(curation.getId()))
+            .toList());
+
+    List<Integer> slots =
+        orderedCurations.stream().map(CurationKeyword::getDisplayOrder).sorted().toList();
+    for (int i = 0; i < reordered.size(); i++) {
+      reordered.get(i).updateDisplayOrder(slots.get(i));
+    }
+    return AdminResultResponse.of(CURATION_DISPLAY_ORDER_UPDATED, null);
+  }
+
+  @Transactional
   public AdminResultResponse addAlcohols(Long curationId, AdminCurationAlcoholRequest request) {
     CurationKeyword curation =
         curationKeywordRepository
@@ -177,5 +210,20 @@ public class AdminCurationService {
 
     curation.removeAlcohol(alcoholId);
     return AdminResultResponse.of(CURATION_ALCOHOL_REMOVED, curationId);
+  }
+
+  private void validateReorderIds(List<Long> ids) {
+    if (new HashSet<>(ids).size() != ids.size()) {
+      throw new AlcoholException(CURATION_REORDER_DUPLICATE_ID);
+    }
+  }
+
+  private CurationKeyword findReorderTarget(
+      Map<Long, CurationKeyword> curationById, Long curationId) {
+    CurationKeyword curation = curationById.get(curationId);
+    if (curation == null) {
+      throw new AlcoholException(CURATION_NOT_FOUND);
+    }
+    return curation;
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java
@@ -8,6 +8,8 @@ import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_MAX_
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_NOT_FOUND;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_PARENT_CYCLE;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_PARENT_NOT_FOUND;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_REORDER_DUPLICATE_ID;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_REORDER_SCOPE_MISMATCH;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.REGION_CREATED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.REGION_DELETED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.REGION_SORT_ORDER_UPDATED;
@@ -20,8 +22,16 @@ import app.bottlenote.alcohols.dto.request.AdminRegionSortOrderRequest;
 import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest;
 import app.bottlenote.alcohols.dto.response.AdminRegionDetailResponse;
 import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.alcohols.exception.AlcoholExceptionCode;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
 import app.bottlenote.global.dto.response.AdminResultResponse;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -142,6 +152,27 @@ public class AdminRegionService {
     return AdminResultResponse.of(REGION_SORT_ORDER_UPDATED, regionId);
   }
 
+  @Transactional
+  public AdminResultResponse reorder(AdminBulkReorderRequest request) {
+    validateReorderIds(request.ids());
+    reorderInScope(request.ids(), regionRepository.findAllOrderBySortOrderAsc(), REGION_NOT_FOUND);
+    return AdminResultResponse.of(REGION_SORT_ORDER_UPDATED, null);
+  }
+
+  @Transactional
+  public AdminResultResponse reorderChildren(Long parentId, AdminBulkReorderRequest request) {
+    validateReorderIds(request.ids());
+    regionRepository
+        .findById(parentId)
+        .orElseThrow(() -> new AlcoholException(REGION_PARENT_NOT_FOUND));
+
+    reorderInScope(
+        request.ids(),
+        regionRepository.findAllByParentIdOrderBySortOrderAsc(parentId),
+        REGION_REORDER_SCOPE_MISMATCH);
+    return AdminResultResponse.of(REGION_SORT_ORDER_UPDATED, parentId);
+  }
+
   private void validateUniqueNames(String korName, String engName, Long excludeId) {
     boolean korDuplicated =
         excludeId == null
@@ -198,5 +229,37 @@ public class AdminRegionService {
     conflicting.stream()
         .filter(r -> excludeRegionId == null || !r.getId().equals(excludeRegionId))
         .forEach(r -> r.updateSortOrder(r.getSortOrder() + 1));
+  }
+
+  private void validateReorderIds(List<Long> ids) {
+    if (new HashSet<>(ids).size() != ids.size()) {
+      throw new AlcoholException(REGION_REORDER_DUPLICATE_ID);
+    }
+  }
+
+  private void reorderInScope(
+      List<Long> ids, List<Region> orderedRegions, AlcoholExceptionCode notFoundCode) {
+    Map<Long, Region> regionById =
+        orderedRegions.stream().collect(Collectors.toMap(Region::getId, Function.identity()));
+    Set<Long> requestedIds = new HashSet<>(ids);
+    List<Region> reordered =
+        new ArrayList<>(
+            ids.stream().map(id -> findReorderTarget(regionById, id, notFoundCode)).toList());
+    reordered.addAll(
+        orderedRegions.stream().filter(region -> !requestedIds.contains(region.getId())).toList());
+
+    List<Integer> slots = orderedRegions.stream().map(Region::getSortOrder).sorted().toList();
+    for (int i = 0; i < reordered.size(); i++) {
+      reordered.get(i).updateSortOrder(slots.get(i));
+    }
+  }
+
+  private Region findReorderTarget(
+      Map<Long, Region> regionById, Long regionId, AlcoholExceptionCode notFoundCode) {
+    Region region = regionById.get(regionId);
+    if (region == null) {
+      throw new AlcoholException(notFoundCode);
+    }
+    return region;
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/DistilleryService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/DistilleryService.java
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.service;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.DISTILLERY_DUPLICATE_NAME;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.DISTILLERY_HAS_ALCOHOLS;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.DISTILLERY_NOT_FOUND;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.DISTILLERY_REORDER_DUPLICATE_ID;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.DISTILLERY_CREATED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.DISTILLERY_DELETED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.DISTILLERY_SORT_ORDER_UPDATED;
@@ -15,8 +16,15 @@ import app.bottlenote.alcohols.dto.request.AdminDistillerySortOrderRequest;
 import app.bottlenote.alcohols.dto.request.AdminDistilleryUpsertRequest;
 import app.bottlenote.alcohols.dto.response.AdminDistilleryItem;
 import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
 import app.bottlenote.global.dto.response.AdminResultResponse;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -113,6 +121,32 @@ public class DistilleryService {
     return AdminResultResponse.of(DISTILLERY_SORT_ORDER_UPDATED, distilleryId);
   }
 
+  @Transactional
+  public AdminResultResponse reorder(AdminBulkReorderRequest request) {
+    validateReorderIds(request.ids());
+
+    List<Distillery> orderedDistilleries = distilleryRepository.findAllOrderBySortOrderAsc();
+    Map<Long, Distillery> distilleryById =
+        orderedDistilleries.stream()
+            .collect(Collectors.toMap(Distillery::getId, Function.identity()));
+
+    Set<Long> requestedIds = new HashSet<>(request.ids());
+    List<Distillery> reordered =
+        new ArrayList<>(
+            request.ids().stream().map(id -> findReorderTarget(distilleryById, id)).toList());
+    reordered.addAll(
+        orderedDistilleries.stream()
+            .filter(distillery -> !requestedIds.contains(distillery.getId()))
+            .toList());
+
+    List<Integer> slots =
+        orderedDistilleries.stream().map(Distillery::getSortOrder).sorted().toList();
+    for (int i = 0; i < reordered.size(); i++) {
+      reordered.get(i).updateSortOrder(slots.get(i));
+    }
+    return AdminResultResponse.of(DISTILLERY_SORT_ORDER_UPDATED, null);
+  }
+
   private void reorderSortOrders(Integer newSortOrder, Long excludeDistilleryId) {
     if (newSortOrder == null) {
       return;
@@ -122,6 +156,20 @@ public class DistilleryService {
     conflicting.stream()
         .filter(d -> excludeDistilleryId == null || !d.getId().equals(excludeDistilleryId))
         .forEach(d -> d.updateSortOrder(d.getSortOrder() + 1));
+  }
+
+  private void validateReorderIds(List<Long> ids) {
+    if (new HashSet<>(ids).size() != ids.size()) {
+      throw new AlcoholException(DISTILLERY_REORDER_DUPLICATE_ID);
+    }
+  }
+
+  private Distillery findReorderTarget(Map<Long, Distillery> distilleryById, Long distilleryId) {
+    Distillery distillery = distilleryById.get(distilleryId);
+    if (distillery == null) {
+      throw new AlcoholException(DISTILLERY_NOT_FOUND);
+    }
+    return distillery;
   }
 
   private AdminDistilleryItem toAdminDistilleryItem(Distillery d) {

--- a/bottlenote-mono/src/main/java/app/bottlenote/banner/domain/BannerRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/banner/domain/BannerRepository.java
@@ -21,5 +21,7 @@ public interface BannerRepository {
 
   List<Banner> findAllBySortOrderGreaterThanEqual(Integer sortOrder);
 
+  List<Banner> findAllOrderBySortOrderAsc();
+
   Page<AdminBannerListResponse> searchForAdmin(AdminBannerSearchRequest request, Pageable pageable);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/banner/exception/BannerExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/banner/exception/BannerExceptionCode.java
@@ -7,7 +7,8 @@ public enum BannerExceptionCode implements ExceptionCode {
   BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "배너를 찾을 수 없습니다."),
   BANNER_DUPLICATE_NAME(HttpStatus.CONFLICT, "동일한 이름의 배너가 이미 존재합니다."),
   BANNER_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다."),
-  BANNER_TARGET_URL_REQUIRED(HttpStatus.BAD_REQUEST, "외부 URL 사용 시 이동 URL은 필수입니다.");
+  BANNER_TARGET_URL_REQUIRED(HttpStatus.BAD_REQUEST, "외부 URL 사용 시 이동 URL은 필수입니다."),
+  BANNER_REORDER_DUPLICATE_ID(HttpStatus.BAD_REQUEST, "중복된 배너 ID로 정렬을 요청할 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/bottlenote-mono/src/main/java/app/bottlenote/banner/repository/JpaBannerRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/banner/repository/JpaBannerRepository.java
@@ -5,6 +5,7 @@ import app.bottlenote.banner.domain.BannerRepository;
 import app.bottlenote.common.annotation.JpaRepositoryImpl;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 @JpaRepositoryImpl
 public interface JpaBannerRepository
@@ -15,4 +16,8 @@ public interface JpaBannerRepository
   boolean existsByName(String name);
 
   List<Banner> findAllBySortOrderGreaterThanEqual(Integer sortOrder);
+
+  @Override
+  @Query("select b from banner b order by b.sortOrder asc, b.id asc")
+  List<Banner> findAllOrderBySortOrderAsc();
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/banner/service/AdminBannerService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/banner/service/AdminBannerService.java
@@ -3,6 +3,7 @@ package app.bottlenote.banner.service;
 import static app.bottlenote.banner.exception.BannerExceptionCode.BANNER_DUPLICATE_NAME;
 import static app.bottlenote.banner.exception.BannerExceptionCode.BANNER_INVALID_DATE_RANGE;
 import static app.bottlenote.banner.exception.BannerExceptionCode.BANNER_NOT_FOUND;
+import static app.bottlenote.banner.exception.BannerExceptionCode.BANNER_REORDER_DUPLICATE_ID;
 import static app.bottlenote.banner.exception.BannerExceptionCode.BANNER_TARGET_URL_REQUIRED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.BANNER_CREATED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.BANNER_DELETED;
@@ -20,9 +21,16 @@ import app.bottlenote.banner.dto.request.AdminBannerUpdateRequest;
 import app.bottlenote.banner.dto.response.AdminBannerDetailResponse;
 import app.bottlenote.banner.exception.BannerException;
 import app.bottlenote.global.data.response.GlobalResponse;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
 import app.bottlenote.global.dto.response.AdminResultResponse;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -179,6 +187,29 @@ public class AdminBannerService {
     return AdminResultResponse.of(BANNER_SORT_ORDER_UPDATED, bannerId);
   }
 
+  @Transactional
+  public AdminResultResponse reorder(AdminBulkReorderRequest request) {
+    validateReorderIds(request.ids());
+
+    List<Banner> orderedBanners = bannerRepository.findAllOrderBySortOrderAsc();
+    Map<Long, Banner> bannerById =
+        orderedBanners.stream().collect(Collectors.toMap(Banner::getId, Function.identity()));
+
+    List<Banner> requested =
+        request.ids().stream().map(id -> findReorderTarget(bannerById, id)).toList();
+
+    Set<Long> requestedIds = new HashSet<>(request.ids());
+    List<Banner> reordered = new ArrayList<>(requested);
+    reordered.addAll(
+        orderedBanners.stream().filter(banner -> !requestedIds.contains(banner.getId())).toList());
+
+    List<Integer> slots = orderedBanners.stream().map(Banner::getSortOrder).sorted().toList();
+    for (int i = 0; i < reordered.size(); i++) {
+      reordered.get(i).updateSortOrder(slots.get(i));
+    }
+    return AdminResultResponse.of(BANNER_SORT_ORDER_UPDATED, null);
+  }
+
   private void validateDateRange(LocalDateTime startDate, LocalDateTime endDate) {
     if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
       throw new BannerException(BANNER_INVALID_DATE_RANGE);
@@ -203,5 +234,19 @@ public class AdminBannerService {
     conflicting.stream()
         .filter(b -> !b.getId().equals(excludeBannerId))
         .forEach(b -> b.updateSortOrder(b.getSortOrder() + 1));
+  }
+
+  private void validateReorderIds(List<Long> ids) {
+    if (new HashSet<>(ids).size() != ids.size()) {
+      throw new BannerException(BANNER_REORDER_DUPLICATE_ID);
+    }
+  }
+
+  private Banner findReorderTarget(Map<Long, Banner> bannerById, Long id) {
+    Banner banner = bannerById.get(id);
+    if (banner == null) {
+      throw new BannerException(BANNER_NOT_FOUND);
+    }
+    return banner;
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/dto/request/AdminBulkReorderRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/dto/request/AdminBulkReorderRequest.java
@@ -1,0 +1,15 @@
+package app.bottlenote.global.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record AdminBulkReorderRequest(
+    @NotEmpty(message = "BULK_REORDER_IDS_REQUIRED")
+        @Size(max = 100, message = "BULK_REORDER_IDS_MAX_SIZE")
+        List<
+                @NotNull(message = "BULK_REORDER_ID_REQUIRED")
+                @Min(value = 1, message = "BULK_REORDER_ID_MINIMUM") Long>
+            ids) {}

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/exception/custom/code/ValidExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/exception/custom/code/ValidExceptionCode.java
@@ -17,6 +17,10 @@ public enum ValidExceptionCode implements ExceptionCode {
   CONTENT_NOT_BLANK(HttpStatus.BAD_REQUEST, "공백입니다. 내용을 입력해주세요."),
   CONTENT_NOT_EMPTY(HttpStatus.BAD_REQUEST, "null입니다. 내용을 입력해주세요."),
   TITLE_NOT_EMPTY(HttpStatus.BAD_REQUEST, "null입니다. 타이틀(제목)을 입력해주세요."),
+  BULK_REORDER_IDS_REQUIRED(HttpStatus.BAD_REQUEST, "정렬할 ID 목록은 필수입니다."),
+  BULK_REORDER_IDS_MAX_SIZE(HttpStatus.BAD_REQUEST, "정렬할 ID는 최대 100개까지 요청할 수 있습니다."),
+  BULK_REORDER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "정렬할 ID는 null일 수 없습니다."),
+  BULK_REORDER_ID_MINIMUM(HttpStatus.BAD_REQUEST, "정렬할 ID는 1 이상이어야 합니다."),
 
   // EXTERNAL
   DEVICE_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "디바이스 토큰은 필수입니다."),

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryCurationKeywordRepository.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryCurationKeywordRepository.java
@@ -1,0 +1,85 @@
+package app.bottlenote.alcohols.fixture;
+
+import app.bottlenote.alcohols.domain.CurationKeyword;
+import app.bottlenote.alcohols.domain.CurationKeywordRepository;
+import app.bottlenote.alcohols.dto.request.AdminCurationSearchRequest;
+import app.bottlenote.alcohols.dto.response.AdminCurationListResponse;
+import app.bottlenote.alcohols.dto.response.AlcoholsSearchItem;
+import app.bottlenote.alcohols.dto.response.CurationKeywordResponse;
+import app.bottlenote.global.service.cursor.CursorResponse;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class InMemoryCurationKeywordRepository implements CurationKeywordRepository {
+
+  private final List<CurationKeyword> curations = new ArrayList<>();
+
+  @Override
+  public Optional<CurationKeyword> findById(Long id) {
+    return curations.stream().filter(curation -> curation.getId().equals(id)).findFirst();
+  }
+
+  @Override
+  public Optional<CurationKeyword> findByNameContainingAndIsActiveTrue(String name) {
+    return Optional.empty();
+  }
+
+  @Override
+  public CursorResponse<CurationKeywordResponse> searchCurationKeywords(
+      String keyword, Long alcoholId, Long cursor, Integer pageSize) {
+    return null;
+  }
+
+  @Override
+  public CursorResponse<AlcoholsSearchItem> getCurationAlcohols(
+      Long curationId, Long cursor, Integer pageSize) {
+    return null;
+  }
+
+  @Override
+  public Optional<Set<Long>> findAlcoholIdsByKeyword(String keyword) {
+    return Optional.empty();
+  }
+
+  @Override
+  public CurationKeyword save(CurationKeyword curationKeyword) {
+    if (curationKeyword.getId() == null) {
+      ReflectionTestUtils.setField(curationKeyword, "id", (long) (curations.size() + 1));
+    }
+    curations.removeIf(curation -> curation.getId().equals(curationKeyword.getId()));
+    curations.add(curationKeyword);
+    return curationKeyword;
+  }
+
+  @Override
+  public void delete(CurationKeyword curationKeyword) {
+    curations.removeIf(curation -> curation.getId().equals(curationKeyword.getId()));
+  }
+
+  @Override
+  public boolean existsByName(String name) {
+    return curations.stream().anyMatch(curation -> curation.getName().equals(name));
+  }
+
+  @Override
+  public Page<AdminCurationListResponse> searchForAdmin(
+      AdminCurationSearchRequest request, Pageable pageable) {
+    return new PageImpl<>(List.of(), pageable, 0);
+  }
+
+  @Override
+  public List<CurationKeyword> findAllOrderByDisplayOrderAsc() {
+    return curations.stream()
+        .sorted(
+            Comparator.comparing(CurationKeyword::getDisplayOrder)
+                .thenComparing(CurationKeyword::getId))
+        .toList();
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryDistilleryRepository.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryDistilleryRepository.java
@@ -4,6 +4,7 @@ import app.bottlenote.alcohols.domain.Distillery;
 import app.bottlenote.alcohols.domain.DistilleryRepository;
 import app.bottlenote.alcohols.dto.response.AdminDistilleryItem;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -85,6 +86,13 @@ public class InMemoryDistilleryRepository implements DistilleryRepository {
   @Override
   public List<Distillery> findAllBySortOrderGreaterThanEqual(int sortOrder) {
     return distilleries.stream().filter(d -> d.getSortOrder() >= sortOrder).toList();
+  }
+
+  @Override
+  public List<Distillery> findAllOrderBySortOrderAsc() {
+    return distilleries.stream()
+        .sorted(Comparator.comparing(Distillery::getSortOrder).thenComparing(Distillery::getId))
+        .toList();
   }
 
   public void clear() {

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryRegionRepository.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryRegionRepository.java
@@ -141,6 +141,21 @@ public class InMemoryRegionRepository implements RegionRepository {
   }
 
   @Override
+  public List<Region> findAllOrderBySortOrderAsc() {
+    return regions.stream()
+        .sorted(Comparator.comparing(Region::getSortOrder).thenComparing(Region::getId))
+        .toList();
+  }
+
+  @Override
+  public List<Region> findAllByParentIdOrderBySortOrderAsc(Long parentId) {
+    return regions.stream()
+        .filter(r -> r.getParent() != null && Objects.equals(r.getParent().getId(), parentId))
+        .sorted(Comparator.comparing(Region::getSortOrder).thenComparing(Region::getId))
+        .toList();
+  }
+
+  @Override
   public boolean existsAlcoholByRegionId(Long regionId) {
     return alcoholCountByRegion.getOrDefault(regionId, 0L) > 0;
   }

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminCurationServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminCurationServiceTest.java
@@ -1,0 +1,72 @@
+package app.bottlenote.alcohols.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.bottlenote.alcohols.domain.CurationKeyword;
+import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.alcohols.fixture.InMemoryAlcoholQueryRepository;
+import app.bottlenote.alcohols.fixture.InMemoryCurationKeywordRepository;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("AdminCurationService 단위 테스트")
+class AdminCurationServiceTest {
+
+  private InMemoryCurationKeywordRepository curationKeywordRepository;
+  private AdminCurationService adminCurationService;
+
+  @BeforeEach
+  void setUp() {
+    curationKeywordRepository = new InMemoryCurationKeywordRepository();
+    adminCurationService =
+        new AdminCurationService(curationKeywordRepository, new InMemoryAlcoholQueryRepository());
+  }
+
+  @Test
+  @DisplayName("bulk reorder는 요청 ID를 전체 큐레이션 목록의 맨 앞으로 재배치한다")
+  void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
+    CurationKeyword first = saveCuration("기존 맨 앞", 1);
+    CurationKeyword second = saveCuration("두 번째", 10);
+    CurationKeyword third = saveCuration("세 번째", 20);
+    CurationKeyword fourth = saveCuration("네 번째", 30);
+    CurationKeyword fifth = saveCuration("다섯 번째", 40);
+
+    adminCurationService.reorder(
+        new AdminBulkReorderRequest(
+            List.of(third.getId(), second.getId(), fifth.getId(), fourth.getId())));
+
+    List<CurationKeyword> result = curationKeywordRepository.findAllOrderByDisplayOrderAsc();
+    assertThat(result)
+        .extracting(CurationKeyword::getId)
+        .containsExactly(
+            third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
+    assertThat(result)
+        .extracting(CurationKeyword::getDisplayOrder)
+        .containsExactly(1, 10, 20, 30, 40);
+  }
+
+  @Test
+  @DisplayName("bulk reorder 요청 ID가 중복되면 예외가 발생한다")
+  void reorder_whenDuplicateIds_throwsException() {
+    CurationKeyword curation = saveCuration("큐레이션", 1);
+
+    assertThatThrownBy(
+            () ->
+                adminCurationService.reorder(
+                    new AdminBulkReorderRequest(List.of(curation.getId(), curation.getId()))))
+        .isInstanceOf(AlcoholException.class);
+  }
+
+  private CurationKeyword saveCuration(String name, int displayOrder) {
+    return curationKeywordRepository.save(
+        CurationKeyword.create(
+            name, name + " 설명", "https://example.com/" + name + ".jpg", displayOrder, Set.of()));
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminCurationServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminCurationServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import app.bottlenote.alcohols.domain.CurationKeyword;
 import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.alcohols.exception.AlcoholExceptionCode;
 import app.bottlenote.alcohols.fixture.InMemoryAlcoholQueryRepository;
 import app.bottlenote.alcohols.fixture.InMemoryCurationKeywordRepository;
 import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
@@ -30,7 +31,7 @@ class AdminCurationServiceTest {
   }
 
   @Test
-  @DisplayName("bulk reorder는 요청 ID를 전체 큐레이션 목록의 맨 앞으로 재배치한다")
+  @DisplayName("요청 ID가 주어졌을 때 전체 큐레이션 목록의 맨 앞으로 재배치한다")
   void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
     CurationKeyword first = saveCuration("기존 맨 앞", 1);
     CurationKeyword second = saveCuration("두 번째", 10);
@@ -53,7 +54,7 @@ class AdminCurationServiceTest {
   }
 
   @Test
-  @DisplayName("bulk reorder 요청 ID가 중복되면 예외가 발생한다")
+  @DisplayName("요청 ID가 중복될 때 예외가 발생한다")
   void reorder_whenDuplicateIds_throwsException() {
     CurationKeyword curation = saveCuration("큐레이션", 1);
 
@@ -61,7 +62,23 @@ class AdminCurationServiceTest {
             () ->
                 adminCurationService.reorder(
                     new AdminBulkReorderRequest(List.of(curation.getId(), curation.getId()))))
-        .isInstanceOf(AlcoholException.class);
+        .isInstanceOf(AlcoholException.class)
+        .extracting("exceptionCode")
+        .isEqualTo(AlcoholExceptionCode.CURATION_REORDER_DUPLICATE_ID);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 ID가 포함될 때 예외가 발생한다")
+  void reorder_whenUnknownIdRequested_throwsException() {
+    CurationKeyword curation = saveCuration("큐레이션", 1);
+
+    assertThatThrownBy(
+            () ->
+                adminCurationService.reorder(
+                    new AdminBulkReorderRequest(List.of(curation.getId(), 999L))))
+        .isInstanceOf(AlcoholException.class)
+        .extracting("exceptionCode")
+        .isEqualTo(AlcoholExceptionCode.CURATION_NOT_FOUND);
   }
 
   private CurationKeyword saveCuration(String name, int displayOrder) {

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
@@ -268,7 +268,7 @@ class AdminRegionServiceTest {
   class BulkReorder {
 
     @Test
-    @DisplayName("전체 지역 bulk reorder는 요청 ID를 전체 지역 목록의 맨 앞으로 재배치한다")
+    @DisplayName("요청 ID가 주어졌을 때 전체 지역 목록의 맨 앞으로 재배치한다")
     void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
       Region first = saveRegion("기존 맨 앞", "First", null, 1);
       Region second = saveRegion("두 번째", "Second", null, 10);
@@ -289,7 +289,7 @@ class AdminRegionServiceTest {
     }
 
     @Test
-    @DisplayName("자식 지역 bulk reorder는 같은 parentId의 직접 자식만 재배치한다")
+    @DisplayName("parentId가 주어졌을 때 같은 부모의 직접 자식만 재배치한다")
     void reorderChildrenToFront_whenIdsRequested_updatesOnlyChildrenOfParent() {
       Region parent = saveRegion("스코틀랜드", "Scotland", null, 1);
       Region anotherParent = saveRegion("아일랜드", "Ireland", null, 2);
@@ -312,7 +312,7 @@ class AdminRegionServiceTest {
     }
 
     @Test
-    @DisplayName("자식 지역 bulk reorder에 다른 부모의 ID가 포함되면 예외가 발생한다")
+    @DisplayName("자식 정렬 요청에 다른 부모의 ID가 포함될 때 예외가 발생한다")
     void reorderChildren_whenOtherParentChildIncluded_throwsException() {
       Region parent = saveRegion("스코틀랜드", "Scotland", null, 1);
       Region anotherParent = saveRegion("아일랜드", "Ireland", null, 2);
@@ -327,6 +327,46 @@ class AdminRegionServiceTest {
           .isInstanceOf(AlcoholException.class)
           .extracting("exceptionCode")
           .isEqualTo(AlcoholExceptionCode.REGION_REORDER_SCOPE_MISMATCH);
+    }
+
+    @Test
+    @DisplayName("요청 ID가 중복될 때 예외가 발생한다")
+    void reorder_whenDuplicateIds_throwsException() {
+      Region region = saveRegion("스코틀랜드", "Scotland", null, 1);
+
+      assertThatThrownBy(
+              () ->
+                  service.reorder(
+                      new AdminBulkReorderRequest(List.of(region.getId(), region.getId()))))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_REORDER_DUPLICATE_ID);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID가 포함될 때 예외가 발생한다")
+    void reorder_whenUnknownIdRequested_throwsException() {
+      Region region = saveRegion("스코틀랜드", "Scotland", null, 1);
+
+      assertThatThrownBy(
+              () -> service.reorder(new AdminBulkReorderRequest(List.of(region.getId(), 999L))))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 부모 ID로 자식 정렬을 요청할 때 예외가 발생한다")
+    void reorderChildren_whenUnknownParentIdRequested_throwsException() {
+      Region region = saveRegion("하이랜드", "Highland", null, 1);
+
+      assertThatThrownBy(
+              () ->
+                  service.reorderChildren(
+                      999L, new AdminBulkReorderRequest(List.of(region.getId()))))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_PARENT_NOT_FOUND);
     }
   }
 

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
@@ -10,6 +10,8 @@ import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest;
 import app.bottlenote.alcohols.exception.AlcoholException;
 import app.bottlenote.alcohols.exception.AlcoholExceptionCode;
 import app.bottlenote.alcohols.fixture.InMemoryRegionRepository;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -258,6 +260,73 @@ class AdminRegionServiceTest {
 
       assertThat(regionRepository.findById(target.getId()).orElseThrow().getSortOrder())
           .isEqualTo(50);
+    }
+  }
+
+  @Nested
+  @DisplayName("bulk reorder")
+  class BulkReorder {
+
+    @Test
+    @DisplayName("전체 지역 bulk reorder는 요청 ID를 전체 지역 목록의 맨 앞으로 재배치한다")
+    void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
+      Region first = saveRegion("기존 맨 앞", "First", null, 1);
+      Region second = saveRegion("두 번째", "Second", null, 10);
+      Region third = saveRegion("세 번째", "Third", null, 20);
+      Region fourth = saveRegion("네 번째", "Fourth", null, 30);
+      Region fifth = saveRegion("다섯 번째", "Fifth", null, 40);
+
+      service.reorder(
+          new AdminBulkReorderRequest(
+              List.of(third.getId(), second.getId(), fifth.getId(), fourth.getId())));
+
+      List<Region> result = regionRepository.findAllOrderBySortOrderAsc();
+      assertThat(result)
+          .extracting(Region::getId)
+          .containsExactly(
+              third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
+      assertThat(result).extracting(Region::getSortOrder).containsExactly(1, 10, 20, 30, 40);
+    }
+
+    @Test
+    @DisplayName("자식 지역 bulk reorder는 같은 parentId의 직접 자식만 재배치한다")
+    void reorderChildrenToFront_whenIdsRequested_updatesOnlyChildrenOfParent() {
+      Region parent = saveRegion("스코틀랜드", "Scotland", null, 1);
+      Region anotherParent = saveRegion("아일랜드", "Ireland", null, 2);
+      Region first = saveRegion("기존 맨 앞", "First", parent, 1);
+      Region second = saveRegion("두 번째", "Second", parent, 10);
+      Region third = saveRegion("세 번째", "Third", parent, 20);
+      Region fourth = saveRegion("네 번째", "Fourth", parent, 30);
+      Region otherChild = saveRegion("다른 부모 자식", "OtherChild", anotherParent, 5);
+
+      service.reorderChildren(
+          parent.getId(), new AdminBulkReorderRequest(List.of(third.getId(), second.getId())));
+
+      List<Region> result = regionRepository.findAllByParentIdOrderBySortOrderAsc(parent.getId());
+      assertThat(result)
+          .extracting(Region::getId)
+          .containsExactly(third.getId(), second.getId(), first.getId(), fourth.getId());
+      assertThat(result).extracting(Region::getSortOrder).containsExactly(1, 10, 20, 30);
+      assertThat(regionRepository.findById(otherChild.getId()).orElseThrow().getSortOrder())
+          .isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("자식 지역 bulk reorder에 다른 부모의 ID가 포함되면 예외가 발생한다")
+    void reorderChildren_whenOtherParentChildIncluded_throwsException() {
+      Region parent = saveRegion("스코틀랜드", "Scotland", null, 1);
+      Region anotherParent = saveRegion("아일랜드", "Ireland", null, 2);
+      Region child = saveRegion("하이랜드", "Highland", parent, 10);
+      Region otherChild = saveRegion("더블린", "Dublin", anotherParent, 20);
+
+      assertThatThrownBy(
+              () ->
+                  service.reorderChildren(
+                      parent.getId(),
+                      new AdminBulkReorderRequest(List.of(child.getId(), otherChild.getId()))))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.REGION_REORDER_SCOPE_MISMATCH);
     }
   }
 

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/DistilleryServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/DistilleryServiceTest.java
@@ -296,7 +296,7 @@ class DistilleryServiceTest {
     }
 
     @Test
-    @DisplayName("bulk reorder는 요청 ID를 전체 증류소 목록의 맨 앞으로 재배치한다")
+    @DisplayName("요청 ID가 주어졌을 때 전체 증류소 목록의 맨 앞으로 재배치한다")
     void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
       Distillery first =
           distilleryRepository.save(
@@ -324,6 +324,38 @@ class DistilleryServiceTest {
           .containsExactly(
               third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
       assertThat(result).extracting(Distillery::getSortOrder).containsExactly(1, 10, 20, 30, 40);
+    }
+
+    @Test
+    @DisplayName("요청 ID가 중복될 때 예외가 발생한다")
+    void reorder_whenDuplicateIds_throwsException() {
+      Distillery distillery =
+          distilleryRepository.save(
+              Distillery.builder().korName("증류소").engName("Distillery").sortOrder(1).build());
+
+      assertThatThrownBy(
+              () ->
+                  distilleryService.reorder(
+                      new AdminBulkReorderRequest(List.of(distillery.getId(), distillery.getId()))))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.DISTILLERY_REORDER_DUPLICATE_ID);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID가 포함될 때 예외가 발생한다")
+    void reorder_whenUnknownIdRequested_throwsException() {
+      Distillery distillery =
+          distilleryRepository.save(
+              Distillery.builder().korName("증류소").engName("Distillery").sortOrder(1).build());
+
+      assertThatThrownBy(
+              () ->
+                  distilleryService.reorder(
+                      new AdminBulkReorderRequest(List.of(distillery.getId(), 999L))))
+          .isInstanceOf(AlcoholException.class)
+          .extracting("exceptionCode")
+          .isEqualTo(AlcoholExceptionCode.DISTILLERY_NOT_FOUND);
     }
   }
 }

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/DistilleryServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/DistilleryServiceTest.java
@@ -14,7 +14,9 @@ import app.bottlenote.alcohols.exception.AlcoholException;
 import app.bottlenote.alcohols.exception.AlcoholExceptionCode;
 import app.bottlenote.alcohols.fixture.DistilleryTestFactory;
 import app.bottlenote.alcohols.fixture.InMemoryDistilleryRepository;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
 import app.bottlenote.global.dto.response.AdminResultResponse;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -291,6 +293,37 @@ class DistilleryServiceTest {
 
       assertThat(distilleryRepository.findById(result.targetId()).orElseThrow().getSortOrder())
           .isEqualTo(9999);
+    }
+
+    @Test
+    @DisplayName("bulk reorder는 요청 ID를 전체 증류소 목록의 맨 앞으로 재배치한다")
+    void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
+      Distillery first =
+          distilleryRepository.save(
+              Distillery.builder().korName("기존 맨 앞").engName("First").sortOrder(1).build());
+      Distillery second =
+          distilleryRepository.save(
+              Distillery.builder().korName("두 번째").engName("Second").sortOrder(10).build());
+      Distillery third =
+          distilleryRepository.save(
+              Distillery.builder().korName("세 번째").engName("Third").sortOrder(20).build());
+      Distillery fourth =
+          distilleryRepository.save(
+              Distillery.builder().korName("네 번째").engName("Fourth").sortOrder(30).build());
+      Distillery fifth =
+          distilleryRepository.save(
+              Distillery.builder().korName("다섯 번째").engName("Fifth").sortOrder(40).build());
+
+      distilleryService.reorder(
+          new AdminBulkReorderRequest(
+              List.of(third.getId(), second.getId(), fifth.getId(), fourth.getId())));
+
+      List<Distillery> result = distilleryRepository.findAllOrderBySortOrderAsc();
+      assertThat(result)
+          .extracting(Distillery::getId)
+          .containsExactly(
+              third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
+      assertThat(result).extracting(Distillery::getSortOrder).containsExactly(1, 10, 20, 30, 40);
     }
   }
 }

--- a/bottlenote-mono/src/test/java/app/bottlenote/banner/fixture/InMemoryBannerRepository.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/banner/fixture/InMemoryBannerRepository.java
@@ -4,6 +4,7 @@ import app.bottlenote.banner.domain.Banner;
 import app.bottlenote.banner.domain.BannerRepository;
 import app.bottlenote.banner.dto.request.AdminBannerSearchRequest;
 import app.bottlenote.banner.dto.response.AdminBannerListResponse;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,13 @@ public class InMemoryBannerRepository implements BannerRepository {
   @Override
   public List<Banner> findAllBySortOrderGreaterThanEqual(Integer sortOrder) {
     return database.values().stream().filter(banner -> banner.getSortOrder() >= sortOrder).toList();
+  }
+
+  @Override
+  public List<Banner> findAllOrderBySortOrderAsc() {
+    return database.values().stream()
+        .sorted(Comparator.comparing(Banner::getSortOrder).thenComparing(Banner::getId))
+        .toList();
   }
 
   @Override

--- a/bottlenote-mono/src/test/java/app/bottlenote/banner/service/AdminBannerServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/banner/service/AdminBannerServiceTest.java
@@ -1,0 +1,73 @@
+package app.bottlenote.banner.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.bottlenote.banner.constant.BannerType;
+import app.bottlenote.banner.domain.Banner;
+import app.bottlenote.banner.exception.BannerException;
+import app.bottlenote.banner.fixture.InMemoryBannerRepository;
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("AdminBannerService 단위 테스트")
+class AdminBannerServiceTest {
+
+  private InMemoryBannerRepository bannerRepository;
+  private AdminBannerService adminBannerService;
+
+  @BeforeEach
+  void setUp() {
+    bannerRepository = new InMemoryBannerRepository();
+    adminBannerService = new AdminBannerService(bannerRepository);
+  }
+
+  @Test
+  @DisplayName("bulk reorder는 요청 ID를 전체 배너 목록의 맨 앞으로 재배치한다")
+  void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
+    Banner first = saveBanner("기존 맨 앞", 1);
+    Banner second = saveBanner("두 번째", 10);
+    Banner third = saveBanner("세 번째", 20);
+    Banner fourth = saveBanner("네 번째", 30);
+    Banner fifth = saveBanner("다섯 번째", 40);
+
+    adminBannerService.reorder(
+        new AdminBulkReorderRequest(
+            List.of(third.getId(), second.getId(), fifth.getId(), fourth.getId())));
+
+    List<Banner> result = bannerRepository.findAllOrderBySortOrderAsc();
+    assertThat(result)
+        .extracting(Banner::getId)
+        .containsExactly(
+            third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
+    assertThat(result).extracting(Banner::getSortOrder).containsExactly(1, 10, 20, 30, 40);
+  }
+
+  @Test
+  @DisplayName("bulk reorder 요청 ID가 중복되면 예외가 발생한다")
+  void reorder_whenDuplicateIds_throwsException() {
+    Banner banner = saveBanner("배너", 1);
+
+    assertThatThrownBy(
+            () ->
+                adminBannerService.reorder(
+                    new AdminBulkReorderRequest(List.of(banner.getId(), banner.getId()))))
+        .isInstanceOf(BannerException.class);
+  }
+
+  private Banner saveBanner(String name, int sortOrder) {
+    return bannerRepository.save(
+        Banner.builder()
+            .name(name)
+            .imageUrl("https://example.com/" + name + ".jpg")
+            .bannerType(BannerType.CURATION)
+            .sortOrder(sortOrder)
+            .isActive(true)
+            .build());
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/banner/service/AdminBannerServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/banner/service/AdminBannerServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import app.bottlenote.banner.constant.BannerType;
 import app.bottlenote.banner.domain.Banner;
 import app.bottlenote.banner.exception.BannerException;
+import app.bottlenote.banner.exception.BannerExceptionCode;
 import app.bottlenote.banner.fixture.InMemoryBannerRepository;
 import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
 import java.util.List;
@@ -28,7 +29,7 @@ class AdminBannerServiceTest {
   }
 
   @Test
-  @DisplayName("bulk reorder는 요청 ID를 전체 배너 목록의 맨 앞으로 재배치한다")
+  @DisplayName("요청 ID가 주어졌을 때 전체 배너 목록의 맨 앞으로 재배치한다")
   void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
     Banner first = saveBanner("기존 맨 앞", 1);
     Banner second = saveBanner("두 번째", 10);
@@ -49,7 +50,7 @@ class AdminBannerServiceTest {
   }
 
   @Test
-  @DisplayName("bulk reorder 요청 ID가 중복되면 예외가 발생한다")
+  @DisplayName("요청 ID가 중복될 때 예외가 발생한다")
   void reorder_whenDuplicateIds_throwsException() {
     Banner banner = saveBanner("배너", 1);
 
@@ -57,7 +58,23 @@ class AdminBannerServiceTest {
             () ->
                 adminBannerService.reorder(
                     new AdminBulkReorderRequest(List.of(banner.getId(), banner.getId()))))
-        .isInstanceOf(BannerException.class);
+        .isInstanceOf(BannerException.class)
+        .extracting("exceptionCode")
+        .isEqualTo(BannerExceptionCode.BANNER_REORDER_DUPLICATE_ID);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 ID가 포함될 때 예외가 발생한다")
+  void reorder_whenUnknownIdRequested_throwsException() {
+    Banner banner = saveBanner("배너", 1);
+
+    assertThatThrownBy(
+            () ->
+                adminBannerService.reorder(
+                    new AdminBulkReorderRequest(List.of(banner.getId(), 999L))))
+        .isInstanceOf(BannerException.class)
+        .extracting("exceptionCode")
+        .isEqualTo(BannerExceptionCode.BANNER_NOT_FOUND);
   }
 
   private Banner saveBanner(String name, int sortOrder) {

--- a/bottlenote-mono/src/test/java/app/bottlenote/global/dto/request/AdminBulkReorderRequestTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/global/dto/request/AdminBulkReorderRequestTest.java
@@ -1,0 +1,90 @@
+package app.bottlenote.global.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("AdminBulkReorderRequest 단위 테스트")
+class AdminBulkReorderRequestTest {
+
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  @DisplayName("ids가 100개일 때 검증에 성공한다")
+  void validate_whenIdsSizeIsOneHundred_succeeds() {
+    AdminBulkReorderRequest request = new AdminBulkReorderRequest(ids(100));
+
+    Set<ConstraintViolation<AdminBulkReorderRequest>> violations = validator.validate(request);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("ids가 비어 있을 때 검증에 실패한다")
+  void validate_whenIdsIsEmpty_fails() {
+    AdminBulkReorderRequest request = new AdminBulkReorderRequest(List.of());
+
+    Set<ConstraintViolation<AdminBulkReorderRequest>> violations = validator.validate(request);
+
+    assertThat(violations)
+        .extracting(ConstraintViolation::getMessage)
+        .contains("BULK_REORDER_IDS_REQUIRED");
+  }
+
+  @Test
+  @DisplayName("ids가 100개를 초과할 때 검증에 실패한다")
+  void validate_whenIdsSizeExceedsOneHundred_fails() {
+    AdminBulkReorderRequest request = new AdminBulkReorderRequest(ids(101));
+
+    Set<ConstraintViolation<AdminBulkReorderRequest>> violations = validator.validate(request);
+
+    assertThat(violations)
+        .extracting(ConstraintViolation::getMessage)
+        .contains("BULK_REORDER_IDS_MAX_SIZE");
+  }
+
+  @Test
+  @DisplayName("ids에 null이 포함될 때 검증에 실패한다")
+  void validate_whenIdIsNull_fails() {
+    List<Long> ids = new ArrayList<>();
+    ids.add(1L);
+    ids.add(null);
+
+    AdminBulkReorderRequest request = new AdminBulkReorderRequest(ids);
+
+    Set<ConstraintViolation<AdminBulkReorderRequest>> violations = validator.validate(request);
+
+    assertThat(violations)
+        .extracting(ConstraintViolation::getMessage)
+        .contains("BULK_REORDER_ID_REQUIRED");
+  }
+
+  @Test
+  @DisplayName("ids에 0 이하 값이 포함될 때 검증에 실패한다")
+  void validate_whenIdIsLessThanOne_fails() {
+    AdminBulkReorderRequest request = new AdminBulkReorderRequest(List.of(1L, 0L));
+
+    Set<ConstraintViolation<AdminBulkReorderRequest>> violations = validator.validate(request);
+
+    assertThat(violations)
+        .extracting(ConstraintViolation::getMessage)
+        .contains("BULK_REORDER_ID_MINIMUM");
+  }
+
+  private List<Long> ids(int size) {
+    List<Long> ids = new ArrayList<>();
+    for (long id = 1; id <= size; id++) {
+      ids.add(id);
+    }
+    return ids;
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/global/fixture/AdminBulkReorderRequestTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/global/fixture/AdminBulkReorderRequestTest.java
@@ -1,7 +1,8 @@
-package app.bottlenote.global.dto.request;
+package app.bottlenote.global.fixture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import app.bottlenote.global.dto.request.AdminBulkReorderRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;

--- a/plan/admin-bulk-reorder.md
+++ b/plan/admin-bulk-reorder.md
@@ -1,0 +1,265 @@
+# Plan: Admin Bulk Reorder API
+
+## Overview
+
+어드민에서 드래그로 정렬한 항목을 한 번에 저장할 수 있도록 bulk reorder API를 추가한다.
+기존 단건 정렬 API는 유지하고, bulk API는 모든 도메인에서 `/bulk/reorder` 경로로 통일한다.
+
+공통 요청 형식은 다음과 같다.
+
+```json
+{
+  "ids": [3, 1, 6, 5]
+}
+```
+
+`ids`는 전체 목록이 아니라 해당 scope의 맨 앞 구간으로 올릴 항목들의 최종 순서다.
+요청 ID는 최소 1개, 최대 100개까지만 허용한다.
+
+정렬 예시는 다음과 같다.
+
+```text
+변경 전
+
+정렬 슬롯:   1    10    20    30    40
+          +----+-----+-----+-----+-----+
+항목 ID:  | 11 |  1  |  3  |  5  |  6  |
+          +----+-----+-----+-----+-----+
+
+요청
+
+{ "ids": [3, 1, 6, 5] }
+
+변경 후
+
+정렬 슬롯:   1    10    20    30    40
+          +----+-----+-----+-----+-----+
+항목 ID:  |  3 |  1  |  6  |  5  | 11  |
+          +----+-----+-----+-----+-----+
+```
+
+요청에 포함된 항목은 scope의 맨 앞 정렬 슬롯부터 배열 순서대로 배정된다.
+기존 앞쪽에 있던 미포함 항목은 뒤로 밀리고, 나머지 미포함 항목의 상대 순서는 유지된다.
+
+## Assumptions
+
+1. 대상 API는 admin-api이며, 비즈니스 로직은 기존 패턴대로 bottlenote-mono 서비스에 둔다.
+2. 인증/인가 정책은 기존 어드민 API 정책을 그대로 따른다.
+3. DB schema 변경은 하지 않는다. 기존 `sortOrder` 또는 `displayOrder` 필드를 재사용한다.
+4. 기존 단건 API 동작은 변경하지 않는다.
+5. bulk reorder는 임의 위치 삽입이 아니라 scope의 앞쪽으로 올리는 동작이다.
+6. `ids`에 없는 항목은 삭제/비활성/숨김 처리하지 않고 정렬 위치만 필요 시 뒤로 밀린다.
+7. 요청 ID가 100개를 초과하면 validation 실패로 처리한다.
+8. 중복 ID, 존재하지 않는 ID, scope가 다른 ID는 실패 처리한다.
+9. 지역 자식 정렬 API의 path variable은 부모 지역 ID인 `parentId`다.
+10. 배너와 큐레이션은 비활성 또는 미노출 항목도 정렬값을 가질 수 있다.
+
+## Success Criteria
+
+1. `PATCH /admin/api/v1/banners/bulk/reorder`가 전체 배너 scope에서 `sortOrder`를 재배치한다.
+2. `PATCH /admin/api/v1/curations/bulk/reorder`가 전체 큐레이션 scope에서 `displayOrder`를 재배치한다.
+3. `PATCH /admin/api/v1/distilleries/bulk/reorder`가 전체 증류소 scope에서 `sortOrder`를 재배치한다.
+4. `PATCH /admin/api/v1/regions/bulk/reorder`가 전체 지역 scope에서 `sortOrder`를 재배치한다.
+5. `PATCH /admin/api/v1/regions/{parentId}/children/bulk/reorder`가 해당 `parentId`의 직접 자식 지역 scope에서만 `sortOrder`를 재배치한다.
+6. 모든 bulk reorder 요청은 하나의 트랜잭션에서 처리된다.
+7. 요청 ID 순서대로 scope의 맨 앞 정렬 슬롯에 배정된다.
+8. 기존 앞쪽 미포함 항목은 뒤로 밀리고, 나머지 미포함 항목의 상대 순서는 유지된다.
+9. 요청 ID가 비어 있거나 100개를 초과하면 validation 실패가 발생한다.
+10. 요청 ID가 중복되면 validation 실패가 발생한다.
+11. 존재하지 않는 ID가 포함되면 도메인 예외가 발생한다.
+12. 지역 자식 정렬에서 다른 부모의 지역 ID가 포함되면 scope 검증 실패가 발생한다.
+13. 단건 정렬 API와 bulk reorder API의 차이를 admin API adoc 문서에 설명한다.
+14. adoc 문서에 ASCII 정렬 예시를 포함한다.
+15. 배너/큐레이션 문서에 비활성 또는 미노출 항목이 정렬값을 가지지만 조회 필터에 따라 화면에 보이지 않을 수 있음을 예시와 함께 설명한다.
+16. 관련 단위 테스트, RestDocs 테스트, full verify가 통과한다.
+
+## Impact Scope
+
+### Modules
+
+- `bottlenote-admin-api`: admin controller endpoint 및 RestDocs 테스트
+- `bottlenote-mono`: request DTO, service reorder logic, repository query, exception/result code, unit test fixture
+
+### API Surface
+
+추가 API:
+
+```text
+PATCH /admin/api/v1/banners/bulk/reorder
+PATCH /admin/api/v1/curations/bulk/reorder
+PATCH /admin/api/v1/distilleries/bulk/reorder
+PATCH /admin/api/v1/regions/bulk/reorder
+PATCH /admin/api/v1/regions/{parentId}/children/bulk/reorder
+```
+
+유지 API:
+
+```text
+PATCH /admin/api/v1/banners/{bannerId}/sort-order
+PATCH /admin/api/v1/curations/{curationId}/display-order
+PATCH /admin/api/v1/distilleries/{distilleryId}/sort-order
+PATCH /admin/api/v1/regions/{regionId}/sort-order
+```
+
+### Persistence
+
+- schema 변경 없음
+- 기존 `sortOrder` / `displayOrder` 컬럼 업데이트만 수행
+- 대량 ID는 최대 100개로 제한
+
+### Domain Rules
+
+- 배너: 전체 배너 기준 `sortOrder`
+- 큐레이션: 전체 큐레이션 기준 `displayOrder`
+- 증류소: 전체 증류소 기준 `sortOrder`
+- 지역 전체: 전체 지역 기준 `sortOrder`
+- 지역 자식: `parentId`의 직접 자식 지역 기준 `sortOrder`
+
+### Tests
+
+- service unit test: 재배치 성공, 중복 ID, 빈 요청, 100개 초과, 존재하지 않는 ID, scope mismatch
+- fake/in-memory repository: bulk 조회와 정렬 검증 지원
+- RestDocs test: 5개 endpoint 문서 snippet 생성
+- verification: GSL full verify 전 `./gradlew test` baseline은 이미 통과한 상태에서 시작
+
+### Documentation
+
+- `bottlenote-admin-api/src/docs/asciidoc/api/admin-banners/banners.adoc`
+- `bottlenote-admin-api/src/docs/asciidoc/api/admin-curations/curations.adoc`
+- `bottlenote-admin-api/src/docs/asciidoc/api/admin-reference/reference.adoc`
+
+문서에는 FE가 이해하기 쉽도록 단건 API와 bulk API의 차이, 최대 100개 제한, 앞쪽 이동 방식, 비활성/미노출 항목 주의사항, 지역 자식 scope 검증을 명확히 기록한다.
+
+## Tasks
+
+### Task 1: 공통 bulk reorder 요청 계약
+
+- Acceptance: 공통 request DTO가 `ids` 최소 1개, 최대 100개, null/0 이하 ID를 Bean Validation으로 막는다.
+- Verification: `./gradlew :bottlenote-mono:compileJava :bottlenote-admin-api:compileKotlin`
+- Files:
+  - Create: `bottlenote-mono/src/main/java/app/bottlenote/global/dto/request/AdminBulkReorderRequest.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/global/exception/custom/code/ValidExceptionCode.java`
+- Size: S
+- Status: [x] done
+
+### Task 2: 배너 bulk reorder core
+
+- Acceptance: 전체 배너 scope에서 요청 ID가 맨 앞 슬롯으로 이동하고, 미포함 항목의 상대 순서가 유지된다.
+- Verification: `./gradlew :bottlenote-mono:test --tests app.bottlenote.banner.service.AdminBannerServiceTest`
+- Files:
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/banner/domain/BannerRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/banner/repository/JpaBannerRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/banner/service/AdminBannerService.java`
+  - Modify: `bottlenote-mono/src/test/java/app/bottlenote/banner/fixture/InMemoryBannerRepository.java`
+  - Create: `bottlenote-mono/src/test/java/app/bottlenote/banner/service/AdminBannerServiceTest.java`
+- Size: M
+- Status: [x] done
+
+### Task 3: 배너 bulk reorder API와 문서
+
+- Acceptance: `PATCH /banners/bulk/reorder`가 RestDocs snippet을 생성하고 adoc에 단건 API와 bulk API 차이, 비활성 항목 예시가 포함된다.
+- Verification: `./gradlew :bottlenote-admin-api:test --tests app.docs.banner.AdminBannerControllerDocsTest`
+- Files:
+  - Modify: `bottlenote-admin-api/src/main/kotlin/app/bottlenote/banner/presentation/AdminBannerController.kt`
+  - Modify: `bottlenote-admin-api/src/test/kotlin/app/docs/banner/AdminBannerControllerDocsTest.kt`
+  - Modify: `bottlenote-admin-api/src/docs/asciidoc/api/admin-banners/banners.adoc`
+- Size: S
+- Status: [x] done
+
+### Checkpoint: after Tasks 1-3
+
+- [x] Compile passes
+- [x] Banner unit test passes
+- [x] Banner RestDocs test passes
+
+### Task 4: 큐레이션 bulk reorder core
+
+- Acceptance: 전체 큐레이션 scope에서 요청 ID가 맨 앞 `displayOrder` 슬롯으로 이동하고, 미포함 항목의 상대 순서가 유지된다.
+- Verification: `./gradlew :bottlenote-mono:test --tests app.bottlenote.alcohols.service.AdminCurationServiceTest`
+- Files:
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/CurationKeywordRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaCurationKeywordRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminCurationService.java`
+  - Create: `bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryCurationKeywordRepository.java`
+  - Create: `bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminCurationServiceTest.java`
+- Size: M
+- Status: [x] done
+
+### Task 5: 증류소 bulk reorder core
+
+- Acceptance: 전체 증류소 scope에서 요청 ID가 맨 앞 `sortOrder` 슬롯으로 이동하고, 미포함 항목의 상대 순서가 유지된다.
+- Verification: `./gradlew :bottlenote-mono:test --tests app.bottlenote.alcohols.service.DistilleryServiceTest`
+- Files:
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/DistilleryRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaDistilleryRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/DistilleryService.java`
+  - Modify: `bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryDistilleryRepository.java`
+  - Modify: `bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/DistilleryServiceTest.java`
+- Size: M
+- Status: [x] done
+
+### Task 6: 큐레이션/증류소 API와 문서
+
+- Acceptance: `PATCH /curations/bulk/reorder`, `PATCH /distilleries/bulk/reorder`가 RestDocs snippet을 생성하고 adoc에 bulk reorder 예시와 주의사항이 포함된다.
+- Verification: `./gradlew :bottlenote-admin-api:test --tests app.docs.curation.AdminCurationControllerDocsTest --tests app.docs.alcohols.AdminDistilleryControllerDocsTest`
+- Files:
+  - Modify: `bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminCurationController.kt`
+  - Modify: `bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminDistilleryController.kt`
+  - Modify: `bottlenote-admin-api/src/test/kotlin/app/docs/curation/AdminCurationControllerDocsTest.kt`
+  - Modify: `bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminDistilleryControllerDocsTest.kt`
+  - Modify: `bottlenote-admin-api/src/docs/asciidoc/api/admin-curations/curations.adoc`
+  - Modify: `bottlenote-admin-api/src/docs/asciidoc/api/admin-reference/reference.adoc`
+- Size: M
+- Status: [x] done
+
+### Checkpoint: after Tasks 4-6
+
+- [x] Curation unit test passes
+- [x] Distillery unit test passes
+- [x] Curation/Distillery RestDocs tests pass
+
+### Task 7: 지역 전체/자식 bulk reorder core
+
+- Acceptance: 전체 지역 scope와 `parentId` 직접 자식 scope가 분리되고, 자식 API에서 다른 부모 ID가 섞이면 실패한다.
+- Verification: `./gradlew :bottlenote-mono:test --tests app.bottlenote.alcohols.service.AdminRegionServiceTest`
+- Files:
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/RegionRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaRegionQueryRepository.java`
+  - Modify: `bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java`
+  - Modify: `bottlenote-mono/src/test/java/app/bottlenote/alcohols/fixture/InMemoryRegionRepository.java`
+  - Modify: `bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java`
+- Size: M
+- Status: [x] done
+
+### Task 8: 지역 API와 문서
+
+- Acceptance: `PATCH /regions/bulk/reorder`, `PATCH /regions/{parentId}/children/bulk/reorder`가 RestDocs snippet을 생성하고 adoc에 전체 지역과 자식 지역 scope 차이가 포함된다.
+- Verification: `./gradlew :bottlenote-admin-api:test --tests app.docs.alcohols.AdminRegionControllerDocsTest`
+- Files:
+  - Modify: `bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt`
+  - Modify: `bottlenote-admin-api/src/test/kotlin/app/docs/alcohols/AdminRegionControllerDocsTest.kt`
+  - Modify: `bottlenote-admin-api/src/docs/asciidoc/api/admin-reference/reference.adoc`
+- Size: S
+- Status: [x] done
+
+### Task 9: full verification과 PR
+
+- Acceptance: GSL `/verify full`에 해당하는 전체 검증이 통과하고 PR이 생성된다.
+- Verification:
+  - `./gradlew check_rule_test`
+  - `./gradlew unit_test integration_test`
+  - `./gradlew admin_integration_test`
+  - `./gradlew :bottlenote-admin-api:test`
+  - `./gradlew asciidoctor`
+- Files:
+  - Modify: `plan/admin-bulk-reorder.md`
+- Size: S
+- Status: [x] done
+
+## Progress Log
+
+- 2026-05-23: `/define` 완료. baseline `./gradlew test` BUILD SUCCESSFUL in 1m 37s.
+- 2026-05-23: `/plan` 태스크 9개로 분해.
+- 2026-05-23: `codex/alcohol-lookup` 기반 워크트리 변경분을 `origin/main` 기반 `feat/admin-bulk-reorder-main` 워크트리로 충돌 없이 이식.
+- 2026-05-23: `./gradlew integration_test` 최초 실패 원인은 새 워크트리의 `git.environment-variables` 서브모듈 미초기화로 확인. `git submodule update --init --recursive` 후 재실행 통과.
+- 2026-05-23: `/verify full` 완료. compile, check_rule_test, unit_test, build, integration_test, admin_integration_test, admin-api test, asciidoctor 모두 BUILD SUCCESSFUL.

--- a/plan/complete/admin-bulk-reorder.md
+++ b/plan/complete/admin-bulk-reorder.md
@@ -263,3 +263,10 @@ PATCH /admin/api/v1/regions/{regionId}/sort-order
 - 2026-05-23: `codex/alcohol-lookup` 기반 워크트리 변경분을 `origin/main` 기반 `feat/admin-bulk-reorder-main` 워크트리로 충돌 없이 이식.
 - 2026-05-23: `./gradlew integration_test` 최초 실패 원인은 새 워크트리의 `git.environment-variables` 서브모듈 미초기화로 확인. `git submodule update --init --recursive` 후 재실행 통과.
 - 2026-05-23: `/verify full` 완료. compile, check_rule_test, unit_test, build, integration_test, admin_integration_test, admin-api test, asciidoctor 모두 BUILD SUCCESSFUL.
+- 2026-05-23: 추가 네거티브/바운더리 테스트 보강. 요청 DTO 빈 배열, 100개 초과, null ID, 0 이하 ID, 100개 정상 케이스와 도메인별 존재하지 않는 ID/중복 ID/scope mismatch 케이스를 명시적으로 검증.
+
+## Completion
+
+- Completed at: 2026-05-23
+- PR: https://github.com/bottle-note/bottle-note-api-server/pull/614
+- Issue: https://github.com/bottle-note/workspace/issues/258


### PR DESCRIPTION
## Summary

- Add admin bulk reorder APIs for banners, curations, distilleries, regions, and child regions.
- Standardize endpoint path to `/bulk/reorder` while preserving existing single-item sort APIs.
- Use relative front-of-scope reorder semantics with request body `{ "ids": [...] }`, limited to 1-100 IDs.
- Add clear adoc documentation with ASCII examples, inactive/hidden item caveats, and region child scope rules.
- Complete the GSL plan document under `plan/complete/admin-bulk-reorder.md`.

## API

- `PATCH /admin/api/v1/banners/bulk/reorder`
- `PATCH /admin/api/v1/curations/bulk/reorder`
- `PATCH /admin/api/v1/distilleries/bulk/reorder`
- `PATCH /admin/api/v1/regions/bulk/reorder`
- `PATCH /admin/api/v1/regions/{parentId}/children/bulk/reorder`

## Behavior

```json
{ "ids": [3, 1, 6, 5] }
```

The requested IDs are moved to the front of the target scope in array order. Existing non-requested items are pushed behind them while preserving their relative order.

Example:

```text
Before:  [11, 1, 3, 5, 6]
Request: [3, 1, 6, 5]
After:   [3, 1, 6, 5, 11]
```

Notes:

- IDs can be reordered even when the item is inactive or not currently exposed.
- Visibility filters may make the final rendered order look like `1, 3, 5, 6` or similar subsets.
- Child region reorder only accepts direct children of `parentId`.

## Test Coverage

- Positive: each domain reorders requested IDs to the front while preserving non-requested relative order.
- Negative: duplicate IDs, unknown IDs, unknown child-region parent ID, and child-region scope mismatch.
- Boundary: request `ids` validation for empty array, 100 IDs accepted, 101 IDs rejected, null ID rejected, and ID less than 1 rejected.

## Verification

- `./gradlew compileJava compileTestJava` - PASS
- `./gradlew :bottlenote-admin-api:compileKotlin :bottlenote-admin-api:compileTestKotlin` - PASS
- `./gradlew check_rule_test` - PASS
- `./gradlew unit_test` - PASS
- `./gradlew build -x test -x asciidoctor --build-cache --parallel` - PASS
- `./gradlew integration_test` - PASS after initializing `git.environment-variables` submodule
- `./gradlew admin_integration_test` - PASS
- `./gradlew :bottlenote-admin-api:test` - PASS
- `./gradlew asciidoctor` - PASS
- `./gradlew :bottlenote-mono:test --tests app.bottlenote.global.dto.request.AdminBulkReorderRequestTest --tests app.bottlenote.banner.service.AdminBannerServiceTest --tests app.bottlenote.alcohols.service.AdminCurationServiceTest --tests app.bottlenote.alcohols.service.DistilleryServiceTest --tests app.bottlenote.alcohols.service.AdminRegionServiceTest` - PASS
- `./gradlew unit_test` - PASS after adding negative/boundary tests

Refs bottle-note/workspace#258
