### PR TITLE
fix: bulk reorder 정렬값 재번호 부여

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminCurationService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminCurationService.java
@@ -178,10 +178,8 @@ public class AdminCurationService {
             .filter(curation -> !requestedIds.contains(curation.getId()))
             .toList());
 
-    List<Integer> slots =
-        orderedCurations.stream().map(CurationKeyword::getDisplayOrder).sorted().toList();
     for (int i = 0; i < reordered.size(); i++) {
-      reordered.get(i).updateDisplayOrder(slots.get(i));
+      reordered.get(i).updateDisplayOrder(i + 1);
     }
     return AdminResultResponse.of(CURATION_DISPLAY_ORDER_UPDATED, null);
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminRegionService.java
@@ -248,9 +248,8 @@ public class AdminRegionService {
     reordered.addAll(
         orderedRegions.stream().filter(region -> !requestedIds.contains(region.getId())).toList());
 
-    List<Integer> slots = orderedRegions.stream().map(Region::getSortOrder).sorted().toList();
     for (int i = 0; i < reordered.size(); i++) {
-      reordered.get(i).updateSortOrder(slots.get(i));
+      reordered.get(i).updateSortOrder(i + 1);
     }
   }
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/DistilleryService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/DistilleryService.java
@@ -125,7 +125,10 @@ public class DistilleryService {
   public AdminResultResponse reorder(AdminBulkReorderRequest request) {
     validateReorderIds(request.ids());
 
-    List<Distillery> orderedDistilleries = distilleryRepository.findAllOrderBySortOrderAsc();
+    List<Distillery> orderedDistilleries =
+        distilleryRepository.findAllOrderBySortOrderAsc().stream()
+            .filter(distillery -> !Long.valueOf(0L).equals(distillery.getId()))
+            .toList();
     Map<Long, Distillery> distilleryById =
         orderedDistilleries.stream()
             .collect(Collectors.toMap(Distillery::getId, Function.identity()));
@@ -139,10 +142,8 @@ public class DistilleryService {
             .filter(distillery -> !requestedIds.contains(distillery.getId()))
             .toList());
 
-    List<Integer> slots =
-        orderedDistilleries.stream().map(Distillery::getSortOrder).sorted().toList();
     for (int i = 0; i < reordered.size(); i++) {
-      reordered.get(i).updateSortOrder(slots.get(i));
+      reordered.get(i).updateSortOrder(i + 1);
     }
     return AdminResultResponse.of(DISTILLERY_SORT_ORDER_UPDATED, null);
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/banner/service/AdminBannerService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/banner/service/AdminBannerService.java
@@ -203,9 +203,8 @@ public class AdminBannerService {
     reordered.addAll(
         orderedBanners.stream().filter(banner -> !requestedIds.contains(banner.getId())).toList());
 
-    List<Integer> slots = orderedBanners.stream().map(Banner::getSortOrder).sorted().toList();
     for (int i = 0; i < reordered.size(); i++) {
-      reordered.get(i).updateSortOrder(slots.get(i));
+      reordered.get(i).updateSortOrder(i + 1);
     }
     return AdminResultResponse.of(BANNER_SORT_ORDER_UPDATED, null);
   }

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminCurationServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminCurationServiceTest.java
@@ -33,24 +33,22 @@ class AdminCurationServiceTest {
   @Test
   @DisplayName("요청 ID가 주어졌을 때 전체 큐레이션 목록의 맨 앞으로 재배치한다")
   void reorderToFront_whenIdsRequested_updatesRelativeOrder() {
-    CurationKeyword first = saveCuration("기존 맨 앞", 1);
-    CurationKeyword second = saveCuration("두 번째", 10);
-    CurationKeyword third = saveCuration("세 번째", 20);
-    CurationKeyword fourth = saveCuration("네 번째", 30);
-    CurationKeyword fifth = saveCuration("다섯 번째", 40);
+    CurationKeyword first = saveCuration("기존 맨 앞", 0);
+    CurationKeyword second = saveCuration("두 번째", 1);
+    CurationKeyword third = saveCuration("세 번째", 1);
+    CurationKeyword fourth = saveCuration("네 번째", 1);
+    CurationKeyword fifth = saveCuration("다섯 번째", 20);
 
     adminCurationService.reorder(
         new AdminBulkReorderRequest(
-            List.of(third.getId(), second.getId(), fifth.getId(), fourth.getId())));
+            List.of(third.getId(), first.getId(), fourth.getId(), second.getId())));
 
     List<CurationKeyword> result = curationKeywordRepository.findAllOrderByDisplayOrderAsc();
     assertThat(result)
         .extracting(CurationKeyword::getId)
         .containsExactly(
-            third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
-    assertThat(result)
-        .extracting(CurationKeyword::getDisplayOrder)
-        .containsExactly(1, 10, 20, 30, 40);
+            third.getId(), first.getId(), fourth.getId(), second.getId(), fifth.getId());
+    assertThat(result).extracting(CurationKeyword::getDisplayOrder).containsExactly(1, 2, 3, 4, 5);
   }
 
   @Test

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminRegionServiceTest.java
@@ -285,7 +285,7 @@ class AdminRegionServiceTest {
           .extracting(Region::getId)
           .containsExactly(
               third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
-      assertThat(result).extracting(Region::getSortOrder).containsExactly(1, 10, 20, 30, 40);
+      assertThat(result).extracting(Region::getSortOrder).containsExactly(1, 2, 3, 4, 5);
     }
 
     @Test
@@ -306,7 +306,7 @@ class AdminRegionServiceTest {
       assertThat(result)
           .extracting(Region::getId)
           .containsExactly(third.getId(), second.getId(), first.getId(), fourth.getId());
-      assertThat(result).extracting(Region::getSortOrder).containsExactly(1, 10, 20, 30);
+      assertThat(result).extracting(Region::getSortOrder).containsExactly(1, 2, 3, 4);
       assertThat(regionRepository.findById(otherChild.getId()).orElseThrow().getSortOrder())
           .isEqualTo(5);
     }

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/DistilleryServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/DistilleryServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @Tag("unit")
 @DisplayName("DistilleryService 단위 테스트")
@@ -323,7 +324,42 @@ class DistilleryServiceTest {
           .extracting(Distillery::getId)
           .containsExactly(
               third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
-      assertThat(result).extracting(Distillery::getSortOrder).containsExactly(1, 10, 20, 30, 40);
+      assertThat(result).extracting(Distillery::getSortOrder).containsExactly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("id 0 기본 증류소는 bulk reorder 범위에서 제외한다")
+    void reorder_whenDefaultDistilleryExists_excludesIdZero() {
+      Distillery defaultDistillery =
+          distilleryRepository.save(
+              Distillery.builder().korName("기본값").engName("Default").sortOrder(0).build());
+      ReflectionTestUtils.setField(defaultDistillery, "id", 0L);
+      Distillery first =
+          distilleryRepository.save(
+              Distillery.builder().korName("기존 맨 앞").engName("First").sortOrder(1).build());
+      Distillery second =
+          distilleryRepository.save(
+              Distillery.builder().korName("두 번째").engName("Second").sortOrder(1).build());
+      Distillery third =
+          distilleryRepository.save(
+              Distillery.builder().korName("세 번째").engName("Third").sortOrder(10).build());
+
+      distilleryService.reorder(
+          new AdminBulkReorderRequest(List.of(third.getId(), first.getId(), second.getId())));
+
+      assertThat(defaultDistillery.getSortOrder()).isZero();
+      assertThat(
+              distilleryRepository.findAllOrderBySortOrderAsc().stream()
+                  .filter(distillery -> !Long.valueOf(0L).equals(distillery.getId()))
+                  .toList())
+          .extracting(Distillery::getId)
+          .containsExactly(third.getId(), first.getId(), second.getId());
+      assertThat(
+              distilleryRepository.findAllOrderBySortOrderAsc().stream()
+                  .filter(distillery -> !Long.valueOf(0L).equals(distillery.getId()))
+                  .toList())
+          .extracting(Distillery::getSortOrder)
+          .containsExactly(1, 2, 3);
     }
 
     @Test

--- a/bottlenote-mono/src/test/java/app/bottlenote/banner/service/AdminBannerServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/banner/service/AdminBannerServiceTest.java
@@ -46,7 +46,7 @@ class AdminBannerServiceTest {
         .extracting(Banner::getId)
         .containsExactly(
             third.getId(), second.getId(), fifth.getId(), fourth.getId(), first.getId());
-    assertThat(result).extracting(Banner::getSortOrder).containsExactly(1, 10, 20, 30, 40);
+    assertThat(result).extracting(Banner::getSortOrder).containsExactly(1, 2, 3, 4, 5);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Admin bulk reorder가 기존 sort/display order 슬롯을 재사용하던 방식을 제거했습니다.
- 요청 `ids` 순서대로 대상 항목을 맨 앞에 배치하고, 전체 reorder scope를 `1..N` 연속 정렬값으로 재번호 부여합니다.
- distillery의 `id=0` 기본값 항목은 bulk reorder scope에서 제외했습니다.

## Problem

개발 서버 검증 중 `PATCH /admin/api/v1/curations/bulk/reorder`에서 아래 불일치를 확인했습니다.

```text
request ids: [5, 17, 1, 29]
expected:    5 -> 17 -> 1 -> 29
actual:      5 -> 29 -> 17 -> 1
```

원인은 기존 구현이 `displayOrder`를 새로 부여하지 않고 기존 슬롯 `[0, 1, 1, 1, ...]`을 재사용했기 때문입니다. 같은 정렬값이 유지되면 조회 쿼리의 tie-breaker에 의해 요청 순서가 깨질 수 있습니다.

## Changes

- `AdminBannerService.reorder()`
  - 기존 `sortOrder` 슬롯 재사용 제거
  - `1..N` 순번 재부여
- `AdminCurationService.reorder()`
  - 기존 `displayOrder` 슬롯 재사용 제거
  - `1..N` 순번 재부여
- `DistilleryService.reorder()`
  - `id=0` 기본 증류소를 reorder scope에서 제외
  - 나머지 증류소에 `1..N` 순번 재부여
- `AdminRegionService.reorder()` / `reorderChildren()`
  - scope 내 항목에 `1..N` 순번 재부여
- 회귀 테스트 보강
  - 중복 displayOrder 상태에서도 curation 요청 순서가 보장되는지 검증
  - distillery `id=0` 기본값 제외 검증
  - banner/region/distillery 정렬값 기대치를 연속 번호 기준으로 갱신

## Verification

- `git diff --check`
- `./gradlew :bottlenote-mono:test --tests 'app.bottlenote.banner.service.AdminBannerServiceTest' --tests 'app.bottlenote.alcohols.service.AdminCurationServiceTest' --tests 'app.bottlenote.alcohols.service.DistilleryServiceTest' --tests 'app.bottlenote.alcohols.service.AdminRegionServiceTest'`
- `./gradlew :bottlenote-admin-api:test`
- `./gradlew unit_test`

## Follow-up

배포 후 dev API에서 다시 아래 흐름으로 확인하면 됩니다.

```text
조회 -> bulk reorder -> 재조회 -> 원복 -> 재조회
```

특히 `curations`는 기존 중복 `displayOrder=1` 데이터가 있어 이번 수정 효과를 바로 확인할 수 있습니다.
