### PR TITLE
feat: 큐레이션 피드 복수 코드 조회 개선

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/domain/CurationExtensionRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/domain/CurationExtensionRepository.java
@@ -1,12 +1,16 @@
 package app.bottlenote.curation.domain;
 
 import app.bottlenote.common.annotation.DomainRepository;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @DomainRepository
 public interface CurationExtensionRepository {
 
   Optional<CurationExtension> findByCurationId(Long curationId);
+
+  List<CurationExtension> findAllByCurationIdIn(Collection<Long> curationIds);
 
   CurationExtension save(CurationExtension curationExtension);
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/domain/CurationRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/domain/CurationRepository.java
@@ -1,7 +1,9 @@
 package app.bottlenote.curation.domain;
 
 import app.bottlenote.common.annotation.DomainRepository;
+import app.bottlenote.curation.dto.dsl.CurationFeedSearchCriteria;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,10 @@ public interface CurationRepository {
   List<Curation> findAllByIsActiveTrueOrderByDisplayOrderAscIdAsc();
 
   List<Curation> findAllVisibleOn(LocalDate today);
+
+  List<Long> findFeedCandidateIds(CurationFeedSearchCriteria criteria);
+
+  List<Curation> findAllByIdIn(Collection<Long> ids);
 
   Optional<Curation> findVisibleById(Long id, LocalDate today);
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/domain/CurationSpecRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/domain/CurationSpecRepository.java
@@ -19,6 +19,8 @@ public interface CurationSpecRepository {
 
   List<CurationSpecListResponse> findAllActiveSpecSummaries();
 
+  List<CurationSpec> findAllByCodeIn(Collection<String> codes);
+
   List<CurationSpec> findAllByIdIn(Collection<Long> ids);
 
   boolean existsByCode(String code);

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/dto/dsl/CurationFeedSearchCriteria.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/dto/dsl/CurationFeedSearchCriteria.java
@@ -1,0 +1,18 @@
+package app.bottlenote.curation.dto.dsl;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+public record CurationFeedSearchCriteria(
+    String keyword,
+    Set<Long> specIds,
+    Set<Long> keywordMatchedSpecIds,
+    LocalDate today,
+    long offset,
+    int fetchSize) {
+
+  public CurationFeedSearchCriteria {
+    specIds = Set.copyOf(specIds);
+    keywordMatchedSpecIds = Set.copyOf(keywordMatchedSpecIds);
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/dto/request/CurationFeedSearchRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/dto/request/CurationFeedSearchRequest.java
@@ -1,0 +1,21 @@
+package app.bottlenote.curation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.Builder;
+
+public record CurationFeedSearchRequest(
+    @NotEmpty(message = "CURATION_CODE_REQUIRED")
+        List<@NotBlank(message = "CURATION_CODE_REQUIRED") String> code,
+    String keyword,
+    Long cursor,
+    Integer size) {
+
+  @Builder
+  public CurationFeedSearchRequest {
+    code = code != null ? List.copyOf(code) : List.of();
+    cursor = cursor != null ? cursor : 0L;
+    size = size != null ? size : 10;
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/CustomCurationFeedRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/CustomCurationFeedRepository.java
@@ -1,0 +1,9 @@
+package app.bottlenote.curation.repository;
+
+import app.bottlenote.curation.dto.dsl.CurationFeedSearchCriteria;
+import java.util.List;
+
+public interface CustomCurationFeedRepository {
+
+  List<Long> findFeedCandidateIds(CurationFeedSearchCriteria criteria);
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/CustomCurationFeedRepositoryImpl.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/CustomCurationFeedRepositoryImpl.java
@@ -1,0 +1,53 @@
+package app.bottlenote.curation.repository;
+
+import static app.bottlenote.curation.domain.QCuration.curation;
+
+import app.bottlenote.curation.dto.dsl.CurationFeedSearchCriteria;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomCurationFeedRepositoryImpl implements CustomCurationFeedRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<Long> findFeedCandidateIds(CurationFeedSearchCriteria criteria) {
+    if (criteria.specIds().isEmpty()) {
+      return List.of();
+    }
+
+    return queryFactory
+        .select(curation.id)
+        .from(curation)
+        .where(
+            curation.isActive.isTrue(),
+            curation
+                .exposureStartDate
+                .isNull()
+                .or(curation.exposureStartDate.loe(criteria.today())),
+            curation.exposureEndDate.isNull().or(curation.exposureEndDate.goe(criteria.today())),
+            curation.specId.in(criteria.specIds()),
+            matchesKeyword(criteria))
+        .orderBy(curation.displayOrder.asc(), curation.id.asc())
+        .offset(criteria.offset())
+        .limit(criteria.fetchSize())
+        .fetch();
+  }
+
+  private BooleanExpression matchesKeyword(CurationFeedSearchCriteria criteria) {
+    if (criteria.keyword() == null || criteria.keyword().isBlank()) {
+      return null;
+    }
+
+    String keyword = criteria.keyword().trim();
+    BooleanExpression matchesCuration =
+        curation.name.contains(keyword).or(curation.description.contains(keyword));
+    if (criteria.keywordMatchedSpecIds().isEmpty()) {
+      return matchesCuration;
+    }
+    return matchesCuration.or(curation.specId.in(criteria.keywordMatchedSpecIds()));
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/JpaCurationExtensionRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/JpaCurationExtensionRepository.java
@@ -3,6 +3,8 @@ package app.bottlenote.curation.repository;
 import app.bottlenote.common.annotation.JpaRepositoryImpl;
 import app.bottlenote.curation.domain.CurationExtension;
 import app.bottlenote.curation.domain.CurationExtensionRepository;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,6 +13,8 @@ public interface JpaCurationExtensionRepository
     extends CurationExtensionRepository, JpaRepository<CurationExtension, Long> {
 
   Optional<CurationExtension> findByCurationId(Long curationId);
+
+  List<CurationExtension> findAllByCurationIdIn(Collection<Long> curationIds);
 
   void deleteByCurationId(Long curationId);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/JpaCurationRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/JpaCurationRepository.java
@@ -4,6 +4,7 @@ import app.bottlenote.common.annotation.JpaRepositoryImpl;
 import app.bottlenote.curation.domain.Curation;
 import app.bottlenote.curation.domain.CurationRepository;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -13,9 +14,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 @JpaRepositoryImpl
-public interface JpaCurationRepository extends CurationRepository, JpaRepository<Curation, Long> {
+public interface JpaCurationRepository
+    extends CurationRepository, JpaRepository<Curation, Long>, CustomCurationFeedRepository {
 
   List<Curation> findAllByIsActiveTrueOrderByDisplayOrderAscIdAsc();
+
+  List<Curation> findAllByIdIn(Collection<Long> ids);
 
   @Override
   @Query(

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/JpaCurationSpecRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/repository/JpaCurationSpecRepository.java
@@ -34,6 +34,8 @@ public interface JpaCurationSpecRepository
       """)
   List<CurationSpecListResponse> findAllActiveSpecSummaries();
 
+  List<CurationSpec> findAllByCodeIn(Collection<String> codes);
+
   List<CurationSpec> findAllByIdIn(Collection<Long> ids);
 
   boolean existsByCode(String code);

--- a/bottlenote-mono/src/main/java/app/bottlenote/curation/service/ProductSpecBasedCurationService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/curation/service/ProductSpecBasedCurationService.java
@@ -9,16 +9,19 @@ import app.bottlenote.curation.domain.CurationExtensionRepository;
 import app.bottlenote.curation.domain.CurationRepository;
 import app.bottlenote.curation.domain.CurationSpec;
 import app.bottlenote.curation.domain.CurationSpecRepository;
+import app.bottlenote.curation.dto.dsl.CurationFeedSearchCriteria;
 import app.bottlenote.curation.dto.response.ProductSpecBasedCurationDetailResponse;
 import app.bottlenote.curation.dto.response.ProductSpecBasedCurationFeedItemResponse;
 import app.bottlenote.curation.dto.response.ProductSpecBasedCurationListResponse;
 import app.bottlenote.curation.exception.CurationException;
+import app.bottlenote.curation.exception.CurationExceptionCode;
+import app.bottlenote.global.service.cursor.CursorPageable;
 import app.bottlenote.global.service.cursor.CursorResponse;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -53,36 +56,56 @@ public class ProductSpecBasedCurationService {
 
   @Transactional(readOnly = true)
   public CursorResponse<ProductSpecBasedCurationFeedItemResponse> searchFeed(
-      Long cursor, Integer size) {
-    return searchFeed(null, null, cursor, size);
-  }
-
-  @Transactional(readOnly = true)
-  public CursorResponse<ProductSpecBasedCurationFeedItemResponse> searchFeed(
-      String keyword, String code, Long cursor, Integer size) {
+      String keyword, List<String> codes, Long cursor, Integer size) {
     int pageSize = normalizeFeedSize(size);
     long currentCursor = cursor != null && cursor > 0 ? cursor : 0L;
-    List<Curation> visibleCurations = curationRepository.findAllVisibleOn(LocalDate.now());
-    Map<Long, CurationSpec> allSpecMap =
-        curationSpecRepository
-            .findAllByIdIn(
-                visibleCurations.stream().map(Curation::getSpecId).collect(Collectors.toSet()))
-            .stream()
-            .collect(Collectors.toMap(CurationSpec::getId, Function.identity()));
-    List<Curation> filteredCurations =
-        visibleCurations.stream()
-            .filter(curation -> matchesCode(allSpecMap.get(curation.getSpecId()), code))
-            .filter(
-                curation -> matchesKeyword(curation, allSpecMap.get(curation.getSpecId()), keyword))
-            .toList();
-    int fromIndex = Math.min(Math.toIntExact(currentCursor), filteredCurations.size());
-    int toIndex = Math.min(fromIndex + pageSize + 1, filteredCurations.size());
-    List<Curation> pageContent = new ArrayList<>(filteredCurations.subList(fromIndex, toIndex));
+    List<String> normalizedCodes = normalizeCodes(codes);
+    List<CurationSpec> specs =
+        normalizedCodes.isEmpty()
+            ? List.of()
+            : curationSpecRepository.findAllByCodeIn(normalizedCodes);
+    Map<Long, CurationSpec> specMap =
+        specs.stream().collect(Collectors.toMap(CurationSpec::getId, Function.identity()));
+    Set<Long> keywordMatchedSpecIds =
+        specs.stream()
+            .filter(spec -> matchesKeyword(spec, keyword))
+            .map(CurationSpec::getId)
+            .collect(Collectors.toSet());
+    CurationFeedSearchCriteria criteria =
+        new CurationFeedSearchCriteria(
+            keyword,
+            specMap.keySet(),
+            keywordMatchedSpecIds,
+            LocalDate.now(),
+            currentCursor,
+            pageSize + 1);
+    List<Long> candidateIds = curationRepository.findFeedCandidateIds(criteria);
+    if (candidateIds.isEmpty()) {
+      return CursorResponse.of(
+          List.of(), CursorPageable.of(candidateIds, currentCursor, Integer.valueOf(pageSize)));
+    }
+    List<Long> pageIds =
+        candidateIds.size() > pageSize ? candidateIds.subList(0, pageSize) : candidateIds;
+    Map<Long, Curation> curationMap =
+        curationRepository.findAllByIdIn(pageIds).stream()
+            .collect(Collectors.toMap(Curation::getId, Function.identity()));
+    Map<Long, CurationExtension> extensionMap =
+        curationExtensionRepository.findAllByCurationIdIn(pageIds).stream()
+            .collect(Collectors.toMap(CurationExtension::getCurationId, Function.identity()));
     List<ProductSpecBasedCurationFeedItemResponse> items =
-        pageContent.stream()
-            .map(curation -> toFeedResponse(curation, allSpecMap.get(curation.getSpecId())))
+        pageIds.stream()
+            .map(
+                curationId -> {
+                  Curation curation = requireValue(curationMap.get(curationId), CURATION_NOT_FOUND);
+                  CurationSpec spec =
+                      requireValue(specMap.get(curation.getSpecId()), CURATION_SPEC_NOT_FOUND);
+                  CurationExtension extension =
+                      requireValue(extensionMap.get(curationId), CURATION_NOT_FOUND);
+                  return toFeedResponse(curation, spec, extension);
+                })
             .toList();
-    return CursorResponse.of(items, currentCursor, pageSize);
+    return CursorResponse.of(
+        items, CursorPageable.of(candidateIds, currentCursor, Integer.valueOf(pageSize)));
   }
 
   @Transactional(readOnly = true)
@@ -140,11 +163,7 @@ public class ProductSpecBasedCurationService {
   }
 
   private ProductSpecBasedCurationFeedItemResponse toFeedResponse(
-      Curation curation, CurationSpec spec) {
-    CurationExtension extension =
-        curationExtensionRepository
-            .findByCurationId(curation.getId())
-            .orElseThrow(() -> new CurationException(CURATION_NOT_FOUND));
+      Curation curation, CurationSpec spec, CurationExtension extension) {
     Object materialized =
         responseMaterializer.materializeFeed(
             curation.getId(), spec.getCode(), spec.getResponseSpec(), extension.getPayload());
@@ -169,23 +188,13 @@ public class ProductSpecBasedCurationService {
         .toList();
   }
 
-  private boolean matchesCode(CurationSpec spec, String code) {
-    if (isBlank(code)) {
-      return true;
-    }
-    return spec != null && spec.getCode().equals(code.trim());
-  }
-
-  private boolean matchesKeyword(Curation curation, CurationSpec spec, String keyword) {
+  private boolean matchesKeyword(CurationSpec spec, String keyword) {
     if (isBlank(keyword)) {
-      return true;
+      return false;
     }
     String normalizedKeyword = keyword.trim();
-    return contains(curation.getName(), normalizedKeyword)
-        || contains(curation.getDescription(), normalizedKeyword)
-        || (spec != null
-            && (contains(spec.getName(), normalizedKeyword)
-                || contains(spec.getDescription(), normalizedKeyword)));
+    return contains(spec.getName(), normalizedKeyword)
+        || contains(spec.getDescription(), normalizedKeyword);
   }
 
   private boolean contains(String value, String keyword) {
@@ -194,6 +203,25 @@ public class ProductSpecBasedCurationService {
 
   private boolean isBlank(String value) {
     return value == null || value.isBlank();
+  }
+
+  private List<String> normalizeCodes(List<String> codes) {
+    if (codes == null) {
+      return List.of();
+    }
+    return codes.stream()
+        .filter(Objects::nonNull)
+        .map(String::trim)
+        .filter(code -> !code.isBlank())
+        .distinct()
+        .toList();
+  }
+
+  private <T> T requireValue(T value, CurationExceptionCode code) {
+    if (value == null) {
+      throw new CurationException(code);
+    }
+    return value;
   }
 
   private int normalizeFeedSize(Integer size) {

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/exception/custom/code/ValidExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/exception/custom/code/ValidExceptionCode.java
@@ -110,6 +110,7 @@ public enum ValidExceptionCode implements ExceptionCode {
   CURATION_DISPLAY_ORDER_REQUIRED(HttpStatus.BAD_REQUEST, "노출 순서는 필수입니다."),
   CURATION_IS_ACTIVE_REQUIRED(HttpStatus.BAD_REQUEST, "활성화 상태는 필수입니다."),
   CURATION_PAYLOAD_REQUIRED(HttpStatus.BAD_REQUEST, "payload는 필수입니다."),
+  CURATION_CODE_REQUIRED(HttpStatus.BAD_REQUEST, "큐레이션 스펙 코드는 최소 1개 이상이어야 합니다."),
 
   // REGION
   REGION_KOR_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "지역 한글명은 필수입니다."),

--- a/bottlenote-mono/src/test/java/app/bottlenote/curation/service/ProductSpecBasedCurationServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/curation/service/ProductSpecBasedCurationServiceTest.java
@@ -116,7 +116,7 @@ class ProductSpecBasedCurationServiceTest {
     CurationSpec spec = createSpec();
     createCuration(spec.getId(), "피드", 1, true);
 
-    var result = productService.searchFeed(0L, 20);
+    var result = productService.searchFeed(null, List.of(spec.getCode()), 0L, 20);
 
     assertThat(result.items()).hasSize(1);
     assertThat(result.pageable().getPageSize()).isEqualTo(10L);
@@ -138,7 +138,7 @@ class ProductSpecBasedCurationServiceTest {
     CurationSpec spec = createTastingEventSpec();
     Long curationId = createTastingEventCuration(spec.getId());
 
-    var result = productService.searchFeed(0L, 20);
+    var result = productService.searchFeed(null, List.of(spec.getCode()), 0L, 20);
 
     assertThat(result.items()).hasSize(1);
     assertThat(result.items().get(0).id()).isEqualTo(curationId);
@@ -176,7 +176,7 @@ class ProductSpecBasedCurationServiceTest {
     createCuration(
         spec.getId(), "미노출", 1, true, LocalDate.now().plusDays(1), LocalDate.now().plusDays(5));
 
-    var result = productService.searchFeed(null, null, 0L, 30);
+    var result = productService.searchFeed(null, List.of(spec.getCode()), 0L, 30);
 
     assertThat(result.items()).hasSize(10);
     assertThat(result.pageable().getPageSize()).isEqualTo(10L);
@@ -204,12 +204,14 @@ class ProductSpecBasedCurationServiceTest {
     createCuration(pairingSpec.getId(), "일반 제목", "일반 설명", 3, true);
     createCuration(pairingSpec.getId(), "큐레이션 제목 매치 페어링", "일반 설명", 4, true);
 
-    var keywordResult = productService.searchFeed("큐레이션", null, 0L, 10);
-    var specKeywordResult = productService.searchFeed("안주", null, 0L, 10);
-    var codeResult = productService.searchFeed(null, "WHISKY_PAIRING", 0L, 10);
-    var combinedResult = productService.searchFeed("큐레이션", "WHISKY_PAIRING", 0L, 10);
-    var negativeResult = productService.searchFeed("큐레이션", "UNKNOWN_CODE", 0L, 10);
-    var boundaryResult = productService.searchFeed("   ", "   ", 0L, 10);
+    List<String> allCodes = List.of("RECOMMENDED_WHISKY", "WHISKY_PAIRING");
+    var keywordResult = productService.searchFeed("큐레이션", allCodes, 0L, 10);
+    var specKeywordResult = productService.searchFeed("안주", allCodes, 0L, 10);
+    var codeResult = productService.searchFeed(null, List.of("WHISKY_PAIRING"), 0L, 10);
+    var multiCodeResult = productService.searchFeed(null, allCodes, 0L, 10);
+    var combinedResult = productService.searchFeed("큐레이션", List.of("WHISKY_PAIRING"), 0L, 10);
+    var negativeResult = productService.searchFeed("큐레이션", List.of("UNKNOWN_CODE"), 0L, 10);
+    var emptyCodeResult = productService.searchFeed(null, List.of(), 0L, 10);
 
     assertThat(keywordResult.items())
         .extracting("name")
@@ -218,9 +220,12 @@ class ProductSpecBasedCurationServiceTest {
         .extracting("name")
         .containsExactly("일반 제목", "큐레이션 제목 매치 페어링");
     assertThat(codeResult.items()).extracting("name").containsExactly("일반 제목", "큐레이션 제목 매치 페어링");
+    assertThat(multiCodeResult.items())
+        .extracting("name")
+        .containsExactly("큐레이션 제목 매치", "일반 제목", "일반 제목", "큐레이션 제목 매치 페어링");
     assertThat(combinedResult.items()).extracting("name").containsExactly("큐레이션 제목 매치 페어링");
     assertThat(negativeResult.items()).isEmpty();
-    assertThat(boundaryResult.items()).hasSize(4);
+    assertThat(emptyCodeResult.items()).isEmpty();
   }
 
   @Test

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/ProductSpecBasedCurationController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/ProductSpecBasedCurationController.java
@@ -2,15 +2,17 @@ package app.bottlenote.curation.controller;
 
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 
+import app.bottlenote.curation.dto.request.CurationFeedSearchRequest;
 import app.bottlenote.curation.service.ProductSpecBasedCurationService;
 import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,12 +30,10 @@ public class ProductSpecBasedCurationController {
 
   @GetMapping("/feed")
   public ResponseEntity<?> getCurationFeed(
-      @RequestParam(required = false) String keyword,
-      @RequestParam(required = false) String code,
-      @RequestParam(required = false, defaultValue = "0") Long cursor,
-      @RequestParam(required = false, defaultValue = "10") Integer size) {
+      @ModelAttribute @Valid CurationFeedSearchRequest request) {
     return GlobalResponse.ok(
-        productSpecBasedCurationService.searchFeed(keyword, code, cursor, size));
+        productSpecBasedCurationService.searchFeed(
+            request.keyword(), request.code(), request.cursor(), request.size()));
   }
 
   @GetMapping("/{curationId}")

--- a/bottlenote-product-api/src/test/java/app/bottlenote/curation/integration/ProductSpecBasedCurationIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/curation/integration/ProductSpecBasedCurationIntegrationTest.java
@@ -1,6 +1,7 @@
 package app.bottlenote.curation.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import app.bottlenote.IntegrationTestSupport;
@@ -175,7 +176,7 @@ class ProductSpecBasedCurationIntegrationTest extends IntegrationTestSupport {
       MvcTestResult result =
           mockMvcTester
               .get()
-              .uri("/api/v2/curations/feed?size=10")
+              .uri("/api/v2/curations/feed?code=RECOMMENDED_WHISKY&size=10")
               .contentType(APPLICATION_JSON)
               .exchange();
 
@@ -203,7 +204,7 @@ class ProductSpecBasedCurationIntegrationTest extends IntegrationTestSupport {
       MvcTestResult result =
           mockMvcTester
               .get()
-              .uri("/api/v2/curations/feed?size=10")
+              .uri("/api/v2/curations/feed?code=WHISKY_TASTING_EVENT&size=10")
               .contentType(APPLICATION_JSON)
               .exchange();
 
@@ -219,7 +220,7 @@ class ProductSpecBasedCurationIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("Product feed는 keyword와 code 조건을 분리해 필터링하고 빈 조건은 전체 조건으로 처리한다")
+    @DisplayName("Product feed는 복수 code를 OR로, keyword를 AND로 적용한다")
     void searchFeed_whenKeywordAndCodeProvided_filtersBySearchContract() throws Exception {
       // given
       createCuration("제목 매치 큐레이션", "일반 설명", 1, true, List.of(manualItem("제목")));
@@ -227,10 +228,11 @@ class ProductSpecBasedCurationIntegrationTest extends IntegrationTestSupport {
       Long tastingId = createTastingEventCuration();
 
       // when
-      MvcTestResult keywordResult =
+      MvcTestResult multiCodeResult =
           mockMvcTester
               .get()
-              .uri("/api/v2/curations/feed?keyword=큐레이션&size=10")
+              .uri(
+                  "/api/v2/curations/feed?keyword=큐레이션&code=RECOMMENDED_WHISKY&code=WHISKY_TASTING_EVENT&size=10")
               .contentType(APPLICATION_JSON)
               .exchange();
       MvcTestResult codeResult =
@@ -245,21 +247,70 @@ class ProductSpecBasedCurationIntegrationTest extends IntegrationTestSupport {
               .uri("/api/v2/curations/feed?keyword=큐레이션&code=UNKNOWN_CODE&size=10")
               .contentType(APPLICATION_JSON)
               .exchange();
-      MvcTestResult boundaryResult =
-          mockMvcTester
-              .get()
-              .uri("/api/v2/curations/feed?keyword=%20%20%20&code=%20%20%20&size=10")
-              .contentType(APPLICATION_JSON)
-              .exchange();
-
       // then
-      assertThat(dataNode(keywordResult).path("items")).hasSize(3);
+      assertThat(dataNode(multiCodeResult).path("items")).hasSize(3);
       assertThat(dataNode(codeResult).path("items")).hasSize(1);
       assertThat(dataNode(codeResult).path("items").get(0).path("id").asLong())
           .isEqualTo(tastingId);
       assertThat(dataNode(negativeResult).path("items")).isEmpty();
-      assertThat(dataNode(boundaryResult).path("items").isArray()).isTrue();
-      assertThat(dataNode(boundaryResult).path("pageable").path("pageSize").asInt()).isEqualTo(10);
+      mockMvcTester
+          .get()
+          .uri("/api/v2/curations/feed")
+          .exchange()
+          .assertThat()
+          .hasStatus(BAD_REQUEST);
+      mockMvcTester
+          .get()
+          .uri("/api/v2/curations/feed")
+          .param("code", " ")
+          .exchange()
+          .assertThat()
+          .hasStatus(BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("Product feed는 노출 조건과 정렬을 적용한 뒤 offset cursor로 최대 10개를 반환한다")
+    void searchFeed_whenPageBoundaryReached_returnsStableOffsetPage() throws Exception {
+      // given
+      for (int i = 0; i < 12; i++) {
+        createCuration("노출 " + i, "페이지 경계", i, true, List.of(manualItem("위스키 " + i)));
+      }
+      createCuration("비활성", 1, false, List.of(manualItem("비활성")));
+      createCuration(
+          "미노출",
+          "페이지 경계",
+          1,
+          true,
+          LocalDate.now().plusDays(1),
+          LocalDate.now().plusDays(5),
+          List.of(manualItem("미노출")));
+
+      // when
+      MvcTestResult firstPage =
+          mockMvcTester
+              .get()
+              .uri("/api/v2/curations/feed?code=RECOMMENDED_WHISKY&cursor=0&size=30")
+              .contentType(APPLICATION_JSON)
+              .exchange();
+      MvcTestResult secondPage =
+          mockMvcTester
+              .get()
+              .uri("/api/v2/curations/feed?code=RECOMMENDED_WHISKY&cursor=10&size=10")
+              .contentType(APPLICATION_JSON)
+              .exchange();
+
+      // then
+      JsonNode firstPageData = dataNode(firstPage);
+      assertThat(firstPageData.path("items")).hasSize(10);
+      assertThat(firstPageData.path("items").get(0).path("name").asText()).isEqualTo("노출 0");
+      assertThat(firstPageData.path("pageable").path("pageSize").asInt()).isEqualTo(10);
+      assertThat(firstPageData.path("pageable").path("cursor").asLong()).isEqualTo(10L);
+      assertThat(firstPageData.path("pageable").path("hasNext").asBoolean()).isTrue();
+
+      JsonNode secondPageData = dataNode(secondPage);
+      assertThat(secondPageData.path("items")).hasSize(2);
+      assertThat(secondPageData.path("items").get(0).path("name").asText()).isEqualTo("노출 10");
+      assertThat(secondPageData.path("pageable").path("hasNext").asBoolean()).isFalse();
     }
   }
 

--- a/bottlenote-product-api/src/test/java/app/docs/curation/RestProductSpecBasedCurationControllerTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/curation/RestProductSpecBasedCurationControllerTest.java
@@ -103,7 +103,8 @@ class RestProductSpecBasedCurationControllerTest extends AbstractRestDocs {
   @Test
   @DisplayName("spec 기반 큐레이션 v2 피드를 상세 응답 기반 payload로 조회할 수 있다")
   void getCurationFeed() throws Exception {
-    when(productSpecBasedCurationService.searchFeed("페어링", "WHISKY_PAIRING", 0L, 10))
+    when(productSpecBasedCurationService.searchFeed(
+            "페어링", List.of("PROGRAM", "WHISKY_TASTING_EVENT"), 0L, 10))
         .thenReturn(
             CursorResponse.of(
                 List.of(
@@ -133,7 +134,9 @@ class RestProductSpecBasedCurationControllerTest extends AbstractRestDocs {
                 10));
 
     mockMvc
-        .perform(get("/api/v2/curations/feed?keyword=페어링&code=WHISKY_PAIRING&cursor=0&size=10"))
+        .perform(
+            get(
+                "/api/v2/curations/feed?keyword=페어링&code=PROGRAM&code=WHISKY_TASTING_EVENT&cursor=0&size=10"))
         .andExpect(status().isOk())
         .andDo(
             document(
@@ -143,9 +146,7 @@ class RestProductSpecBasedCurationControllerTest extends AbstractRestDocs {
                         .description("검색어. 큐레이션 제목/설명, 스펙 제목/설명에 LIKE 조건으로 적용됩니다.")
                         .optional(),
                     parameterWithName("code")
-                        .description(
-                            "큐레이션 스펙 코드 exact match 필터. 사용 가능한 값은 큐레이션 목록 조회의 specCode 또는 상세 조회의 spec.code에서 확인합니다.")
-                        .optional(),
+                        .description("필수 큐레이션 스펙 코드 배열. 동일한 code 파라미터를 반복하면 OR 조건으로 조회합니다."),
                     parameterWithName("cursor").description("조회 시작 커서. 기본값 0").optional(),
                     parameterWithName("size").description("페이지 크기. 최대 10, 기본값 10").optional()),
                 responseFields(
@@ -181,6 +182,20 @@ class RestProductSpecBasedCurationControllerTest extends AbstractRestDocs {
                     fieldWithPath("meta.serverVersion").ignored(),
                     fieldWithPath("meta.serverPathVersion").ignored(),
                     fieldWithPath("meta.serverResponseTime").ignored())));
+  }
+
+  @Test
+  @DisplayName("spec 기반 큐레이션 v2 피드는 code가 없으면 400을 반환한다")
+  void getCurationFeed_whenCodeMissing_returnsBadRequest() throws Exception {
+    mockMvc.perform(get("/api/v2/curations/feed")).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("spec 기반 큐레이션 v2 피드는 공백 code가 있으면 400을 반환한다")
+  void getCurationFeed_whenCodeBlank_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(get("/api/v2/curations/feed").param("code", " "))
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/bottlenote-test-support/src/main/java/app/bottlenote/curation/fixture/InMemoryCurationExtensionRepository.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/curation/fixture/InMemoryCurationExtensionRepository.java
@@ -2,7 +2,9 @@ package app.bottlenote.curation.fixture;
 
 import app.bottlenote.curation.domain.CurationExtension;
 import app.bottlenote.curation.domain.CurationExtensionRepository;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -13,6 +15,13 @@ public class InMemoryCurationExtensionRepository implements CurationExtensionRep
   @Override
   public Optional<CurationExtension> findByCurationId(Long curationId) {
     return Optional.ofNullable(database.get(curationId));
+  }
+
+  @Override
+  public List<CurationExtension> findAllByCurationIdIn(Collection<Long> curationIds) {
+    return database.values().stream()
+        .filter(extension -> curationIds.contains(extension.getCurationId()))
+        .toList();
   }
 
   @Override

--- a/bottlenote-test-support/src/main/java/app/bottlenote/curation/fixture/InMemoryCurationRepository.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/curation/fixture/InMemoryCurationRepository.java
@@ -2,7 +2,9 @@ package app.bottlenote.curation.fixture;
 
 import app.bottlenote.curation.domain.Curation;
 import app.bottlenote.curation.domain.CurationRepository;
+import app.bottlenote.curation.dto.dsl.CurationFeedSearchCriteria;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +39,31 @@ public class InMemoryCurationRepository implements CurationRepository {
         .filter(curation -> isVisibleOn(curation, today))
         .sorted(Comparator.comparing(Curation::getDisplayOrder).thenComparing(Curation::getId))
         .toList();
+  }
+
+  @Override
+  public List<Long> findFeedCandidateIds(CurationFeedSearchCriteria criteria) {
+    if (criteria.specIds().isEmpty()) {
+      return List.of();
+    }
+
+    List<Long> candidateIds =
+        database.values().stream()
+            .filter(curation -> Boolean.TRUE.equals(curation.getIsActive()))
+            .filter(curation -> isVisibleOn(curation, criteria.today()))
+            .filter(curation -> criteria.specIds().contains(curation.getSpecId()))
+            .filter(curation -> matchesKeyword(curation, criteria))
+            .sorted(Comparator.comparing(Curation::getDisplayOrder).thenComparing(Curation::getId))
+            .map(Curation::getId)
+            .toList();
+    int start = (int) Math.min(criteria.offset(), candidateIds.size());
+    int end = Math.min(start + criteria.fetchSize(), candidateIds.size());
+    return candidateIds.subList(start, end);
+  }
+
+  @Override
+  public List<Curation> findAllByIdIn(Collection<Long> ids) {
+    return database.values().stream().filter(curation -> ids.contains(curation.getId())).toList();
   }
 
   @Override
@@ -84,5 +111,19 @@ public class InMemoryCurationRepository implements CurationRepository {
             || !curation.getExposureStartDate().isAfter(today))
         && (curation.getExposureEndDate() == null
             || !curation.getExposureEndDate().isBefore(today));
+  }
+
+  private boolean matchesKeyword(Curation curation, CurationFeedSearchCriteria criteria) {
+    if (criteria.keyword() == null || criteria.keyword().isBlank()) {
+      return true;
+    }
+    String keyword = criteria.keyword().trim();
+    return contains(curation.getName(), keyword)
+        || contains(curation.getDescription(), keyword)
+        || criteria.keywordMatchedSpecIds().contains(curation.getSpecId());
+  }
+
+  private boolean contains(String value, String keyword) {
+    return value != null && value.contains(keyword);
   }
 }

--- a/bottlenote-test-support/src/main/java/app/bottlenote/curation/fixture/InMemoryCurationSpecRepository.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/curation/fixture/InMemoryCurationSpecRepository.java
@@ -53,6 +53,11 @@ public class InMemoryCurationSpecRepository implements CurationSpecRepository {
   }
 
   @Override
+  public List<CurationSpec> findAllByCodeIn(Collection<String> codes) {
+    return database.values().stream().filter(spec -> codes.contains(spec.getCode())).toList();
+  }
+
+  @Override
   public List<CurationSpec> findAllByIdIn(Collection<Long> ids) {
     return database.values().stream().filter(spec -> ids.contains(spec.getId())).toList();
   }

--- a/plan/multi-code-curation-feed.md
+++ b/plan/multi-code-curation-feed.md
@@ -153,10 +153,12 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
 - Verification:
   `./gradlew :bottlenote-product-api:test --tests '*RestProductSpecBasedCurationControllerTest'`
 - Files:
+  `CurationFeedSearchRequest.java`,
+  `ValidExceptionCode.java`,
   `ProductSpecBasedCurationController.java`,
   `RestProductSpecBasedCurationControllerTest.java`
-- Size: S
-- Status: [ ] not done
+- Size: M
+- Status: [x] done
 
 ### Task 5: 피드 조회 계약 통합 검증
 
@@ -188,3 +190,5 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
 - Task 3 완료: 후보 ID의 큐레이션과 Extension만 일괄 조회하고 최대 10건만
   hydration하도록 서비스 흐름을 교체했다. Product 큐레이션 서비스 단위
   테스트를 통과했다.
+- Task 4 완료: `code` 반복 파라미터를 필수 배열로 바꾸고 누락·공백 요청을
+  HTTP 400으로 검증했다. Product REST Docs 테스트 5개를 통과했다.

--- a/plan/multi-code-curation-feed.md
+++ b/plan/multi-code-curation-feed.md
@@ -172,7 +172,7 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
 - Files:
   `ProductSpecBasedCurationIntegrationTest.java`
 - Size: S
-- Status: [ ] not done
+- Status: [x] done
 
 ### Checkpoint: after Tasks 4-5
 
@@ -192,3 +192,6 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
   테스트를 통과했다.
 - Task 4 완료: `code` 반복 파라미터를 필수 배열로 바꾸고 누락·공백 요청을
   HTTP 400으로 검증했다. Product REST Docs 테스트 5개를 통과했다.
+- Task 5 완료: 실제 DB에서 복수 code OR, keyword AND, 노출·정렬,
+  offset cursor, 미존재 code와 기존 `x-feed` 응답을 검증했다. Product
+  큐레이션 통합 테스트 14개를 통과했다.

--- a/plan/multi-code-curation-feed.md
+++ b/plan/multi-code-curation-feed.md
@@ -1,0 +1,184 @@
+# Plan: 복수 코드 기반 큐레이션 피드 조회 개선
+
+## Overview
+
+Product API의 `GET /api/v2/curations/feed`가 하나 이상의 큐레이션 스펙 코드를
+받아 필요한 후보만 DB에서 먼저 선별하도록 개선한다. 피드 응답 계약과 기존
+`x-feed` 기반 GraphQL hydration 규칙은 유지하면서, 전체 노출 큐레이션 및
+payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한다.
+
+### Assumptions
+
+- 변경 대상은 `bottlenote-product-api`의 공개 피드 API와
+  `bottlenote-mono`의 큐레이션 조회 경로다.
+- 쿼리 파라미터 이름은 `code`를 유지하고 배열로 받는다.
+  복수 값은 `?code=PROGRAM&code=WHISKY_TASTING_EVENT` 형태로 전달한다.
+- `code`는 한 개 이상 필수다. 누락, 빈 배열, 공백 값은 유효하지 않은
+  요청으로 처리한다.
+- 여러 `code` 값은 OR 조건으로 조회하며, `keyword`가 함께 있으면 코드
+  조건과 AND로 결합한다.
+- 존재하지 않는 코드만 전달된 경우 오류가 아니라 빈 피드 결과를 반환한다.
+- 노출 여부는 기존과 동일하게 활성 상태와 노출 시작일·종료일을 기준으로
+  판단한다.
+- 정렬은 기존 `displayOrder ASC, id ASC`를 유지한다.
+- 현재 `cursor`는 마지막 ID가 아닌 offset으로 사용되고 있으므로 이번
+  변경에서도 그 의미를 유지한다.
+- `size`의 기본값 10과 최대값 10을 유지한다.
+- 후보 조회는 조건에 맞는 큐레이션 ID를 `size + 1`개까지만 먼저 조회하고,
+  응답에 필요한 큐레이션·스펙·Extension은 후보 ID 기준으로 일괄 조회한다.
+- 피드 응답의 공통 필드와 `payload` 구조는 변경하지 않는다.
+- GraphQL 조회는 기존처럼 `x-feed.enabled=true`인 응답 필드와 교차하는
+  쿼리만 실행한다.
+- `feed_source_payload` Read Model, DB 스키마, 캐시, Admin API는 이번 PR의
+  범위에 포함하지 않는다.
+
+### Success Criteria
+
+- `GET /api/v2/curations/feed?code=PROGRAM` 요청이 단일 코드 피드를 반환한다.
+- `GET /api/v2/curations/feed?code=PROGRAM&code=WHISKY_TASTING_EVENT` 요청이
+  두 코드 중 하나에 해당하는 피드를 반환한다.
+- `keyword`와 복수 `code`를 함께 전달하면 두 조건을 모두 만족하는
+  큐레이션만 반환한다.
+- `code` 누락, 공백 값 또는 빈 값은 HTTP 400으로 거부된다.
+- 존재하지 않는 코드만 전달하면 HTTP 200과 빈 `items`를 반환한다.
+- 활성·노출 기간 조건, 정렬, `cursor`, `size`, `hasNext` 동작이 기존 계약과
+  동일하다.
+- 응답의 필드명, 타입, 중첩 구조와 `x-feed` projection 결과가 변경 전과
+  동일하다.
+- 피드 조회 경로에서 전체 노출 큐레이션을 조회하는
+  `findAllVisibleOn`을 사용하지 않는다.
+- 첫 후보 조회 결과는 최대 `size + 1`, 즉 현재 제한에서 최대 11개 ID다.
+- 후보 큐레이션의 스펙과 Extension은 항목별 조회가 아닌 각각 일괄 조회한다.
+- 단위 테스트는 단일 코드, 복수 코드, keyword 결합, 필수값 검증, 미존재
+  코드, 페이지 경계를 검증한다.
+- Product 통합 테스트와 REST Docs 테스트가 요청 파라미터 및 기존 응답
+  호환성을 검증한다.
+
+### Impact Scope
+
+- **Product API**:
+  `ProductSpecBasedCurationController`의 `code` 파라미터 타입과 필수값 검증,
+  REST Docs 요청 계약이 변경된다.
+- **Mono service**:
+  `ProductSpecBasedCurationService`의 메모리 필터링·페이지 분할을 후보 ID
+  기반 조회와 일괄 조립으로 교체한다.
+- **Persistence**:
+  큐레이션 후보 ID 조회와 후보 엔티티 일괄 조회를 위한 도메인 포트 및
+  JPA/QueryDSL 구현이 필요하다. Extension 저장소에도 후보 ID 기반 일괄
+  조회가 필요하다.
+- **GraphQL**:
+  SDL과 executor 계약은 변경하지 않는다. 후보 수가 제한된 이후 기존
+  `materializeFeed` 흐름을 사용한다.
+- **Schema / migration**:
+  DB 컬럼, 테이블, 인덱스 변경은 없다.
+- **Admin / batch / events / cache**:
+  변경하지 않는다.
+- **Tests / docs**:
+  Mono 단위 테스트, Product 통합 테스트, Product REST Docs가 영향을 받는다.
+- **외부 계약**:
+  응답은 호환되지만 요청의 `code`가 선택값에서 한 개 이상 필수인 배열로
+  변경된다. 호출자는 동일한 파라미터를 반복해 복수 코드를 전달해야 한다.
+
+## Tasks
+
+### Task 1: 피드 대상 스펙 일괄 해석
+
+- Acceptance:
+  - 전달된 단일·복수 code에 해당하는 스펙을 한 번에 조회한다.
+  - 존재하지 않는 code가 포함돼도 조회된 스펙만 반환한다.
+  - JPA 구현과 InMemory 구현이 동일한 계약을 따른다.
+- Verification:
+  `./gradlew :bottlenote-mono:compileJava :bottlenote-test-support:compileJava`
+- Files:
+  `CurationSpecRepository.java`,
+  `JpaCurationSpecRepository.java`,
+  `InMemoryCurationSpecRepository.java`
+- Size: S
+- Status: [x] done
+
+### Task 2: 제한된 피드 후보 조회 경로 구축
+
+- Acceptance:
+  - 활성 상태, 노출 기간, keyword, 스펙 ID 조건을 DB에서 적용해
+    `displayOrder ASC, id ASC` 순서의 큐레이션 ID만 반환한다.
+  - offset cursor부터 `size + 1`개까지만 조회하며, 후보 엔티티도 ID로
+    일괄 조회한다.
+  - 도메인 포트에 `Pageable`이나 QueryDSL 타입을 노출하지 않고 실제 JPA
+    구현과 InMemory 구현이 동일한 계약을 따른다.
+- Verification:
+  `./gradlew :bottlenote-mono:compileJava :bottlenote-test-support:compileJava`
+- Files:
+  `CurationFeedSearchCriteria.java`,
+  `CurationRepository.java`,
+  `CustomCurationFeedRepository.java`,
+  `CustomCurationFeedRepositoryImpl.java`,
+  `JpaCurationRepository.java`,
+  `InMemoryCurationRepository.java`
+- Size: M
+- Status: [ ] not done
+
+### Task 3: 후보 피드 일괄 조립
+
+- Acceptance:
+  - 서비스는 전체 노출 큐레이션을 읽지 않고 Task 1과 Task 2의 결과만
+    사용한다.
+  - 후보 큐레이션, 스펙, Extension을 각각 일괄 조회하고 기존 항목 순서를
+    보존한다.
+  - 기존 `materializeFeed`와 응답 projection을 유지하며 최대 크기와
+    offset cursor 경계 테스트가 통과한다.
+- Verification:
+  `./gradlew :bottlenote-mono:unit_test --tests '*ProductSpecBasedCurationServiceTest'`
+- Files:
+  `CurationExtensionRepository.java`,
+  `JpaCurationExtensionRepository.java`,
+  `InMemoryCurationExtensionRepository.java`,
+  `ProductSpecBasedCurationService.java`,
+  `ProductSpecBasedCurationServiceTest.java`
+- Size: M
+- Status: [ ] not done
+
+### Checkpoint: after Tasks 1-3
+
+- [ ] Mono와 test-support가 컴파일된다.
+- [ ] Product 큐레이션 서비스 단위 테스트가 통과한다.
+- [ ] 도메인 저장소 포트에 Spring Data 또는 QueryDSL 타입이 추가되지 않는다.
+
+### Task 4: code 배열 HTTP 계약 반영
+
+- Acceptance:
+  - Controller가 동일한 `code` 쿼리 파라미터를 한 개 이상의 문자열 배열로
+    받아 서비스에 전달한다.
+  - `code` 누락, 빈 값, 공백 값은 HTTP 400으로 거부된다.
+  - REST Docs가 단일·복수 code 요청과 변경되지 않은 응답 필드를 문서화한다.
+- Verification:
+  `./gradlew :bottlenote-product-api:test --tests '*RestProductSpecBasedCurationControllerTest'`
+- Files:
+  `ProductSpecBasedCurationController.java`,
+  `RestProductSpecBasedCurationControllerTest.java`
+- Size: S
+- Status: [ ] not done
+
+### Task 5: 피드 조회 계약 통합 검증
+
+- Acceptance:
+  - 실제 DB에서 단일 code, 복수 code OR, keyword AND, 미존재 code 조건을
+    검증한다.
+  - 노출 조건, 정렬, offset cursor, `hasNext`, 최대 10개 반환을 검증한다.
+  - 기존 응답 구조와 `x-feed` projection이 유지됨을 검증한다.
+- Verification:
+  `./gradlew :bottlenote-product-api:integration_test --tests '*ProductSpecBasedCurationIntegrationTest'`
+- Files:
+  `ProductSpecBasedCurationIntegrationTest.java`
+- Size: S
+- Status: [ ] not done
+
+### Checkpoint: after Tasks 4-5
+
+- [ ] Product REST Docs 테스트가 통과한다.
+- [ ] Product 큐레이션 통합 테스트가 통과한다.
+- [ ] 요청 파라미터 외 기존 피드 응답 계약에 변경이 없다.
+
+## Progress Log
+
+- Task 1 완료: 복수 code 기반 스펙 일괄 조회 포트를 JPA와 InMemory 구현에
+  추가했다. Mono와 test-support 컴파일을 통과했다.

--- a/plan/multi-code-curation-feed.md
+++ b/plan/multi-code-curation-feed.md
@@ -115,7 +115,7 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
   `JpaCurationRepository.java`,
   `InMemoryCurationRepository.java`
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 3: 후보 피드 일괄 조립
 
@@ -182,3 +182,6 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
 
 - Task 1 완료: 복수 code 기반 스펙 일괄 조회 포트를 JPA와 InMemory 구현에
   추가했다. Mono와 test-support 컴파일을 통과했다.
+- Task 2 완료: 노출·스펙·keyword 조건과 offset/limit을 적용하는 후보 ID
+  조회를 QueryDSL과 InMemory에 추가했다. Mono와 test-support 컴파일을
+  통과했다.

--- a/plan/multi-code-curation-feed.md
+++ b/plan/multi-code-curation-feed.md
@@ -135,7 +135,7 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
   `ProductSpecBasedCurationService.java`,
   `ProductSpecBasedCurationServiceTest.java`
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Checkpoint: after Tasks 1-3
 
@@ -185,3 +185,6 @@ payload를 메모리에 적재하던 방식과 Extension N+1 조회를 제거한
 - Task 2 완료: 노출·스펙·keyword 조건과 offset/limit을 적용하는 후보 ID
   조회를 QueryDSL과 InMemory에 추가했다. Mono와 test-support 컴파일을
   통과했다.
+- Task 3 완료: 후보 ID의 큐레이션과 Extension만 일괄 조회하고 최대 10건만
+  hydration하도록 서비스 흐름을 교체했다. Product 큐레이션 서비스 단위
+  테스트를 통과했다.


### PR DESCRIPTION
## 변경 사항

- Product `GET /api/v2/curations/feed`의 `code`를 한 개 이상 필수인 배열 파라미터로 변경했습니다.
- 동일한 `code` 파라미터를 반복하면 복수 스펙을 OR 조건으로 조회하고, `keyword`는 코드 조건과 AND로 결합합니다.
- 스펙을 먼저 일괄 조회한 뒤 조건에 맞는 큐레이션 ID를 DB에서 `size + 1`개까지만 조회하도록 변경했습니다.
- 실제 반환 대상의 큐레이션과 Extension을 일괄 조회해 전체 노출 큐레이션 적재와 Extension N+1 조회를 제거했습니다.
- 기존 offset cursor, 응답 필드, `x-feed` projection 및 GraphQL hydration 계약은 유지합니다.

## 간단한 체인지로그

- Changed: `code`를 필수 반복 파라미터 배열로 변경
- Added: 복수 code OR 및 keyword AND 검색
- Improved: 피드 후보 ID 선조회와 큐레이션·스펙·Extension 일괄 조회
- Preserved: 기존 cursor와 피드 응답 구조

## 영향

- FE는 `?code=PROGRAM&code=WHISKY_TASTING_EVENT` 형태로 한 개 이상의 code를 전달해야 합니다.
- code 누락·빈 값·공백 값은 HTTP 400을 반환합니다.
- DB 스키마, Admin API, 캐시, 이벤트, GraphQL SDL은 변경하지 않습니다.
- `feed_source_payload` Read Model 분리는 이번 PR 범위에 포함하지 않습니다.

## 검증

- 전체 Java/Kotlin 컴파일 및 테스트 컴파일: 통과
- `./gradlew check_rule_test`: 통과
- `./gradlew unit_test`: 통과
- `./gradlew build -x test -x asciidoctor --build-cache --parallel`: 통과
- `./gradlew integration_test`: 통과
- `./gradlew admin_integration_test`: 통과
- `./gradlew asciidoctor`: 통과
- 대상 Product 큐레이션 통합 테스트 14개: 통과
- Product 큐레이션 REST Docs 테스트 5개: 통과

## 관련

- 장기 Read Model 분리 논의: bottle-note/workspace#322
