### PR TITLE
fix: MySQL 세션 시간대를 KST로 통일

### DIFF
--- a/bottlenote-admin-api/src/main/resources/application-datasource.yml
+++ b/bottlenote-admin-api/src/main/resources/application-datasource.yml
@@ -44,7 +44,7 @@ spring:
       on-profile: default,local
   datasource:
     driver-class-name: com.p6spy.engine.spy.P6SpyDriver
-    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:localhost_bottle_note_username}
     password: ${DB_PASSWORD:localhost_bottle_note_password}
 
@@ -55,7 +55,7 @@ spring:
       on-profile: debug
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:localhost_bottle_note_username}
     password: ${DB_PASSWORD:localhost_bottle_note_password}
 
@@ -66,6 +66,6 @@ spring:
       on-profile: "dev,prod"
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST}/${DB_NAME}?useSSL=${DB_USE_SSL}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST}/${DB_NAME}?useSSL=${DB_USE_SSL}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}

--- a/bottlenote-batch/src/main/resources/application-datasource.yml
+++ b/bottlenote-batch/src/main/resources/application-datasource.yml
@@ -3,7 +3,7 @@
 spring:
   datasource:
     driver-class-name: com.p6spy.engine.spy.P6SpyDriver
-    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:localhost_bottle_note_username}
     password: ${DB_PASSWORD:localhost_bottle_note_password}
     hikari:
@@ -43,7 +43,7 @@ spring:
       on-profile: default,local
   datasource:
     driver-class-name: com.p6spy.engine.spy.P6SpyDriver
-    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:localhost_bottle_note_username}
     password: ${DB_PASSWORD:localhost_bottle_note_password}
 
@@ -54,7 +54,7 @@ spring:
       on-profile: debug
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:localhost_bottle_note_username}
     password: ${DB_PASSWORD:localhost_bottle_note_password}
 
@@ -65,6 +65,6 @@ spring:
       on-profile: "dev,prod"
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST}/${DB_NAME}?useSSL=${DB_USE_SSL}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST}/${DB_NAME}?useSSL=${DB_USE_SSL}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}

--- a/bottlenote-product-api/src/main/resources/application-datasource.yml
+++ b/bottlenote-product-api/src/main/resources/application-datasource.yml
@@ -50,7 +50,7 @@ spring:
       on-profile: default,local
   datasource:
     driver-class-name: com.p6spy.engine.spy.P6SpyDriver
-    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:p6spy:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:localhost_bottle_note_username}
     password: ${DB_PASSWORD:localhost_bottle_note_password}
 
@@ -61,7 +61,7 @@ spring:
       on-profile: debug
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_HOST:localhost:3306}/${DB_NAME:bottle_note}?useSSL=${DB_USE_SSL:false}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME:localhost_bottle_note_username}
     password: ${DB_PASSWORD:localhost_bottle_note_password}
 
@@ -79,6 +79,6 @@ spring:
     # - maintainTimeStats: 드라이버 자체 통계 비활성 (CPU/락 비용 제거)
     # - tcpKeepAlive: OS-level TCP keepalive 활성
     # - socketTimeout: 소켓 단위 8s 타임아웃 (행 무한 대기 방지)
-    url: jdbc:mysql://${DB_HOST}/${DB_NAME}?useSSL=${DB_USE_SSL}&serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useLocalSessionState=true&elideSetAutoCommits=true&cacheServerConfiguration=true&maintainTimeStats=false&tcpKeepAlive=true&socketTimeout=8000
+    url: jdbc:mysql://${DB_HOST}/${DB_NAME}?useSSL=${DB_USE_SSL}&connectionTimeZone=Asia/Seoul&forceConnectionTimeZoneToSession=true&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useLocalSessionState=true&elideSetAutoCommits=true&cacheServerConfiguration=true&maintainTimeStats=false&tcpKeepAlive=true&socketTimeout=8000
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}


### PR DESCRIPTION
## 변경 목적

MySQL 서버의 global timezone이 UTC여도 Product/Admin/Batch가 생성하는 각 JDBC 세션은 `Asia/Seoul`을 사용하도록 통일합니다.

## 원인

기존 `serverTimezone=Asia/Seoul`은 Connector/J 8.3에서 `connectionTimeZone`의 별칭이지만, 기본값인 `forceConnectionTimeZoneToSession=false` 때문에 MySQL의 `@@session.time_zone`은 UTC로 유지됐습니다. 이로 인해 DB 기본값 `CURRENT_TIMESTAMP`로 생성되는 `create_at`이 UTC로 기록됐습니다.

## 변경 사항

- Product API의 default/local, debug, dev/prod JDBC URL 변경
- Admin API의 default/local, debug, dev/prod JDBC URL 변경
- Batch의 공통, default/local, debug, dev/prod JDBC URL 변경
- `serverTimezone`을 공식 속성 `connectionTimeZone`으로 교체
- `forceConnectionTimeZoneToSession=true`를 추가해 신규 연결의 DB 세션 timezone을 KST로 강제

## 영향

- OCI MySQL HeatWave의 global timezone은 UTC로 유지됩니다.
- 애플리케이션에서 생성한 세션의 `NOW()`, `CURRENT_TIMESTAMP`, `CURDATE()` 등이 Asia/Seoul 기준으로 동작합니다.
- 기존 저장 데이터는 변경하지 않습니다.
- 배포 후 기존 커넥션 풀 교체를 위해 각 애플리케이션 Pod 재기동이 필요합니다.

## 검증

- 세 모듈의 10개 datasource URL 전체 적용 및 기존 `serverTimezone` 잔존 0건 확인
- Product/Admin/Batch `processResources` 성공
- Connector/J 8.3으로 개발 DB 신규 연결 확인
  - `@@global.time_zone = UTC`
  - `@@session.time_zone = Asia/Seoul`
  - `NOW()`와 `UTC_TIMESTAMP()`의 차이 9시간 확인
- `git diff --check` 성공
