### PR TITLE
feat: VisitorTelemetry 사용자 식별 정보 저장

### DIFF
--- a/bottlenote-batch/src/main/java/app/batch/bottlenote/visitor/VisitorTelemetryJdbcWriter.java
+++ b/bottlenote-batch/src/main/java/app/batch/bottlenote/visitor/VisitorTelemetryJdbcWriter.java
@@ -11,10 +11,11 @@ final class VisitorTelemetryJdbcWriter {
   private static final String INSERT_SQL =
       """
       INSERT INTO visitor_telemetry_events (
-          stream_event_id, occurred_at, visitor_id, trace_id, http_method,
-          request_path, request_uri, normalized_request_path, status_code, duration_ms,
-          device_type, operating_system, browser, browser_major_version, is_webview
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          stream_event_id, occurred_at, visitor_id, user_id, ip_address,
+          trace_id, http_method, request_path, request_uri, normalized_request_path,
+          status_code, duration_ms, device_type, operating_system, browser,
+          browser_major_version, is_webview
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON DUPLICATE KEY UPDATE stream_event_id = VALUES(stream_event_id)
       """;
 
@@ -36,18 +37,20 @@ final class VisitorTelemetryJdbcWriter {
                   statement.setString(1, message.streamEventId());
                   statement.setObject(2, message.occurredAt());
                   statement.setString(3, message.visitorId());
-                  statement.setString(4, message.traceId());
-                  statement.setString(5, message.httpMethod());
-                  statement.setString(6, message.requestPath());
-                  statement.setString(7, message.requestUri());
-                  statement.setString(8, message.normalizedRequestPath());
-                  statement.setInt(9, message.statusCode());
-                  statement.setLong(10, message.durationMs());
-                  statement.setString(11, message.deviceType());
-                  statement.setString(12, message.operatingSystem());
-                  statement.setString(13, message.browser());
-                  statement.setString(14, message.browserMajorVersion());
-                  statement.setBoolean(15, message.webview());
+                  statement.setObject(4, message.userId());
+                  statement.setString(5, message.ipAddress());
+                  statement.setString(6, message.traceId());
+                  statement.setString(7, message.httpMethod());
+                  statement.setString(8, message.requestPath());
+                  statement.setString(9, message.requestUri());
+                  statement.setString(10, message.normalizedRequestPath());
+                  statement.setInt(11, message.statusCode());
+                  statement.setLong(12, message.durationMs());
+                  statement.setString(13, message.deviceType());
+                  statement.setString(14, message.operatingSystem());
+                  statement.setString(15, message.browser());
+                  statement.setString(16, message.browserMajorVersion());
+                  statement.setBoolean(17, message.webview());
                 }));
   }
 }

--- a/bottlenote-batch/src/main/java/app/batch/bottlenote/visitor/VisitorTelemetryMessage.java
+++ b/bottlenote-batch/src/main/java/app/batch/bottlenote/visitor/VisitorTelemetryMessage.java
@@ -8,6 +8,8 @@ record VisitorTelemetryMessage(
     String streamEventId,
     LocalDateTime occurredAt,
     String visitorId,
+    Long userId,
+    String ipAddress,
     String traceId,
     String httpMethod,
     String requestPath,
@@ -22,11 +24,14 @@ record VisitorTelemetryMessage(
     boolean webview) {
 
   static VisitorTelemetryMessage from(String streamEventId, Map<String, String> fields) {
+    String userId = optional(fields, "user_id", 20);
     try {
       return new VisitorTelemetryMessage(
           required(streamEventId, "stream_event_id", 41),
           LocalDateTime.parse(required(fields, "occurred_at", 26)),
           required(fields, "visitor_id", 64),
+          userId == null ? null : Long.valueOf(userId),
+          optional(fields, "ip_address", 45),
           optional(fields, "trace_id", 64),
           required(fields, "http_method", 10),
           required(fields, "request_path", 2048),
@@ -41,6 +46,8 @@ record VisitorTelemetryMessage(
           strictBoolean(fields, "is_webview"));
     } catch (DateTimeParseException exception) {
       throw new IllegalArgumentException("occurred_at 형식이 올바르지 않습니다", exception);
+    } catch (NumberFormatException exception) {
+      throw new IllegalArgumentException("user_id 필드가 숫자가 아닙니다", exception);
     }
   }
 

--- a/bottlenote-batch/src/test/java/app/batch/bottlenote/visitor/VisitorTelemetryMessageTest.java
+++ b/bottlenote-batch/src/test/java/app/batch/bottlenote/visitor/VisitorTelemetryMessageTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 class VisitorTelemetryMessageTest {
 
   @Test
-  @DisplayName("정상 필드를 Batch 내부 메시지로 변환하고 선택 필드는 null로 처리한다")
+  @DisplayName("새 필드를 변환하고 기존 Stream의 선택 필드는 null로 처리한다")
   void 정상_필드를_변환한다() {
     Map<String, String> fields = validFields();
     fields.put("trace_id", "");
@@ -22,11 +22,19 @@ class VisitorTelemetryMessageTest {
     fields.put("future_field", "ignored");
 
     VisitorTelemetryMessage message = VisitorTelemetryMessage.from("1-0", fields);
+    Map<String, String> legacyFields = validFields();
+    legacyFields.remove("user_id");
+    legacyFields.remove("ip_address");
+    VisitorTelemetryMessage legacyMessage = VisitorTelemetryMessage.from("2-0", legacyFields);
 
     assertThat(message.streamEventId()).isEqualTo("1-0");
+    assertThat(message.userId()).isEqualTo(42L);
+    assertThat(message.ipAddress()).isEqualTo("2001:db8::1");
     assertThat(message.traceId()).isNull();
     assertThat(message.browserMajorVersion()).isNull();
     assertThat(message.webview()).isFalse();
+    assertThat(legacyMessage.userId()).isNull();
+    assertThat(legacyMessage.ipAddress()).isNull();
   }
 
   @Test
@@ -57,12 +65,24 @@ class VisitorTelemetryMessageTest {
     invalidTime.put("occurred_at", "2026/07/17");
     assertThatThrownBy(() -> VisitorTelemetryMessage.from("1-0", invalidTime))
         .hasMessageContaining("occurred_at");
+
+    Map<String, String> invalidUserId = validFields();
+    invalidUserId.put("user_id", "not-number");
+    assertThatThrownBy(() -> VisitorTelemetryMessage.from("1-0", invalidUserId))
+        .hasMessageContaining("user_id");
+
+    Map<String, String> tooLongIpAddress = validFields();
+    tooLongIpAddress.put("ip_address", "a".repeat(46));
+    assertThatThrownBy(() -> VisitorTelemetryMessage.from("1-0", tooLongIpAddress))
+        .hasMessageContaining("ip_address");
   }
 
   static Map<String, String> validFields() {
     Map<String, String> fields = new LinkedHashMap<>();
     fields.put("occurred_at", "2026-07-17T01:20:13.717000");
     fields.put("visitor_id", "a".repeat(64));
+    fields.put("user_id", "42");
+    fields.put("ip_address", "2001:db8::1");
     fields.put("trace_id", "trace-id");
     fields.put("http_method", "GET");
     fields.put("request_path", "/api/v1/alcohols/search?keyword=test");

--- a/bottlenote-batch/src/test/java/app/batch/bottlenote/visitor/VisitorTelemetryStreamConsumerIntegrationTest.java
+++ b/bottlenote-batch/src/test/java/app/batch/bottlenote/visitor/VisitorTelemetryStreamConsumerIntegrationTest.java
@@ -65,6 +65,8 @@ class VisitorTelemetryStreamConsumerIntegrationTest {
           stream_event_id VARCHAR(41) NOT NULL UNIQUE,
           occurred_at DATETIME(6) NOT NULL,
           visitor_id CHAR(64) NOT NULL,
+          user_id BIGINT NULL,
+          ip_address VARCHAR(45) ASCII NULL,
           trace_id VARCHAR(64) NULL,
           http_method VARCHAR(10) NOT NULL,
           request_path VARCHAR(2048) NOT NULL,
@@ -110,12 +112,27 @@ class VisitorTelemetryStreamConsumerIntegrationTest {
   @Test
   @DisplayName("기존 Stream부터 소비해 DB 저장 후 ACK하고 삭제한다")
   void 기존_Stream을_소비하고_저장한다() {
+    Map<String, String> legacyFields = validFields();
+    legacyFields.remove("user_id");
+    legacyFields.remove("ip_address");
+    redisTemplate.opsForStream().add(properties.getStreamKey(), legacyFields);
     redisTemplate.opsForStream().add(properties.getStreamKey(), validFields());
 
     consumer.start();
 
     await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-      assertThat(rowCount()).isEqualTo(1);
+      assertThat(rowCount()).isEqualTo(2);
+      assertThat(
+              jdbcTemplate.queryForObject(
+                  "SELECT COUNT(*) FROM visitor_telemetry_events "
+                      + "WHERE user_id IS NULL AND ip_address IS NULL",
+                  Integer.class))
+          .isEqualTo(1);
+      assertThat(
+              jdbcTemplate.queryForObject(
+                  "SELECT ip_address FROM visitor_telemetry_events WHERE user_id = 42",
+                  String.class))
+          .isEqualTo("2001:db8::1");
       assertThat(redisTemplate.opsForStream().size(properties.getStreamKey())).isZero();
       assertThat(
               redisTemplate
@@ -193,6 +210,8 @@ class VisitorTelemetryStreamConsumerIntegrationTest {
             java.time.LocalDateTime.now().minusDays(91),
             "a".repeat(64),
             null,
+            null,
+            null,
             "GET",
             "/api/v1/old",
             "/api/v1/old",
@@ -209,6 +228,8 @@ class VisitorTelemetryStreamConsumerIntegrationTest {
             "recent-0",
             java.time.LocalDateTime.now().minusDays(89),
             "b".repeat(64),
+            null,
+            null,
             null,
             "GET",
             "/api/v1/recent",

--- a/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetry.java
+++ b/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetry.java
@@ -9,6 +9,8 @@ import java.util.Map;
 public record VisitorTelemetry(
     LocalDateTime occurredAt,
     String visitorId,
+    Long userId,
+    String ipAddress,
     String traceId,
     String httpMethod,
     String requestPath,
@@ -30,6 +32,8 @@ public record VisitorTelemetry(
     Map<String, String> fields = new LinkedHashMap<>();
     fields.put("occurred_at", occurredAt.format(DATE_TIME_FORMATTER));
     fields.put("visitor_id", visitorId);
+    fields.put("user_id", userId == null ? "" : Long.toString(userId));
+    fields.put("ip_address", ipAddress == null ? "" : ipAddress);
     fields.put("trace_id", traceId == null ? "" : traceId);
     fields.put("http_method", httpMethod);
     fields.put("request_path", requestPath);

--- a/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetryConfiguration.java
+++ b/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetryConfiguration.java
@@ -1,5 +1,6 @@
 package app.bottlenote.observability.visitor;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -26,11 +27,7 @@ public class VisitorTelemetryConfiguration {
   }
 
   @Bean
-  public VisitorTelemetryFilter visitorTelemetryFilter(VisitorTelemetryPublisher publisher) {
-    return new VisitorTelemetryFilter(publisher);
-  }
-
-  @Bean
+  @ConditionalOnBean(VisitorTelemetryFilter.class)
   FilterRegistrationBean<VisitorTelemetryFilter> visitorTelemetryFilterRegistration(
       VisitorTelemetryFilter filter) {
     FilterRegistrationBean<VisitorTelemetryFilter> registration =

--- a/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetryFilter.java
+++ b/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetryFilter.java
@@ -19,6 +19,8 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
@@ -55,14 +57,25 @@ public final class VisitorTelemetryFilter extends OncePerRequestFilter {
           "phone");
 
   private final VisitorTelemetryPublisher publisher;
+  private final Supplier<Long> userIdSupplier;
+  private final Function<HttpServletRequest, String> clientIpResolver;
   private final Clock clock;
 
-  public VisitorTelemetryFilter(VisitorTelemetryPublisher publisher) {
-    this(publisher, Clock.system(KOREA_ZONE_ID));
+  public VisitorTelemetryFilter(
+      VisitorTelemetryPublisher publisher,
+      Supplier<Long> userIdSupplier,
+      Function<HttpServletRequest, String> clientIpResolver) {
+    this(publisher, userIdSupplier, clientIpResolver, Clock.system(KOREA_ZONE_ID));
   }
 
-  VisitorTelemetryFilter(VisitorTelemetryPublisher publisher, Clock clock) {
+  VisitorTelemetryFilter(
+      VisitorTelemetryPublisher publisher,
+      Supplier<Long> userIdSupplier,
+      Function<HttpServletRequest, String> clientIpResolver,
+      Clock clock) {
     this.publisher = publisher;
+    this.userIdSupplier = userIdSupplier;
+    this.clientIpResolver = clientIpResolver;
     this.clock = clock;
   }
 
@@ -136,6 +149,8 @@ public final class VisitorTelemetryFilter extends OncePerRequestFilter {
     return new VisitorTelemetry(
         LocalDateTime.now(clock),
         digest(visitorId),
+        userIdSupplier.get(),
+        clientIpResolver.apply(request),
         MDC.get("traceId"),
         request.getMethod(),
         sanitizedRequestPath(request),

--- a/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetryPublisher.java
+++ b/bottlenote-observability/src/main/java/app/bottlenote/observability/visitor/VisitorTelemetryPublisher.java
@@ -1,6 +1,6 @@
 package app.bottlenote.observability.visitor;
 
-interface VisitorTelemetryPublisher {
+public interface VisitorTelemetryPublisher {
 
   void publish(VisitorTelemetry telemetry);
 }

--- a/bottlenote-observability/src/test/java/app/bottlenote/observability/visitor/VisitorTelemetryConfigurationTest.java
+++ b/bottlenote-observability/src/test/java/app/bottlenote/observability/visitor/VisitorTelemetryConfigurationTest.java
@@ -32,10 +32,15 @@ class VisitorTelemetryConfigurationTest {
   }
 
   @Test
-  @DisplayName("활성화하면 필터를 생성하지만 Servlet 자동 등록은 비활성화한다")
+  @DisplayName("활성화하면 Publisher를 생성하고 Product 필터의 Servlet 자동 등록을 비활성화한다")
   void 활성화하면_Security_chain_연결용_필터를_생성한다() {
     contextRunner
         .withPropertyValues("bottlenote.observability.visitor-telemetry.enabled=true")
+        .withBean(
+            VisitorTelemetryFilter.class,
+            () ->
+                new VisitorTelemetryFilter(
+                    telemetry -> {}, () -> null, request -> null))
         .run(
             context -> {
               assertThat(context).hasSingleBean(VisitorTelemetryFilter.class);

--- a/bottlenote-observability/src/test/java/app/bottlenote/observability/visitor/VisitorTelemetryFilterTest.java
+++ b/bottlenote-observability/src/test/java/app/bottlenote/observability/visitor/VisitorTelemetryFilterTest.java
@@ -39,7 +39,9 @@ class VisitorTelemetryFilterTest {
   @DisplayName("최초 성공 요청은 쿠키를 발급하고 같은 방문자를 즉시 발행한다")
   void 최초_성공_요청을_발행한다() throws Exception {
     CapturingPublisher publisher = new CapturingPublisher();
-    VisitorTelemetryFilter filter = new VisitorTelemetryFilter(publisher, FIXED_CLOCK);
+    VisitorTelemetryFilter filter =
+        new VisitorTelemetryFilter(
+            publisher, () -> 42L, request -> "203.0.113.10", FIXED_CLOCK);
     MockHttpServletRequest request =
         new MockHttpServletRequest("GET", "/api/v1/alcohols/search");
     MockHttpServletResponse response = new MockHttpServletResponse();
@@ -59,6 +61,8 @@ class VisitorTelemetryFilterTest {
     assertThat(issuedVisitorId).satisfies(value -> UUID.fromString(value));
     assertThat(publisher.single()).satisfies(telemetry -> {
       assertThat(telemetry.visitorId()).isEqualTo(sha256(issuedVisitorId));
+      assertThat(telemetry.userId()).isEqualTo(42L);
+      assertThat(telemetry.ipAddress()).isEqualTo("203.0.113.10");
       assertThat(telemetry.occurredAt()).hasToString("2026-07-17T00:00");
       assertThat(telemetry.statusCode()).isEqualTo(200);
     });
@@ -68,7 +72,8 @@ class VisitorTelemetryFilterTest {
   @DisplayName("기존 쿠키와 라우트 패턴을 재사용하고 민감 쿼리 값만 치환한다")
   void 기존_쿠키와_정규화_경로를_발행한다() throws Exception {
     CapturingPublisher publisher = new CapturingPublisher();
-    VisitorTelemetryFilter filter = new VisitorTelemetryFilter(publisher, FIXED_CLOCK);
+    VisitorTelemetryFilter filter =
+        new VisitorTelemetryFilter(publisher, () -> null, request -> null, FIXED_CLOCK);
     MockHttpServletRequest request = request("GET", "/api/v1/alcohols/123");
     request.setCookies(new Cookie(VisitorTelemetryFilter.VISITOR_COOKIE_NAME, VISITOR_ID));
     request.setQueryString(
@@ -88,6 +93,8 @@ class VisitorTelemetryFilterTest {
     assertThat(response.getHeader(HttpHeaders.SET_COOKIE)).isNull();
     assertThat(publisher.single()).satisfies(telemetry -> {
       assertThat(telemetry.visitorId()).isEqualTo(sha256(VISITOR_ID));
+      assertThat(telemetry.userId()).isNull();
+      assertThat(telemetry.ipAddress()).isNull();
       assertThat(telemetry.traceId()).isEqualTo("trace-123");
       assertThat(telemetry.requestPath())
           .isEqualTo(
@@ -104,7 +111,8 @@ class VisitorTelemetryFilterTest {
   @DisplayName("잘못된 쿠키는 교체하고 교체한 방문자를 즉시 발행한다")
   void 잘못된_쿠키를_교체하고_발행한다() throws Exception {
     CapturingPublisher publisher = new CapturingPublisher();
-    VisitorTelemetryFilter filter = new VisitorTelemetryFilter(publisher, FIXED_CLOCK);
+    VisitorTelemetryFilter filter =
+        new VisitorTelemetryFilter(publisher, () -> null, request -> null, FIXED_CLOCK);
     MockHttpServletRequest request = request("GET", "/api/v1/alcohols/search");
     request.setCookies(
         new Cookie(VisitorTelemetryFilter.VISITOR_COOKIE_NAME, "client-created-value"));
@@ -122,7 +130,8 @@ class VisitorTelemetryFilterTest {
   @DisplayName("2xx가 아닌 응답은 쿠키와 텔레메트리를 남기지 않는다")
   void 성공하지_않은_응답은_기록하지_않는다(int status) throws Exception {
     CapturingPublisher publisher = new CapturingPublisher();
-    VisitorTelemetryFilter filter = new VisitorTelemetryFilter(publisher, FIXED_CLOCK);
+    VisitorTelemetryFilter filter =
+        new VisitorTelemetryFilter(publisher, () -> null, request -> null, FIXED_CLOCK);
     MockHttpServletRequest request = request("GET", "/api/v1/alcohols/search");
     MockHttpServletResponse response = new MockHttpServletResponse();
     FilterChain chain =
@@ -145,7 +154,8 @@ class VisitorTelemetryFilterTest {
   @DisplayName("수집 대상이 아닌 요청은 기록하지 않는다")
   void 수집_대상이_아닌_요청은_기록하지_않는다(String method, String path) throws Exception {
     CapturingPublisher publisher = new CapturingPublisher();
-    VisitorTelemetryFilter filter = new VisitorTelemetryFilter(publisher, FIXED_CLOCK);
+    VisitorTelemetryFilter filter =
+        new VisitorTelemetryFilter(publisher, () -> null, request -> null, FIXED_CLOCK);
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     filter.doFilter(request(method, path), response, successfulChain());
@@ -158,7 +168,8 @@ class VisitorTelemetryFilterTest {
   @DisplayName("Android와 iOS WebView 요청을 정규화한다")
   void WebView_요청을_정규화한다() throws Exception {
     CapturingPublisher publisher = new CapturingPublisher();
-    VisitorTelemetryFilter filter = new VisitorTelemetryFilter(publisher, FIXED_CLOCK);
+    VisitorTelemetryFilter filter =
+        new VisitorTelemetryFilter(publisher, () -> null, request -> null, FIXED_CLOCK);
     MockHttpServletRequest androidRequest = request("GET", "/api/v1/alcohols/search");
     androidRequest.addHeader(
         HttpHeaders.USER_AGENT,
@@ -194,7 +205,8 @@ class VisitorTelemetryFilterTest {
   void 주요_브라우저를_정규화한다(
       String expectedBrowser, String expectedVersion, String userAgent) throws Exception {
     CapturingPublisher publisher = new CapturingPublisher();
-    VisitorTelemetryFilter filter = new VisitorTelemetryFilter(publisher, FIXED_CLOCK);
+    VisitorTelemetryFilter filter =
+        new VisitorTelemetryFilter(publisher, () -> null, request -> null, FIXED_CLOCK);
     MockHttpServletRequest request = request("GET", "/api/v1/alcohols/search");
     request.addHeader(HttpHeaders.USER_AGENT, userAgent);
 
@@ -210,7 +222,12 @@ class VisitorTelemetryFilterTest {
   @DisplayName("발행 실패에도 응답 상태와 본문을 유지한다")
   void 발행_실패가_응답에_영향을_주지_않는다() throws Exception {
     VisitorTelemetryFilter filter =
-        new VisitorTelemetryFilter(telemetry -> { throw new IllegalStateException("redis down"); });
+        new VisitorTelemetryFilter(
+            telemetry -> {
+              throw new IllegalStateException("redis down");
+            },
+            () -> null,
+            request -> null);
     MockHttpServletRequest request = request("GET", "/api/v1/alcohols/search");
     MockHttpServletResponse response = new MockHttpServletResponse();
     FilterChain chain =

--- a/bottlenote-observability/src/test/java/app/bottlenote/observability/visitor/VisitorTelemetryTest.java
+++ b/bottlenote-observability/src/test/java/app/bottlenote/observability/visitor/VisitorTelemetryTest.java
@@ -19,6 +19,8 @@ class VisitorTelemetryTest {
         new VisitorTelemetry(
             LocalDateTime.of(2026, 7, 17, 1, 2, 3, 456_000_000),
             "visitor-hash",
+            42L,
+            "2001:db8::1",
             null,
             "GET",
             "/api/v1/alcohols?keyword=peated",
@@ -31,16 +33,40 @@ class VisitorTelemetryTest {
             "Chrome",
             "143",
             true);
+    VisitorTelemetry anonymousTelemetry =
+        new VisitorTelemetry(
+            LocalDateTime.of(2026, 7, 17, 1, 2, 3, 456_000_000),
+            "visitor-hash",
+            null,
+            null,
+            null,
+            "GET",
+            "/api/v1/alcohols",
+            "/api/v1/alcohols",
+            "/api/v1/alcohols",
+            200,
+            15,
+            "모바일",
+            "Android",
+            "Chrome",
+            "143",
+            false);
 
     Map<String, String> fields = telemetry.toStreamFields();
+    Map<String, String> anonymousFields = anonymousTelemetry.toStreamFields();
 
     assertThat(fields)
         .containsEntry("occurred_at", "2026-07-17T01:02:03.456000")
         .containsEntry("visitor_id", "visitor-hash")
+        .containsEntry("user_id", "42")
+        .containsEntry("ip_address", "2001:db8::1")
         .containsEntry("trace_id", "")
         .containsEntry("request_path", "/api/v1/alcohols?keyword=peated")
         .containsEntry("normalized_request_path", "/api/v1/alcohols")
         .containsEntry("is_webview", "true")
-        .doesNotContainKeys("user_id", "ip_hash", "user_agent_raw");
+        .doesNotContainKeys("ip_hash", "user_agent_raw");
+    assertThat(anonymousFields)
+        .containsEntry("user_id", "")
+        .containsEntry("ip_address", "");
   }
 }

--- a/bottlenote-product-api/src/main/java/app/global/security/SecurityConfig.java
+++ b/bottlenote-product-api/src/main/java/app/global/security/SecurityConfig.java
@@ -2,17 +2,23 @@ package app.global.security;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
+import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.global.security.constant.MaliciousPathPattern;
 import app.bottlenote.global.security.jwt.JwtAuthenticationEntryPoint;
 import app.bottlenote.global.security.jwt.JwtAuthenticationFilter;
 import app.bottlenote.global.security.jwt.JwtAuthenticationManager;
 import app.bottlenote.global.security.policy.SecurityPolicyRegistry;
 import app.bottlenote.observability.visitor.VisitorTelemetryFilter;
+import app.bottlenote.observability.visitor.VisitorTelemetryPublisher;
+import com.google.common.net.InetAddresses;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,6 +64,34 @@ public class SecurityConfig {
 
   private static boolean hasJwtException(HttpServletRequest request) {
     return request.getAttribute("exception") != null;
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "bottlenote.observability.visitor-telemetry",
+      name = "enabled",
+      havingValue = "true")
+  public static VisitorTelemetryFilter visitorTelemetryFilter(VisitorTelemetryPublisher publisher) {
+    Supplier<Long> userIdSupplier = () -> SecurityContextUtil.getUserIdByContext().orElse(null);
+    Function<HttpServletRequest, String> clientIpResolver =
+        request -> {
+          String forwardedFor = request.getHeader("X-Forwarded-For");
+          if (forwardedFor != null) {
+            for (String candidate : forwardedFor.split(",")) {
+              String trimmedCandidate = candidate.trim();
+              if (InetAddresses.isInetAddress(trimmedCandidate)) {
+                return InetAddresses.toAddrString(InetAddresses.forString(trimmedCandidate));
+              }
+            }
+          }
+
+          String remoteAddress = request.getRemoteAddr();
+          if (remoteAddress != null && InetAddresses.isInetAddress(remoteAddress)) {
+            return InetAddresses.toAddrString(InetAddresses.forString(remoteAddress));
+          }
+          return null;
+        };
+    return new VisitorTelemetryFilter(publisher, userIdSupplier, clientIpResolver);
   }
 
   /**

--- a/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
@@ -9,9 +9,14 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import app.bottlenote.IntegrationTestSupport;
 import app.bottlenote.global.annotation.SecurityPolicy.AuthType;
 import app.bottlenote.global.security.policy.SecurityPolicyRegistry;
+import app.bottlenote.observability.visitor.VisitorTelemetry;
+import app.bottlenote.observability.visitor.VisitorTelemetryFilter;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +28,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.DispatcherServlet;
 
 @Tag("integration")
@@ -141,6 +150,70 @@ class SecurityConfigIntegrationTest extends IntegrationTestSupport {
 
     // then - 200 OK 또는 정상 응답 (403이 아님)
     result.assertThat().hasStatusOk();
+  }
+
+  @Test
+  @DisplayName("VisitorTelemetry는 인증 사용자와 정규화한 클라이언트 IP를 수집한다")
+  void VisitorTelemetry_요청_문맥을_수집한다() throws Exception {
+    List<VisitorTelemetry> telemetries = new ArrayList<>();
+    VisitorTelemetryFilter filter = SecurityConfig.visitorTelemetryFilter(telemetries::add);
+
+    try {
+      SecurityContextHolder.getContext()
+          .setAuthentication(new TestingAuthenticationToken("42", null));
+      MockHttpServletRequest ipv4Request =
+          new MockHttpServletRequest("GET", "/api/v1/alcohols/search");
+      ipv4Request.addHeader("X-Forwarded-For", "203.0.113.10, 198.51.100.1");
+      ipv4Request.setRemoteAddr("192.0.2.1");
+      filter.doFilter(
+          ipv4Request,
+          new MockHttpServletResponse(),
+          (request, response) ->
+              ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_OK));
+
+      MockHttpServletRequest ipv6Request =
+          new MockHttpServletRequest("GET", "/api/v1/alcohols/search");
+      ipv6Request.addHeader("X-Forwarded-For", "unknown, 2001:0db8:0:0:0:0:0:1");
+      ipv6Request.setRemoteAddr("192.0.2.2");
+      filter.doFilter(
+          ipv6Request,
+          new MockHttpServletResponse(),
+          (request, response) ->
+              ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_OK));
+
+      SecurityContextHolder.clearContext();
+      MockHttpServletRequest fallbackRequest =
+          new MockHttpServletRequest("GET", "/api/v1/alcohols/search");
+      fallbackRequest.addHeader("X-Forwarded-For", "unknown, invalid");
+      fallbackRequest.setRemoteAddr("198.51.100.7");
+      filter.doFilter(
+          fallbackRequest,
+          new MockHttpServletResponse(),
+          (request, response) ->
+              ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_OK));
+
+      MockHttpServletRequest invalidRequest =
+          new MockHttpServletRequest("GET", "/api/v1/alcohols/search");
+      invalidRequest.addHeader("X-Forwarded-For", "unknown");
+      invalidRequest.setRemoteAddr("invalid");
+      filter.doFilter(
+          invalidRequest,
+          new MockHttpServletResponse(),
+          (request, response) ->
+              ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_OK));
+    } finally {
+      SecurityContextHolder.clearContext();
+    }
+
+    assertThat(telemetries).hasSize(4);
+    assertThat(telemetries.get(0).userId()).isEqualTo(42L);
+    assertThat(telemetries.get(0).ipAddress()).isEqualTo("203.0.113.10");
+    assertThat(telemetries.get(1).userId()).isEqualTo(42L);
+    assertThat(telemetries.get(1).ipAddress()).isEqualTo("2001:db8::1");
+    assertThat(telemetries.get(2).userId()).isNull();
+    assertThat(telemetries.get(2).ipAddress()).isEqualTo("198.51.100.7");
+    assertThat(telemetries.get(3).userId()).isNull();
+    assertThat(telemetries.get(3).ipAddress()).isNull();
   }
 
   @Test


### PR DESCRIPTION
## 변경 내역

### Product API

- JWT 필터가 구성한 `SecurityContext`에서 nullable user ID 수집
- `X-Forwarded-For`의 첫 유효 IPv4/IPv6를 표준 문자열로 정규화
- XFF가 유효하지 않으면 `remoteAddr`로 fallback하고 둘 다 유효하지 않으면 `NULL`
- 새 클래스 없이 `SecurityConfig`의 조건부 Filter Bean 메서드 1개만 추가

### Observability

- VisitorTelemetry 이벤트와 Redis Stream 계약에 `user_id`, `ip_address` 추가
- Product에서 필터를 구성할 수 있도록 Publisher 공개 범위 조정
- user ID와 IP는 debug/info 로그에 추가하지 않음

### Batch

- 기존 Stream 메시지에 새 필드가 없어도 `NULL`로 처리
- JDBC INSERT와 바인딩에 두 컬럼 추가
- 잘못된 user ID와 IP 최대 길이 검증
- Redis Stream → MySQL 통합 테스트에서 값/NULL/기존 계약 호환 확인

### Database changelog

- 환경 저장소 Draft PR: https://github.com/bottle-note/environment-variables/pull/4
- changeset: `schema.mysql.sql::20260720-1::hgkim`
- nullable `user_id BIGINT`, `ip_address VARCHAR(45) ASCII` 및 `(occurred_at, user_id)` 인덱스
- FK는 추가하지 않음

## 변경 이유

쿠키 기반 visitor ID는 브라우저·WebView 저장소 단위이므로 회원 DAU를 직접 나타내지 않습니다. 인증 user ID와 요청 IP 근거를 함께 저장해 회원/비회원 활동을 분리하고 현재 오염 데이터를 진단할 수 있도록 합니다.

## 의존성 및 범위

- 기존 방향 `product-api → mono/observability`, `mono → observability`, `batch → mono` 유지
- `observability → mono` 의존성 추가 없음
- User/OAuth Repository 재조회, JPA Entity, Domain Repository, Facade, FK 추가 없음
- 새 production 클래스 없음

## 검증

- Observability 단위 테스트: 21개 통과
- Product 요청 문맥 통합 테스트: 1개 통과
- Batch 메시지 계약 테스트: 3개 통과
- Batch Redis/MySQL 통합 테스트: 6개 통과
- Product API compile 성공
- 총 31개 테스트, 실패 0건

## DB 적용 결과

- Development `development_bottlenote`: 2026-07-20 적용 및 검증 완료
- Production `bottlenote`: 2026-07-20 적용 및 검증 완료
- 두 환경 모두 Liquibase 144/144 up-to-date, changeset `EXECUTED`, lock `0`
- 두 환경 모두 컬럼 nullable/길이와 복합 인덱스 순서 확인

## 배포 순서

1. Product API를 먼저 배포해 새 Redis 필드 발행
2. Envoy가 XFF를 정제하는지 development 요청으로 확인
3. Batch를 배포해 새 필드 저장
4. 인증·비인증 요청 후 DB 저장 결과 확인
5. 동일 순서로 production 반영