### PR TITLE
fix: 배치 테스트 liquibase 비활성화로 컨텍스트 실패 해결

### DIFF
--- a/bottlenote-batch/src/test/resources/application.yml
+++ b/bottlenote-batch/src/test/resources/application.yml
@@ -26,6 +26,10 @@ spring:
         format_sql: false
     show-sql: false
 
+  # Liquibase 비활성화 (컨텍스트 배선 검증만 하므로 도메인 스키마 불필요)
+  liquibase:
+    enabled: false
+
   # Redis
   data:
     redis:


### PR DESCRIPTION
## 개요

`batch_test` 3건이 main에서 실패하는 기존 이슈를 수정합니다. PR #623 작업 중 발견된 건으로, 해당 PR과는 무관한 사전 존재 실패라 분리했습니다.

## 원인

batch 테스트 yml에 liquibase 설정이 없습니다. Liquibase 라이브러리는 mono를 통해 classpath에 들어오므로 자동설정이 활성화되고, `change-log` 미지정 시 기본 경로(`db/changelog/db.changelog-master.yaml`)를 찾다가 파일 부재로 컨텍스트 부팅이 실패합니다. mono가 liquibase-core를 의존성에 추가한 시점부터 조용히 깨진 것으로 추정됩니다.

## 수정

`bottlenote-batch/src/test/resources/application.yml`에 `spring.liquibase.enabled: false` 추가 (1줄 + 주석).

현재 batch 테스트(`BatchApplicationContextTest`)는 빈 MySQL 컨테이너 + `ddl-auto: none`으로 빈 배선만 검증하고 도메인 테이블을 사용하지 않으므로, 스키마 생성이 아니라 비활성화가 테스트 의도에 부합합니다. 추후 batch에 데이터 흐름 통합 테스트가 생기면 product/admin처럼 `change-log: classpath:storage/mysql/changelog/schema.mysql.sql` 지정으로 전환하면 됩니다.

## 검증

- `./gradlew batch_test`: 3건 모두 통과 (수정 전: main에서 3건 모두 실패)

Generated with [Claude Code](https://claude.com/claude-code)