### PR TITLE
feat: springdoc OpenAPI 어노테이션 기반 API 문서화 (product-api)

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/global/data/response/GlobalResponse.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/data/response/GlobalResponse.java
@@ -58,11 +58,11 @@ public class GlobalResponse {
     this.meta = meta;
   }
 
-  public static ResponseEntity<?> ok(Object data) {
+  public static ResponseEntity<GlobalResponse> ok(Object data) {
     return ResponseEntity.ok(success(data));
   }
 
-  public static <T, P> ResponseEntity<?> ok(
+  public static <T, P> ResponseEntity<GlobalResponse> ok(
       Pair<Long, CursorResponse<T>> pair, P searchParameters) {
     Long totalCount = pair.getLeft();
     CursorResponse<T> items = pair.getRight();
@@ -73,7 +73,7 @@ public class GlobalResponse {
     return ResponseEntity.ok(success(response, metaInfos));
   }
 
-  public static ResponseEntity<?> ok(Object data, MetaInfos meta) {
+  public static ResponseEntity<GlobalResponse> ok(Object data, MetaInfos meta) {
     return ResponseEntity.ok(success(data, meta));
   }
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/data/response/GlobalResponse.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/data/response/GlobalResponse.java
@@ -137,7 +137,7 @@ public class GlobalResponse {
         .build();
   }
 
-  public static ResponseEntity<?> error(Error error) {
+  public static ResponseEntity<GlobalResponse> error(Error error) {
     GlobalResponse response =
         GlobalResponse.builder()
             .success(false)
@@ -149,7 +149,7 @@ public class GlobalResponse {
     return new ResponseEntity<>(response, error.code().getHttpStatus());
   }
 
-  public static ResponseEntity<?> error(AbstractCustomException exception) {
+  public static ResponseEntity<GlobalResponse> error(AbstractCustomException exception) {
 
     Error error = Error.of(exception.getExceptionCode());
 
@@ -165,7 +165,7 @@ public class GlobalResponse {
     return new ResponseEntity<>(response, exception.getExceptionCode().getHttpStatus());
   }
 
-  public static ResponseEntity<?> error(Set<Error> errorSet) {
+  public static ResponseEntity<GlobalResponse> error(Set<Error> errorSet) {
     GlobalResponse response =
         GlobalResponse.builder()
             .success(false)

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/exception/handler/GlobalExceptionHandler.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/exception/handler/GlobalExceptionHandler.java
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
    * @return the response entity
    */
   @ExceptionHandler(AbstractCustomException.class)
-  public ResponseEntity<?> handleCustomException(AbstractCustomException exception) {
+  public ResponseEntity<GlobalResponse> handleCustomException(AbstractCustomException exception) {
     log.warn("사용자 정의 예외 발생 : {}", exception.getMessage());
     return GlobalResponse.error(exception);
   }
@@ -52,7 +52,7 @@ public class GlobalExceptionHandler {
    * @return the response entity
    */
   @ExceptionHandler(value = {Exception.class})
-  public ResponseEntity<?> handleGenericException(Exception exception) {
+  public ResponseEntity<GlobalResponse> handleGenericException(Exception exception) {
     log.error("Exception.class 예외 발생 : {}", exception.getMessage());
     Error error = Error.of(UNKNOWN_ERROR.message(exception.getMessage()));
     return GlobalResponse.error(error);
@@ -65,7 +65,8 @@ public class GlobalExceptionHandler {
    * @return the response entity
    */
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException exception) {
+  public ResponseEntity<GlobalResponse> handleValidationException(
+      MethodArgumentNotValidException exception) {
 
     BindingResult bindingResult = exception.getBindingResult();
 
@@ -95,7 +96,7 @@ public class GlobalExceptionHandler {
    * @return the response entity
    */
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-  public ResponseEntity<?> handleTypeMismatchException(
+  public ResponseEntity<GlobalResponse> handleTypeMismatchException(
       MethodArgumentTypeMismatchException exception) {
     String fieldName = exception.getName();
     String rejectedValue = Objects.requireNonNull(exception.getValue()).toString();
@@ -119,7 +120,7 @@ public class GlobalExceptionHandler {
    * @return the response entity
    */
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<?> handleHttpMessageNotReadableException(
+  public ResponseEntity<GlobalResponse> handleHttpMessageNotReadableException(
       HttpMessageNotReadableException exception) {
     final String finallyErrorMessage = "요청 본문을 파싱하는 도중 오류가 발생했습니다. 요청 본문의 형식을 확인해주세요.";
 
@@ -172,7 +173,7 @@ public class GlobalExceptionHandler {
         UnsupportedJwtException.class,
         IllegalArgumentException.class
       })
-  public ResponseEntity<?> jwtTokenException(Exception e) {
+  public ResponseEntity<GlobalResponse> jwtTokenException(Exception e) {
 
     JwtExceptionType exceptionType = getJwtExceptionType(e);
 
@@ -210,7 +211,7 @@ public class GlobalExceptionHandler {
    * @return the response entity
    */
   @ExceptionHandler(SdkException.class)
-  public ResponseEntity<?> handleSdkException(SdkException exception) {
+  public ResponseEntity<GlobalResponse> handleSdkException(SdkException exception) {
     String errorMessage;
 
     if (exception instanceof AwsServiceException ase) {

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/security/policy/SecurityPolicyRouteCollector.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/security/policy/SecurityPolicyRouteCollector.java
@@ -33,6 +33,12 @@ public final class SecurityPolicyRouteCollector {
     return new SecurityPolicyRegistry(collectRoutes(handlerMethods, fallback));
   }
 
+  /** 핸들러에 적용되는 인증 방식. 문서 생성처럼 라우트 수집 밖에서도 같은 판정이 필요해 공개한다. */
+  public static AuthType resolveAuthType(HandlerMethod handlerMethod, AuthType fallback) {
+    SecurityPolicy policy = findPolicy(handlerMethod);
+    return policy == null ? fallback : policy.auth();
+  }
+
   private static List<SecurityPolicyRoute> collectRoutes(
       Map<RequestMappingInfo, HandlerMethod> handlerMethods, AuthType fallback) {
     List<SecurityPolicyRoute> routes = new ArrayList<>();

--- a/bottlenote-product-api/build.gradle
+++ b/bottlenote-product-api/build.gradle
@@ -21,6 +21,9 @@ dependencies {
 	implementation libs.spring.boot.starter.web
 	implementation libs.spring.boot.starter.validation
 
+	// OpenAPI 스펙 생성 (swagger-ui는 설정으로 비활성)
+	implementation libs.springdoc.openapi.starter.webmvc.ui
+
 	// Test - Lombok
 	testAnnotationProcessor libs.lombok
 
@@ -100,7 +103,10 @@ tasks.named('processResources') {
 
 tasks.register("prepareKotlinBuildScriptModel") {}
 
-// Spring REST Docs 설정
+// [삭제 예정] Spring REST Docs 설정
+// API 문서는 springdoc OpenAPI(GET /openapi.product.json)로 대체됐다.
+// 전환 기간 동안만 유지하며 새 엔드포인트를 이 경로로 문서화하지 않는다.
+// 상세: src/test/java/app/docs/DEPRECATED.md
 asciidoctor {
 	inputs.dir snippetsDir
 	configurations 'asciidoctorExt'

--- a/bottlenote-product-api/src/docs/asciidoc/product-api.adoc
+++ b/bottlenote-product-api/src/docs/asciidoc/product-api.adoc
@@ -1,3 +1,6 @@
+// [삭제 예정] 이 문서는 springdoc OpenAPI(GET /openapi.product.json)로 대체됐습니다.
+// 새 엔드포인트를 이 문서에 추가하지 마세요. 상세: ../../test/java/app/docs/DEPRECATED.md
+
 ifndef::snippets[]
 :snippets: ../../build/generated-snippets
 endif::[]

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholExploreController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholExploreController.java
@@ -2,6 +2,7 @@ package app.bottlenote.alcohols.controller;
 
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.OPTIONAL_AUTH;
 
+import app.bottlenote.alcohols.controller.docs.AlcoholExploreApiDocs;
 import app.bottlenote.alcohols.dto.request.ExploreStandardRequest;
 import app.bottlenote.alcohols.dto.response.AlcoholDetailItem;
 import app.bottlenote.alcohols.dto.response.ExploreStandardResponse;
@@ -26,13 +27,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/alcohols/explore")
 @SecurityPolicy(auth = OPTIONAL_AUTH)
+@AlcoholExploreApiDocs.ApiTag
 public class AlcoholExploreController {
 
   private final AlcoholQueryService alcoholQueryService;
 
   /** 기본 표준 형태의 위스키 둘러보기 API. 검색 기능(필터/정렬)을 흡수한 메인 탐색 엔드포인트. */
+  @AlcoholExploreApiDocs.GetStandardExplore
   @GetMapping("/standard")
-  public ResponseEntity<?> getStandardExplore(
+  public ResponseEntity<GlobalResponse> getStandardExplore(
       @ModelAttribute @Valid ExploreStandardRequest request) {
     Long userId = SecurityContextUtil.getUserIdByContext().orElse(-1L);
 

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholPopularQueryController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholPopularQueryController.java
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.controller;
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.OPTIONAL_AUTH;
 import static app.bottlenote.global.security.SecurityContextUtil.getUserIdByContext;
 
+import app.bottlenote.alcohols.controller.docs.AlcoholPopularApiDocs;
 import app.bottlenote.alcohols.dto.response.PopularsOfWeekResponse;
 import app.bottlenote.alcohols.service.AlcoholPopularService;
 import app.bottlenote.global.annotation.SecurityPolicy;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @SecurityPolicy(auth = OPTIONAL_AUTH)
+@AlcoholPopularApiDocs.ApiTag
 public class AlcoholPopularQueryController {
 
   private final AlcoholPopularService alcoholPopularService;
@@ -30,8 +32,10 @@ public class AlcoholPopularQueryController {
    * @param top 조회할 위스키 목록 개수
    * @return 조회된 위스키 목록
    */
+  @AlcoholPopularApiDocs.GetPopularOfWeek
   @GetMapping("/popular/week")
-  public ResponseEntity<?> getPopularOfWeek(@RequestParam(defaultValue = "5") Integer top) {
+  public ResponseEntity<GlobalResponse> getPopularOfWeek(
+      @RequestParam(defaultValue = "5") Integer top) {
     Long userId = getUserIdByContext().orElse(-1L);
     var populars = alcoholPopularService.getPopularOfWeek(top, userId);
     var response = PopularsOfWeekResponse.of(populars.size(), populars);
@@ -39,16 +43,19 @@ public class AlcoholPopularQueryController {
   }
 
   /** 봄 추천 인기 위스키 리스트 조회 */
+  @AlcoholPopularApiDocs.GetSpringItems
   @GetMapping("/popular/spring")
-  public ResponseEntity<?> getSpringItems() {
+  public ResponseEntity<GlobalResponse> getSpringItems() {
     Long userId = getUserIdByContext().orElse(-1L);
     var response = alcoholPopularService.getSpringItems(userId);
     return GlobalResponse.ok(response);
   }
 
   /** 주간 조회수 기반 인기 위스키 리스트 조회 */
+  @AlcoholPopularApiDocs.GetPopularByViewsWeekly
   @GetMapping("/popular/view/week")
-  public ResponseEntity<?> getPopularByViewsWeekly(@RequestParam(defaultValue = "20") Integer top) {
+  public ResponseEntity<GlobalResponse> getPopularByViewsWeekly(
+      @RequestParam(defaultValue = "20") Integer top) {
     Long userId = getUserIdByContext().orElse(-1L);
     var populars = alcoholPopularService.getPopularByViewsWeekly(top, userId);
     var response = PopularsOfWeekResponse.of(populars.size(), populars);
@@ -56,8 +63,9 @@ public class AlcoholPopularQueryController {
   }
 
   /** 월간 조회수 기반 인기 위스키 리스트 조회 */
+  @AlcoholPopularApiDocs.GetPopularByViewsMonthly
   @GetMapping("/popular/view/monthly")
-  public ResponseEntity<?> getPopularByViewsMonthly(
+  public ResponseEntity<GlobalResponse> getPopularByViewsMonthly(
       @RequestParam(defaultValue = "20") Integer top) {
     Long userId = getUserIdByContext().orElse(-1L);
     var populars = alcoholPopularService.getPopularByViewsMonthly(top, userId);

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholQueryController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholQueryController.java
@@ -4,6 +4,7 @@ import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.OPTIONAL_
 import static app.bottlenote.global.security.SecurityContextUtil.getUserIdByContext;
 import static app.bottlenote.global.service.meta.MetaService.createMetaInfo;
 
+import app.bottlenote.alcohols.controller.docs.AlcoholQueryApiDocs;
 import app.bottlenote.alcohols.dto.request.AlcoholLookupRequest;
 import app.bottlenote.alcohols.dto.request.AlcoholSearchRequest;
 import app.bottlenote.alcohols.dto.response.AlcoholSearchResponse;
@@ -27,21 +28,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/alcohols")
 @SecurityPolicy(auth = OPTIONAL_AUTH)
+@AlcoholQueryApiDocs.ApiTag
 public class AlcoholQueryController {
 
   private final AlcoholQueryService alcoholQueryService;
   private final AlcoholLookupService alcoholLookupService;
 
+  @AlcoholQueryApiDocs.GetLookups
   @GetMapping("/lookup")
-  public ResponseEntity<?> getAlcoholLookups(@ModelAttribute @Valid AlcoholLookupRequest request) {
+  public ResponseEntity<GlobalResponse> getAlcoholLookups(
+      @ModelAttribute @Valid AlcoholLookupRequest request) {
     var response = alcoholLookupService.lookup(request);
     return GlobalResponse.ok(
         response.items(),
         createMetaInfo().add("searchParameters", request).add("pageable", response.pageable()));
   }
 
+  @AlcoholQueryApiDocs.SearchAlcohols
   @GetMapping("/search")
-  public ResponseEntity<?> searchAlcohols(@ModelAttribute @Valid AlcoholSearchRequest request) {
+  public ResponseEntity<GlobalResponse> searchAlcohols(
+      @ModelAttribute @Valid AlcoholSearchRequest request) {
 
     // 키워드에 따라 큐레이션 ID 매핑 임시 ( 나중에는 이벤트 시작 시점에 로딩해오는게 더 좋을듯
     request =
@@ -65,8 +71,9 @@ public class AlcoholQueryController {
             .add("pageable", pageResponse.cursorPageable()));
   }
 
+  @AlcoholQueryApiDocs.GetAlcoholDetail
   @GetMapping("/{alcoholId}")
-  public ResponseEntity<?> findAlcoholDetailById(@PathVariable Long alcoholId) {
+  public ResponseEntity<GlobalResponse> findAlcoholDetailById(@PathVariable Long alcoholId) {
     Long id = getUserIdByContext().orElse(-1L);
     return GlobalResponse.ok(alcoholQueryService.findAlcoholDetailById(alcoholId, id));
   }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholReferenceController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/AlcoholReferenceController.java
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.controller;
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 
 import app.bottlenote.alcohols.constant.AlcoholType;
+import app.bottlenote.alcohols.controller.docs.AlcoholReferenceApiDocs;
 import app.bottlenote.alcohols.dto.request.CurationKeywordSearchRequest;
 import app.bottlenote.alcohols.dto.response.AlcoholsSearchItem;
 import app.bottlenote.alcohols.dto.response.CurationKeywordResponse;
@@ -23,31 +24,36 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @SecurityPolicy(auth = PUBLIC)
+@AlcoholReferenceApiDocs.ApiTag
 public class AlcoholReferenceController {
 
   private final AlcoholReferenceService alcoholReferenceService;
 
+  @AlcoholReferenceApiDocs.GetRegions
   @GetMapping("/regions")
-  public ResponseEntity<?> findAll() {
+  public ResponseEntity<GlobalResponse> findAll() {
     return GlobalResponse.ok(alcoholReferenceService.findAllRegion());
   }
 
+  @AlcoholReferenceApiDocs.GetCategories
   @GetMapping("/alcohols/categories")
-  public ResponseEntity<?> getAlcoholCategory(
+  public ResponseEntity<GlobalResponse> getAlcoholCategory(
       @RequestParam(required = false, defaultValue = "WHISKY") AlcoholType type) {
     return GlobalResponse.ok(alcoholReferenceService.getAlcoholCategory(type));
   }
 
+  @AlcoholReferenceApiDocs.SearchCurationKeywords
   @GetMapping("/curations")
-  public ResponseEntity<?> searchCurationKeywords(
+  public ResponseEntity<GlobalResponse> searchCurationKeywords(
       @ModelAttribute CurationKeywordSearchRequest request) {
     CursorResponse<CurationKeywordResponse> response =
         alcoholReferenceService.searchCurationKeywords(request);
     return GlobalResponse.ok(response);
   }
 
+  @AlcoholReferenceApiDocs.GetCurationAlcohols
   @GetMapping("/curations/{curationId}/alcohols")
-  public ResponseEntity<?> getCurationAlcohols(
+  public ResponseEntity<GlobalResponse> getCurationAlcohols(
       @PathVariable Long curationId,
       @RequestParam(required = false, defaultValue = "0") Long cursor,
       @RequestParam(required = false, defaultValue = "10") Long pageSize) {

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/TastingTagController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/TastingTagController.java
@@ -2,6 +2,7 @@ package app.bottlenote.alcohols.controller;
 
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 
+import app.bottlenote.alcohols.controller.docs.TastingTagApiDocs;
 import app.bottlenote.alcohols.service.TastingTagService;
 import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
@@ -17,12 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/tasting-tags")
 @RequiredArgsConstructor
 @SecurityPolicy(auth = PUBLIC)
+@TastingTagApiDocs.ApiTag
 public class TastingTagController {
 
   private final TastingTagService tastingTagService;
 
+  @TastingTagApiDocs.ExtractTags
   @GetMapping("/extract")
-  public ResponseEntity<?> getExtractedTags(@RequestParam String text) {
+  public ResponseEntity<GlobalResponse> getExtractedTags(@RequestParam String text) {
     List<String> tags = tastingTagService.extractTagNames(text);
     return GlobalResponse.ok(tags);
   }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
@@ -12,7 +12,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
-import org.springframework.http.MediaType;
 
 /** 위스키 탐색 엔드포인트의 문서 설명. */
 public final class AlcoholExploreApiDocs {
@@ -40,10 +39,7 @@ public final class AlcoholExploreApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "이번 페이지의 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ExploreResult.class))))
+              content = @Content(schema = @Schema(implementation = ExploreResult.class))))
   public @interface GetStandardExplore {}
 
   /** 탐색 응답의 data 형태. 실제로는 {@code CollectionResponse<AlcoholDetailItem>}이다. */

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
@@ -47,7 +47,7 @@ public final class AlcoholExploreApiDocs {
   public @interface GetStandardExplore {}
 
   /** 탐색 응답의 data 형태. 실제로는 {@code CollectionResponse<AlcoholDetailItem>}이다. */
-  @Schema(name = "위스키 탐색 결과", description = "전체 건수와 이번 페이지의 위스키 목록")
+  @Schema(name = "AlcoholExploreResult", title = "위스키 탐색 결과", description = "전체 건수와 이번 페이지의 위스키 목록")
   private record ExploreResult(
       @Schema(description = "전체 건수. 탐색에서는 집계하지 않아 0으로 내려간다", example = "0") long totalCount,
       @ArraySchema(schema = @Schema(implementation = AlcoholDetailItem.class))

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
@@ -1,0 +1,55 @@
+package app.bottlenote.alcohols.controller.docs;
+
+import app.bottlenote.alcohols.dto.response.AlcoholDetailItem;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import org.springframework.http.MediaType;
+
+/** 위스키 탐색 엔드포인트의 문서 설명. */
+public final class AlcoholExploreApiDocs {
+
+  private AlcoholExploreApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "위스키 탐색", description = "정렬 기준을 골라 위스키를 둘러본다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "정렬 기준에 따라 위스키를 탐색한다",
+      description =
+          """
+          인기순, 별점순, 리뷰순, 찜순, 무작위 중 원하는 기준으로 위스키를 둘러봅니다.
+
+          무작위 정렬은 페이지를 넘길 때 중복이나 누락이 생기지 않도록 seed 값을 사용합니다. \
+          첫 요청에서는 seed를 생략하면 서버가 만들어 meta.seed로 내려주고, 다음 페이지부터 그 값을 그대로 보내면 됩니다.
+          다음 페이지 정보는 meta.pageable, 탐색 조건은 meta.searchParameters에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "이번 페이지의 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ExploreResult.class))))
+  public @interface GetStandardExplore {}
+
+  /** 탐색 응답의 data 형태. 실제로는 {@code CollectionResponse<AlcoholDetailItem>}이다. */
+  @Schema(name = "위스키 탐색 결과", description = "전체 건수와 이번 페이지의 위스키 목록")
+  private record ExploreResult(
+      @Schema(description = "전체 건수. 탐색에서는 집계하지 않아 0으로 내려간다", example = "0") long totalCount,
+      @ArraySchema(schema = @Schema(implementation = AlcoholDetailItem.class))
+          List<AlcoholDetailItem> items) {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholExploreApiDocs.java
@@ -39,12 +39,12 @@ public final class AlcoholExploreApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "이번 페이지의 위스키 목록",
-              content = @Content(schema = @Schema(implementation = ExploreResult.class))))
+              content = @Content(schema = @Schema(implementation = AlcoholExploreResult.class))))
   public @interface GetStandardExplore {}
 
   /** 탐색 응답의 data 형태. 실제로는 {@code CollectionResponse<AlcoholDetailItem>}이다. */
   @Schema(name = "AlcoholExploreResult", title = "위스키 탐색 결과", description = "전체 건수와 이번 페이지의 위스키 목록")
-  private record ExploreResult(
+  private record AlcoholExploreResult(
       @Schema(description = "전체 건수. 탐색에서는 집계하지 않아 0으로 내려간다", example = "0") long totalCount,
       @ArraySchema(schema = @Schema(implementation = AlcoholDetailItem.class))
           List<AlcoholDetailItem> items) {}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholPopularApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholPopularApiDocs.java
@@ -12,7 +12,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 인기 위스키 엔드포인트의 문서 설명. */
 public final class AlcoholPopularApiDocs {
@@ -33,10 +32,7 @@ public final class AlcoholPopularApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "전체 건수와 인기 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = PopularsOfWeekResponse.class))))
+              content = @Content(schema = @Schema(implementation = PopularsOfWeekResponse.class))))
   public @interface GetPopularOfWeek {}
 
   @Target(ElementType.METHOD)
@@ -50,7 +46,6 @@ public final class AlcoholPopularApiDocs {
               description = "봄 추천 위스키 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array = @ArraySchema(schema = @Schema(implementation = PopularItem.class)))))
   public @interface GetSpringItems {}
 
@@ -63,10 +58,7 @@ public final class AlcoholPopularApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "전체 건수와 조회수 상위 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = PopularsOfWeekResponse.class))))
+              content = @Content(schema = @Schema(implementation = PopularsOfWeekResponse.class))))
   public @interface GetPopularByViewsWeekly {}
 
   @Target(ElementType.METHOD)
@@ -78,9 +70,6 @@ public final class AlcoholPopularApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "전체 건수와 조회수 상위 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = PopularsOfWeekResponse.class))))
+              content = @Content(schema = @Schema(implementation = PopularsOfWeekResponse.class))))
   public @interface GetPopularByViewsMonthly {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholPopularApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholPopularApiDocs.java
@@ -1,0 +1,86 @@
+package app.bottlenote.alcohols.controller.docs;
+
+import app.bottlenote.alcohols.dto.response.PopularItem;
+import app.bottlenote.alcohols.dto.response.PopularsOfWeekResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 인기 위스키 엔드포인트의 문서 설명. */
+public final class AlcoholPopularApiDocs {
+
+  private AlcoholPopularApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "인기 위스키", description = "기간과 기준별로 집계한 인기 위스키를 제공한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "이번 주 인기 위스키를 조회한다",
+      description = "최근 한 주간의 별점과 리뷰 활동을 합산해 순위를 매깁니다. top 값으로 받아올 개수를 정할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "전체 건수와 인기 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = PopularsOfWeekResponse.class))))
+  public @interface GetPopularOfWeek {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "봄 추천 위스키를 조회한다",
+      description = "계절 기획으로 선정한 봄 추천 위스키 목록입니다. 집계 결과가 아니라 미리 고른 목록이라 요청 조건이 없습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "봄 추천 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array = @ArraySchema(schema = @Schema(implementation = PopularItem.class)))))
+  public @interface GetSpringItems {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "이번 주 조회수 기준 인기 위스키를 조회한다",
+      description = "최근 한 주간 상세 페이지를 많이 본 순서로 순위를 매깁니다. 별점이나 리뷰가 아니라 조회 이력만 봅니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "전체 건수와 조회수 상위 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = PopularsOfWeekResponse.class))))
+  public @interface GetPopularByViewsWeekly {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "이번 달 조회수 기준 인기 위스키를 조회한다",
+      description = "최근 한 달간 상세 페이지를 많이 본 순서로 순위를 매깁니다. 주간 집계보다 순위가 천천히 바뀝니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "전체 건수와 조회수 상위 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = PopularsOfWeekResponse.class))))
+  public @interface GetPopularByViewsMonthly {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholQueryApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholQueryApiDocs.java
@@ -13,7 +13,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 위스키 조회 엔드포인트의 문서 설명. */
 public final class AlcoholQueryApiDocs {
@@ -42,7 +41,6 @@ public final class AlcoholQueryApiDocs {
               description = "자동 완성 후보 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = AlcoholLookupItem.class)))))
@@ -66,7 +64,6 @@ public final class AlcoholQueryApiDocs {
               description = "검색된 위스키 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = AlcoholSearchResponse.class)))))
@@ -86,9 +83,6 @@ public final class AlcoholQueryApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "위스키 상세 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = AlcoholDetailResponse.class))))
+              content = @Content(schema = @Schema(implementation = AlcoholDetailResponse.class))))
   public @interface GetAlcoholDetail {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholQueryApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholQueryApiDocs.java
@@ -1,0 +1,94 @@
+package app.bottlenote.alcohols.controller.docs;
+
+import app.bottlenote.alcohols.dto.response.AlcoholDetailResponse;
+import app.bottlenote.alcohols.dto.response.AlcoholLookupItem;
+import app.bottlenote.alcohols.dto.response.AlcoholSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 위스키 조회 엔드포인트의 문서 설명. */
+public final class AlcoholQueryApiDocs {
+
+  private AlcoholQueryApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "위스키 조회", description = "위스키를 검색하고 상세 정보를 확인한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "위스키 이름을 자동 완성용으로 조회한다",
+      description =
+          """
+          입력 중인 글자로 시작하거나 그 글자를 포함하는 위스키 이름을 가볍게 가져옵니다.
+
+          검색창 자동 완성을 위한 용도라 상세 정보 없이 식별자와 이름 위주로 응답합니다.
+          다음 페이지 정보는 meta.pageable, 조회 조건은 meta.searchParameters에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "자동 완성 후보 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = AlcoholLookupItem.class)))))
+  public @interface GetLookups {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "조건을 걸어 위스키를 검색한다",
+      description =
+          """
+          키워드, 종류, 지역, 도수 등의 조건을 조합해 위스키를 찾습니다.
+
+          로그인하지 않아도 검색할 수 있고, 로그인한 경우 각 위스키에 본인의 찜 여부가 함께 표시됩니다.
+          일부 키워드는 서버가 기획된 큐레이션 검색으로 바꿔 처리합니다.
+          다음 페이지 정보는 meta.pageable, 검색 조건은 meta.searchParameters에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "검색된 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = AlcoholSearchResponse.class)))))
+  public @interface SearchAlcohols {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "위스키 상세 정보를 조회한다",
+      description =
+          """
+          위스키의 기본 정보와 함께 평균 별점, 리뷰 수, 대표 테이스팅 태그를 반환합니다.
+
+          로그인한 경우 본인이 남긴 별점과 찜 여부가 함께 담깁니다. 조회 이력은 별도로 집계됩니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "위스키 상세 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = AlcoholDetailResponse.class))))
+  public @interface GetAlcoholDetail {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholReferenceApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholReferenceApiDocs.java
@@ -16,7 +16,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
-import org.springframework.http.MediaType;
 
 /** 위스키 기준 정보와 큐레이션 조회 엔드포인트의 문서 설명. */
 public final class AlcoholReferenceApiDocs {
@@ -39,7 +38,6 @@ public final class AlcoholReferenceApiDocs {
               description = "지역 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array = @ArraySchema(schema = @Schema(implementation = RegionsItem.class)))))
   public @interface GetRegions {}
 
@@ -54,7 +52,6 @@ public final class AlcoholReferenceApiDocs {
               description = "종류 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array = @ArraySchema(schema = @Schema(implementation = CategoryItem.class)))))
   public @interface GetCategories {}
 
@@ -67,10 +64,7 @@ public final class AlcoholReferenceApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "큐레이션 키워드 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = CurationKeywordPage.class))))
+              content = @Content(schema = @Schema(implementation = CurationKeywordPage.class))))
   public @interface SearchCurationKeywords {}
 
   @Target(ElementType.METHOD)
@@ -82,10 +76,7 @@ public final class AlcoholReferenceApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "큐레이션에 담긴 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = CurationAlcoholPage.class))))
+              content = @Content(schema = @Schema(implementation = CurationAlcoholPage.class))))
   public @interface GetCurationAlcohols {}
 
   /** 실제로는 {@code CursorResponse<CurationKeywordResponse>}다. */

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholReferenceApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholReferenceApiDocs.java
@@ -89,14 +89,20 @@ public final class AlcoholReferenceApiDocs {
   public @interface GetCurationAlcohols {}
 
   /** 실제로는 {@code CursorResponse<CurationKeywordResponse>}다. */
-  @Schema(name = "큐레이션 키워드 페이지", description = "이번 페이지의 큐레이션과 다음 페이지 정보")
+  @Schema(
+      name = "CurationKeywordPage",
+      title = "큐레이션 키워드 페이지",
+      description = "이번 페이지의 큐레이션과 다음 페이지 정보")
   private record CurationKeywordPage(
       @ArraySchema(schema = @Schema(implementation = CurationKeywordResponse.class))
           List<CurationKeywordResponse> items,
       CursorPageable pageable) {}
 
   /** 실제로는 {@code CursorResponse<AlcoholsSearchItem>}다. */
-  @Schema(name = "큐레이션 위스키 페이지", description = "이번 페이지의 위스키와 다음 페이지 정보")
+  @Schema(
+      name = "CurationAlcoholPage",
+      title = "큐레이션 위스키 페이지",
+      description = "이번 페이지의 위스키와 다음 페이지 정보")
   private record CurationAlcoholPage(
       @ArraySchema(schema = @Schema(implementation = AlcoholsSearchItem.class))
           List<AlcoholsSearchItem> items,

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholReferenceApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/AlcoholReferenceApiDocs.java
@@ -1,0 +1,104 @@
+package app.bottlenote.alcohols.controller.docs;
+
+import app.bottlenote.alcohols.dto.response.AlcoholsSearchItem;
+import app.bottlenote.alcohols.dto.response.CategoryItem;
+import app.bottlenote.alcohols.dto.response.CurationKeywordResponse;
+import app.bottlenote.alcohols.dto.response.RegionsItem;
+import app.bottlenote.global.service.cursor.CursorPageable;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import org.springframework.http.MediaType;
+
+/** 위스키 기준 정보와 큐레이션 조회 엔드포인트의 문서 설명. */
+public final class AlcoholReferenceApiDocs {
+
+  private AlcoholReferenceApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "위스키 기준 정보", description = "지역과 종류 같은 선택 목록, 그리고 큐레이션을 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "위스키 생산 지역 목록을 조회한다",
+      description = "검색 필터에서 지역을 고를 때 쓰는 전체 목록입니다. 자주 바뀌지 않으므로 클라이언트에서 캐싱해도 좋습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "지역 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array = @ArraySchema(schema = @Schema(implementation = RegionsItem.class)))))
+  public @interface GetRegions {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "위스키 종류 목록을 조회한다",
+      description = "검색 필터에서 종류를 고를 때 쓰는 목록입니다. 종류를 지정하면 그 종류에 속한 세부 분류만 가져옵니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "종류 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array = @ArraySchema(schema = @Schema(implementation = CategoryItem.class)))))
+  public @interface GetCategories {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "큐레이션 키워드를 검색한다",
+      description = "노출 중인 큐레이션을 커서 방식으로 가져옵니다. 응답의 pageable로 다음 페이지를 이어 요청합니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "큐레이션 키워드 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = CurationKeywordPage.class))))
+  public @interface SearchCurationKeywords {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "큐레이션에 담긴 위스키를 조회한다",
+      description = "해당 큐레이션에 편성된 위스키를 커서 방식으로 가져옵니다. 삭제된 위스키는 제외됩니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "큐레이션에 담긴 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = CurationAlcoholPage.class))))
+  public @interface GetCurationAlcohols {}
+
+  /** 실제로는 {@code CursorResponse<CurationKeywordResponse>}다. */
+  @Schema(name = "큐레이션 키워드 페이지", description = "이번 페이지의 큐레이션과 다음 페이지 정보")
+  private record CurationKeywordPage(
+      @ArraySchema(schema = @Schema(implementation = CurationKeywordResponse.class))
+          List<CurationKeywordResponse> items,
+      CursorPageable pageable) {}
+
+  /** 실제로는 {@code CursorResponse<AlcoholsSearchItem>}다. */
+  @Schema(name = "큐레이션 위스키 페이지", description = "이번 페이지의 위스키와 다음 페이지 정보")
+  private record CurationAlcoholPage(
+      @ArraySchema(schema = @Schema(implementation = AlcoholsSearchItem.class))
+          List<AlcoholsSearchItem> items,
+      CursorPageable pageable) {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/TastingTagApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/TastingTagApiDocs.java
@@ -10,7 +10,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 테이스팅 태그 추출 엔드포인트의 문서 설명. */
 public final class TastingTagApiDocs {
@@ -38,7 +37,6 @@ public final class TastingTagApiDocs {
               description = "추출된 태그 이름 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema =

--- a/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/TastingTagApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/alcohols/controller/docs/TastingTagApiDocs.java
@@ -1,0 +1,50 @@
+package app.bottlenote.alcohols.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 테이스팅 태그 추출 엔드포인트의 문서 설명. */
+public final class TastingTagApiDocs {
+
+  private TastingTagApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "테이스팅 태그", description = "리뷰 문장에서 맛과 향 표현을 뽑아낸다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "문장에서 테이스팅 태그를 추출한다",
+      description =
+          """
+          리뷰를 쓰는 중에 입력한 문장을 보내면 그 안에 담긴 맛과 향 표현을 태그로 뽑아 돌려줍니다.
+
+          리뷰 작성 화면에서 태그를 자동으로 제안하기 위한 용도입니다. 추출된 태그가 곧바로 리뷰에 저장되지는 않습니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "추출된 태그 이름 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema =
+                                  @Schema(
+                                      type = "string",
+                                      example = "달달한",
+                                      description = "태그 이름")))))
+  public @interface ExtractTags {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/banner/controller/BannerQueryController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/banner/controller/BannerQueryController.java
@@ -2,6 +2,7 @@ package app.bottlenote.banner.controller;
 
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 
+import app.bottlenote.banner.controller.docs.BannerApiDocs;
 import app.bottlenote.banner.service.BannerQueryService;
 import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
@@ -16,10 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/banners")
 @RequiredArgsConstructor
 @SecurityPolicy(auth = PUBLIC)
+@BannerApiDocs.ApiTag
 public class BannerQueryController {
 
   private final BannerQueryService bannerQueryService;
 
+  @BannerApiDocs.GetActiveBanners
   @GetMapping
   public ResponseEntity<GlobalResponse> getActiveBanners(
       @RequestParam(defaultValue = "10") Integer limit) {

--- a/bottlenote-product-api/src/main/java/app/bottlenote/banner/controller/docs/BannerApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/banner/controller/docs/BannerApiDocs.java
@@ -11,7 +11,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 배너 조회 엔드포인트의 문서 설명. */
 public final class BannerApiDocs {
@@ -39,7 +38,6 @@ public final class BannerApiDocs {
               description = "노출 중인 배너 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(schema = @Schema(implementation = BannerResponse.class)))))
   public @interface GetActiveBanners {}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/banner/controller/docs/BannerApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/banner/controller/docs/BannerApiDocs.java
@@ -1,0 +1,46 @@
+package app.bottlenote.banner.controller.docs;
+
+import app.bottlenote.banner.dto.response.BannerResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 배너 조회 엔드포인트의 문서 설명. */
+public final class BannerApiDocs {
+
+  private BannerApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "배너", description = "앱 화면에 노출할 배너를 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "노출 중인 배너를 조회한다",
+      description =
+          """
+          현재 노출 기간에 있는 배너를 우선순위 순으로 가져옵니다.
+
+          limit으로 받아올 개수를 조절할 수 있습니다. 기간이 지났거나 비활성 상태인 배너는 제외됩니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "노출 중인 배너 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(schema = @Schema(implementation = BannerResponse.class)))))
+  public @interface GetActiveBanners {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/common/file/controller/ImageUploadController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/common/file/controller/ImageUploadController.java
@@ -1,5 +1,6 @@
 package app.bottlenote.common.file.controller;
 
+import app.bottlenote.common.file.controller.docs.ImageUploadApiDocs;
 import app.bottlenote.common.file.dto.request.ImageUploadRequest;
 import app.bottlenote.common.file.service.ImageUploadService;
 import app.bottlenote.global.data.response.GlobalResponse;
@@ -13,12 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/s3")
+@ImageUploadApiDocs.ApiTag
 public class ImageUploadController {
 
   private final ImageUploadService imageUploadService;
 
+  @ImageUploadApiDocs.GetPreSignUrl
   @GetMapping("/presign-url")
-  public ResponseEntity<?> getPreSignUrl(@ModelAttribute ImageUploadRequest request) {
+  public ResponseEntity<GlobalResponse> getPreSignUrl(@ModelAttribute ImageUploadRequest request) {
     return ResponseEntity.ok(GlobalResponse.success(imageUploadService.getPreSignUrl(request)));
   }
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/common/file/controller/docs/ImageUploadApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/common/file/controller/docs/ImageUploadApiDocs.java
@@ -10,7 +10,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 이미지 업로드 엔드포인트의 문서 설명. */
 public final class ImageUploadApiDocs {
@@ -37,9 +36,6 @@ public final class ImageUploadApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "업로드 주소와 조회 주소",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ImageUploadResponse.class))))
+              content = @Content(schema = @Schema(implementation = ImageUploadResponse.class))))
   public @interface GetPreSignUrl {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/common/file/controller/docs/ImageUploadApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/common/file/controller/docs/ImageUploadApiDocs.java
@@ -1,0 +1,45 @@
+package app.bottlenote.common.file.controller.docs;
+
+import app.bottlenote.common.file.dto.response.ImageUploadResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 이미지 업로드 엔드포인트의 문서 설명. */
+public final class ImageUploadApiDocs {
+
+  private ImageUploadApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "이미지 업로드", description = "이미지를 직접 올릴 수 있는 임시 주소를 발급한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "이미지 업로드용 임시 주소를 발급한다",
+      description =
+          """
+          이미지를 저장소에 직접 올릴 수 있는 임시 주소를 발급합니다.
+
+          서버를 거치지 않고 클라이언트가 이 주소로 파일을 올린 뒤, 함께 받은 조회 주소를 리뷰나 프로필 등록 요청에 넣습니다.
+          임시 주소는 일정 시간이 지나면 만료됩니다. 한 번에 여러 장이 필요하면 개수를 지정해 요청합니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "업로드 주소와 조회 주소",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ImageUploadResponse.class))))
+  public @interface GetPreSignUrl {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/ProductCurationSpecController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/ProductCurationSpecController.java
@@ -2,6 +2,7 @@ package app.bottlenote.curation.controller;
 
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 
+import app.bottlenote.curation.controller.docs.CurationSpecApiDocs;
 import app.bottlenote.curation.service.CurationSpecQueryService;
 import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
@@ -16,17 +17,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v2/curation-specs")
 @RequiredArgsConstructor
 @SecurityPolicy(auth = PUBLIC)
+@CurationSpecApiDocs.ApiTag
 public class ProductCurationSpecController {
 
   private final CurationSpecQueryService curationSpecQueryService;
 
+  @CurationSpecApiDocs.GetCurationSpecs
   @GetMapping
-  public ResponseEntity<?> getCurationSpecs() {
+  public ResponseEntity<GlobalResponse> getCurationSpecs() {
     return GlobalResponse.ok(curationSpecQueryService.listActiveSpecs());
   }
 
+  @CurationSpecApiDocs.GetCurationSpec
   @GetMapping("/{specId}")
-  public ResponseEntity<?> getCurationSpec(@PathVariable Long specId) {
+  public ResponseEntity<GlobalResponse> getCurationSpec(@PathVariable Long specId) {
     return GlobalResponse.ok(curationSpecQueryService.getActiveSpecDetail(specId));
   }
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/ProductSpecBasedCurationController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/ProductSpecBasedCurationController.java
@@ -2,6 +2,7 @@ package app.bottlenote.curation.controller;
 
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 
+import app.bottlenote.curation.controller.docs.SpecBasedCurationApiDocs;
 import app.bottlenote.curation.dto.request.CurationFeedSearchRequest;
 import app.bottlenote.curation.service.ProductSpecBasedCurationService;
 import app.bottlenote.global.annotation.SecurityPolicy;
@@ -19,25 +20,29 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v2/curations")
 @RequiredArgsConstructor
 @SecurityPolicy(auth = PUBLIC)
+@SpecBasedCurationApiDocs.ApiTag
 public class ProductSpecBasedCurationController {
 
   private final ProductSpecBasedCurationService productSpecBasedCurationService;
 
+  @SpecBasedCurationApiDocs.GetCurations
   @GetMapping
-  public ResponseEntity<?> getCurations() {
+  public ResponseEntity<GlobalResponse> getCurations() {
     return GlobalResponse.ok(productSpecBasedCurationService.listActiveCurations());
   }
 
+  @SpecBasedCurationApiDocs.GetCurationFeed
   @GetMapping("/feed")
-  public ResponseEntity<?> getCurationFeed(
+  public ResponseEntity<GlobalResponse> getCurationFeed(
       @ModelAttribute @Valid CurationFeedSearchRequest request) {
     return GlobalResponse.ok(
         productSpecBasedCurationService.searchFeed(
             request.keyword(), request.code(), request.cursor(), request.size()));
   }
 
+  @SpecBasedCurationApiDocs.GetCuration
   @GetMapping("/{curationId}")
-  public ResponseEntity<?> getCuration(@PathVariable Long curationId) {
+  public ResponseEntity<GlobalResponse> getCuration(@PathVariable Long curationId) {
     return GlobalResponse.ok(productSpecBasedCurationService.getDetail(curationId));
   }
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/CurationSpecApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/CurationSpecApiDocs.java
@@ -1,0 +1,64 @@
+package app.bottlenote.curation.controller.docs;
+
+import app.bottlenote.curation.dto.response.CurationSpecListResponse;
+import app.bottlenote.curation.dto.response.CurationSpecResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 큐레이션 명세 조회 엔드포인트의 문서 설명. */
+public final class CurationSpecApiDocs {
+
+  private CurationSpecApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "큐레이션 명세", description = "큐레이션이 어떤 항목으로 구성되는지 정의한 명세를 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "사용 중인 큐레이션 명세 목록을 조회한다",
+      description =
+          """
+          현재 활성 상태인 큐레이션 명세를 모두 가져옵니다.
+
+          명세는 큐레이션 화면이 어떤 항목을 어떤 형태로 담을지 정의한 틀입니다. \
+          클라이언트가 화면을 구성하기 전에 이 목록으로 지원 가능한 유형을 파악합니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "활성 명세 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = CurationSpecListResponse.class)))))
+  public @interface GetCurationSpecs {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "큐레이션 명세 상세를 조회한다",
+      description = "명세가 정의한 항목 구성과 각 항목의 형식을 반환합니다. 비활성 상태인 명세는 조회되지 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "명세 상세 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = CurationSpecResponse.class))))
+  public @interface GetCurationSpec {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/CurationSpecApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/CurationSpecApiDocs.java
@@ -12,7 +12,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 큐레이션 명세 조회 엔드포인트의 문서 설명. */
 public final class CurationSpecApiDocs {
@@ -41,7 +40,6 @@ public final class CurationSpecApiDocs {
               description = "활성 명세 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = CurationSpecListResponse.class)))))
@@ -56,9 +54,6 @@ public final class CurationSpecApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "명세 상세 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = CurationSpecResponse.class))))
+              content = @Content(schema = @Schema(implementation = CurationSpecResponse.class))))
   public @interface GetCurationSpec {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/SpecBasedCurationApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/SpecBasedCurationApiDocs.java
@@ -15,7 +15,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
-import org.springframework.http.MediaType;
 
 /** 큐레이션 조회 엔드포인트의 문서 설명. */
 public final class SpecBasedCurationApiDocs {
@@ -38,7 +37,6 @@ public final class SpecBasedCurationApiDocs {
               description = "노출 중인 큐레이션 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema =
@@ -62,10 +60,7 @@ public final class SpecBasedCurationApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "피드 항목과 다음 페이지 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = CurationFeedPage.class))))
+              content = @Content(schema = @Schema(implementation = CurationFeedPage.class))))
   public @interface GetCurationFeed {}
 
   @Target(ElementType.METHOD)
@@ -79,7 +74,6 @@ public final class SpecBasedCurationApiDocs {
               description = "큐레이션 상세 정보",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       schema =
                           @Schema(implementation = ProductSpecBasedCurationDetailResponse.class))))
   public @interface GetCuration {}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/SpecBasedCurationApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/SpecBasedCurationApiDocs.java
@@ -85,7 +85,10 @@ public final class SpecBasedCurationApiDocs {
   public @interface GetCuration {}
 
   /** 실제로는 {@code CursorResponse<ProductSpecBasedCurationFeedItemResponse>}다. */
-  @Schema(name = "큐레이션 피드 페이지", description = "이번 페이지의 피드 항목과 다음 페이지 정보")
+  @Schema(
+      name = "CurationFeedPage",
+      title = "큐레이션 피드 페이지",
+      description = "이번 페이지의 피드 항목과 다음 페이지 정보")
   private record CurationFeedPage(
       @ArraySchema(
               schema = @Schema(implementation = ProductSpecBasedCurationFeedItemResponse.class))

--- a/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/SpecBasedCurationApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/curation/controller/docs/SpecBasedCurationApiDocs.java
@@ -1,0 +1,94 @@
+package app.bottlenote.curation.controller.docs;
+
+import app.bottlenote.curation.dto.response.ProductSpecBasedCurationDetailResponse;
+import app.bottlenote.curation.dto.response.ProductSpecBasedCurationFeedItemResponse;
+import app.bottlenote.curation.dto.response.ProductSpecBasedCurationListResponse;
+import app.bottlenote.global.service.cursor.CursorPageable;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import org.springframework.http.MediaType;
+
+/** 큐레이션 조회 엔드포인트의 문서 설명. */
+public final class SpecBasedCurationApiDocs {
+
+  private SpecBasedCurationApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "큐레이션", description = "기획으로 엮은 위스키 모음과 피드를 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "노출 중인 큐레이션 목록을 조회한다",
+      description = "현재 노출 기간에 있는 큐레이션을 모두 가져옵니다. 기간이 지나거나 아직 시작하지 않은 큐레이션은 제외됩니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "노출 중인 큐레이션 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema =
+                                  @Schema(
+                                      implementation =
+                                          ProductSpecBasedCurationListResponse.class)))))
+  public @interface GetCurations {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "큐레이션 피드를 조회한다",
+      description =
+          """
+          큐레이션을 카드 형태로 이어 보여주는 피드를 커서 방식으로 가져옵니다.
+
+          키워드로 제목을 검색하거나 코드로 특정 유형만 걸러낼 수 있고, 코드는 여러 개를 함께 보낼 수 있습니다.
+          각 항목의 내용은 큐레이션 명세에 따라 구성되므로 유형별로 담기는 항목이 다릅니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "피드 항목과 다음 페이지 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = CurationFeedPage.class))))
+  public @interface GetCurationFeed {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "큐레이션 상세를 조회한다",
+      description = "큐레이션의 소개 정보와 편성된 위스키를 반환합니다. 삭제된 위스키는 제외되고, 노출 기간이 아닌 큐레이션은 조회되지 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "큐레이션 상세 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema =
+                          @Schema(implementation = ProductSpecBasedCurationDetailResponse.class))))
+  public @interface GetCuration {}
+
+  /** 실제로는 {@code CursorResponse<ProductSpecBasedCurationFeedItemResponse>}다. */
+  @Schema(name = "큐레이션 피드 페이지", description = "이번 페이지의 피드 항목과 다음 페이지 정보")
+  private record CurationFeedPage(
+      @ArraySchema(
+              schema = @Schema(implementation = ProductSpecBasedCurationFeedItemResponse.class))
+          List<ProductSpecBasedCurationFeedItemResponse> items,
+      CursorPageable pageable) {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/UserHistoryController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/UserHistoryController.java
@@ -7,6 +7,7 @@ import app.bottlenote.global.data.response.CollectionResponse;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.global.service.meta.MetaService;
+import app.bottlenote.history.controller.docs.UserHistoryApiDocs;
 import app.bottlenote.history.dto.request.UserHistorySearchRequest;
 import app.bottlenote.history.dto.response.UserHistorySearchResponse;
 import app.bottlenote.history.service.AlcoholViewHistoryService;
@@ -23,13 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/history")
 @RequiredArgsConstructor
+@UserHistoryApiDocs.ApiTag
 public class UserHistoryController {
 
   private final UserHistoryQueryService userHistoryQueryService;
   private final AlcoholViewHistoryService alcoholViewHistoryService;
 
+  @UserHistoryApiDocs.GetUserHistoryList
   @GetMapping("/{targetUserId}")
-  public ResponseEntity<?> findUserHistoryList(
+  public ResponseEntity<GlobalResponse> findUserHistoryList(
       @PathVariable Long targetUserId,
       @ModelAttribute @Valid UserHistorySearchRequest userHistorySearchRequest) {
 
@@ -40,8 +43,9 @@ public class UserHistoryController {
         MetaService.createMetaInfo().add("pageable", userHistoryList.cursorPageable()));
   }
 
+  @UserHistoryApiDocs.GetViewHistory
   @GetMapping("/view/alcohols")
-  public ResponseEntity<?> getViewHistory() {
+  public ResponseEntity<GlobalResponse> getViewHistory() {
     Long id = getUserIdByContext().orElse(-1L);
     CollectionResponse<ViewHistoryItem> response = alcoholViewHistoryService.getViewHistory(id);
     return GlobalResponse.ok(response);

--- a/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/docs/UserHistoryApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/docs/UserHistoryApiDocs.java
@@ -13,7 +13,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
-import org.springframework.http.MediaType;
 
 /** 활동 기록 엔드포인트의 문서 설명. */
 public final class UserHistoryApiDocs {
@@ -41,7 +40,6 @@ public final class UserHistoryApiDocs {
               description = "활동 기록 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = UserHistorySearchResponse.class)))))
@@ -56,10 +54,7 @@ public final class UserHistoryApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "전체 건수와 최근 본 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ViewHistoryCollection.class))))
+              content = @Content(schema = @Schema(implementation = ViewHistoryCollection.class))))
   public @interface GetViewHistory {}
 
   /** 실제로는 {@code CollectionResponse<ViewHistoryItem>}다. */

--- a/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/docs/UserHistoryApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/docs/UserHistoryApiDocs.java
@@ -63,7 +63,7 @@ public final class UserHistoryApiDocs {
   public @interface GetViewHistory {}
 
   /** 실제로는 {@code CollectionResponse<ViewHistoryItem>}다. */
-  @Schema(name = "최근 본 위스키 목록", description = "전체 건수와 최근 본 위스키")
+  @Schema(name = "ViewHistoryCollection", title = "최근 본 위스키 목록", description = "전체 건수와 최근 본 위스키")
   private record ViewHistoryCollection(
       @Schema(description = "최근 본 위스키 건수", example = "12") long totalCount,
       @ArraySchema(schema = @Schema(implementation = ViewHistoryItem.class))

--- a/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/docs/UserHistoryApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/history/controller/docs/UserHistoryApiDocs.java
@@ -1,0 +1,71 @@
+package app.bottlenote.history.controller.docs;
+
+import app.bottlenote.alcohols.dto.response.ViewHistoryItem;
+import app.bottlenote.history.dto.response.UserHistorySearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import org.springframework.http.MediaType;
+
+/** 활동 기록 엔드포인트의 문서 설명. */
+public final class UserHistoryApiDocs {
+
+  private UserHistoryApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "활동 기록", description = "사용자의 활동 내역과 최근 본 위스키를 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "사용자의 활동 기록을 조회한다",
+      description =
+          """
+          대상 사용자가 남긴 리뷰·별점·찜 등의 활동을 시간순으로 커서 방식으로 가져옵니다.
+
+          기간이나 활동 유형으로 걸러낼 수 있습니다. 다음 페이지 정보는 meta.pageable에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "활동 기록 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = UserHistorySearchResponse.class)))))
+  public @interface GetUserHistoryList {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "최근 본 위스키를 조회한다",
+      description = "로그인한 사용자가 최근에 상세 페이지를 열어본 위스키를 최신순으로 반환합니다. 조회 이력은 일정 주기로 집계됩니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "전체 건수와 최근 본 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ViewHistoryCollection.class))))
+  public @interface GetViewHistory {}
+
+  /** 실제로는 {@code CollectionResponse<ViewHistoryItem>}다. */
+  @Schema(name = "최근 본 위스키 목록", description = "전체 건수와 최근 본 위스키")
+  private record ViewHistoryCollection(
+      @Schema(description = "최근 본 위스키 건수", example = "12") long totalCount,
+      @ArraySchema(schema = @Schema(implementation = ViewHistoryItem.class))
+          List<ViewHistoryItem> items) {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/like/controller/LikesCommandController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/like/controller/LikesCommandController.java
@@ -3,6 +3,7 @@ package app.bottlenote.like.controller;
 import static app.bottlenote.global.security.SecurityContextUtil.getUserIdByContext;
 
 import app.bottlenote.global.data.response.GlobalResponse;
+import app.bottlenote.like.controller.docs.LikesApiDocs;
 import app.bottlenote.like.dto.request.LikesUpdateRequest;
 import app.bottlenote.like.dto.response.LikesUpdateResponse;
 import app.bottlenote.like.service.LikesCommandService;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/likes")
+@LikesApiDocs.ApiTag
 public class LikesCommandController {
 
   private final LikesCommandService likesCommandService;
@@ -25,8 +27,10 @@ public class LikesCommandController {
     this.likesCommandService = likesCommandService;
   }
 
+  @LikesApiDocs.UpdateLikes
   @PutMapping
-  public ResponseEntity<?> updateLikes(@Valid @RequestBody LikesUpdateRequest request) {
+  public ResponseEntity<GlobalResponse> updateLikes(
+      @Valid @RequestBody LikesUpdateRequest request) {
     Long userId =
         getUserIdByContext()
             .orElseThrow(() -> new UserException(UserExceptionCode.REQUIRED_USER_ID));

--- a/bottlenote-product-api/src/main/java/app/bottlenote/like/controller/docs/LikesApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/like/controller/docs/LikesApiDocs.java
@@ -10,7 +10,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 리뷰 좋아요 엔드포인트의 문서 설명. */
 public final class LikesApiDocs {
@@ -36,9 +35,6 @@ public final class LikesApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "변경된 좋아요 상태",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = LikesUpdateResponse.class))))
+              content = @Content(schema = @Schema(implementation = LikesUpdateResponse.class))))
   public @interface UpdateLikes {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/like/controller/docs/LikesApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/like/controller/docs/LikesApiDocs.java
@@ -1,0 +1,44 @@
+package app.bottlenote.like.controller.docs;
+
+import app.bottlenote.like.dto.response.LikesUpdateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 리뷰 좋아요 엔드포인트의 문서 설명. */
+public final class LikesApiDocs {
+
+  private LikesApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "좋아요", description = "리뷰에 좋아요를 누르거나 취소한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰 좋아요 상태를 변경한다",
+      description =
+          """
+          리뷰에 좋아요를 누르거나 취소합니다.
+
+          같은 요청을 반복해도 결과가 같도록 원하는 상태를 직접 지정합니다. 본인이 쓴 리뷰에도 누를 수 있습니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "변경된 좋아요 상태",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = LikesUpdateResponse.class))))
+  public @interface UpdateLikes {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/picks/controller/PicksCommandController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/picks/controller/PicksCommandController.java
@@ -3,6 +3,7 @@ package app.bottlenote.picks.controller;
 import static app.bottlenote.global.security.SecurityContextUtil.getUserIdByContext;
 
 import app.bottlenote.global.data.response.GlobalResponse;
+import app.bottlenote.picks.controller.docs.PicksApiDocs;
 import app.bottlenote.picks.dto.request.PicksUpdateRequest;
 import app.bottlenote.picks.service.PicksCommandService;
 import app.bottlenote.user.exception.UserException;
@@ -18,10 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/picks")
 @RequiredArgsConstructor
+@PicksApiDocs.ApiTag
 public class PicksCommandController {
 
   private final PicksCommandService picksCommandService;
 
+  @PicksApiDocs.UpdatePicks
   @PutMapping
   public ResponseEntity<GlobalResponse> updatePicks(
       @RequestBody @Valid PicksUpdateRequest request) {

--- a/bottlenote-product-api/src/main/java/app/bottlenote/picks/controller/docs/PicksApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/picks/controller/docs/PicksApiDocs.java
@@ -10,7 +10,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 찜하기 엔드포인트의 문서 설명. */
 public final class PicksApiDocs {
@@ -36,9 +35,6 @@ public final class PicksApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "변경된 찜 상태",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = PicksUpdateResponse.class))))
+              content = @Content(schema = @Schema(implementation = PicksUpdateResponse.class))))
   public @interface UpdatePicks {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/picks/controller/docs/PicksApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/picks/controller/docs/PicksApiDocs.java
@@ -1,0 +1,44 @@
+package app.bottlenote.picks.controller.docs;
+
+import app.bottlenote.picks.dto.response.PicksUpdateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 찜하기 엔드포인트의 문서 설명. */
+public final class PicksApiDocs {
+
+  private PicksApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "찜하기", description = "관심 있는 위스키를 찜하거나 해제한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "위스키 찜 상태를 변경한다",
+      description =
+          """
+          위스키를 찜하거나 찜을 해제합니다.
+
+          같은 요청을 반복해도 결과가 같도록 원하는 상태를 직접 지정합니다. 찜한 위스키는 마이페이지에서 모아 볼 수 있습니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "변경된 찜 상태",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = PicksUpdateResponse.class))))
+  public @interface UpdatePicks {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/rating/controller/RatingController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/rating/controller/RatingController.java
@@ -8,6 +8,7 @@ import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.global.service.meta.MetaService;
+import app.bottlenote.rating.controller.docs.RatingApiDocs;
 import app.bottlenote.rating.domain.RatingPoint;
 import app.bottlenote.rating.dto.request.RatingListFetchRequest;
 import app.bottlenote.rating.dto.request.RatingRegisterRequest;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/rating")
+@RatingApiDocs.ApiTag
 public class RatingController {
 
   private final RatingCommandService commandService;
@@ -47,8 +49,10 @@ public class RatingController {
    * @param request the request
    * @return the response entity
    */
+  @RatingApiDocs.RegisterRating
   @PostMapping("/register")
-  public ResponseEntity<?> registerRatingPoint(@RequestBody @Valid RatingRegisterRequest request) {
+  public ResponseEntity<GlobalResponse> registerRatingPoint(
+      @RequestBody @Valid RatingRegisterRequest request) {
     log.info("RatingRegisterRequest: {}", request);
 
     Long userId =
@@ -68,8 +72,10 @@ public class RatingController {
    * @param request 별점 평가 목록 조회 요청 객체
    */
   @SecurityPolicy(auth = OPTIONAL_AUTH)
+  @RatingApiDocs.FetchRatingList
   @GetMapping
-  public ResponseEntity<?> fetchRatingList(@ModelAttribute RatingListFetchRequest request) {
+  public ResponseEntity<GlobalResponse> fetchRatingList(
+      @ModelAttribute RatingListFetchRequest request) {
     Long userId = SecurityContextUtil.getUserIdByContext().orElse(-1L);
     var response = queryService.fetchRatingList(request, userId);
     return ResponseEntity.ok(
@@ -90,8 +96,9 @@ public class RatingController {
    * @param alcoholId 술의 식별자
    */
   @SecurityPolicy(auth = REQUIRED_AUTH)
+  @RatingApiDocs.FetchUserRating
   @GetMapping("/{alcoholId}")
-  public ResponseEntity<?> fetchRatingPoint(@PathVariable Long alcoholId) {
+  public ResponseEntity<GlobalResponse> fetchRatingPoint(@PathVariable Long alcoholId) {
 
     Long userId =
         SecurityContextUtil.getUserIdByContext()

--- a/bottlenote-product-api/src/main/java/app/bottlenote/rating/controller/docs/RatingApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/rating/controller/docs/RatingApiDocs.java
@@ -1,0 +1,85 @@
+package app.bottlenote.rating.controller.docs;
+
+import app.bottlenote.rating.dto.response.RatingListFetchResponse;
+import app.bottlenote.rating.dto.response.RatingRegisterResponse;
+import app.bottlenote.rating.dto.response.UserRatingResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 별점 엔드포인트의 문서 설명. */
+public final class RatingApiDocs {
+
+  private RatingApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "별점", description = "위스키에 별점을 주고 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "위스키에 별점을 준다",
+      description =
+          """
+          위스키에 0.5 단위의 별점을 남깁니다.
+
+          이미 별점을 준 위스키에 다시 요청하면 기존 별점을 덮어씁니다. 별점은 리뷰와 별개로 관리되므로 리뷰 없이도 줄 수 있습니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "등록된 별점 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = RatingRegisterResponse.class))))
+  public @interface RegisterRating {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "별점을 매길 위스키 목록을 조회한다",
+      description =
+          """
+          아직 별점을 주지 않은 위스키를 커서 방식으로 가져옵니다.
+
+          별점 매기기 화면에서 다음에 평가할 대상을 보여주기 위한 목록입니다.
+          다음 페이지 정보는 meta.pageable, 조회 조건은 meta.searchParameters에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "별점을 매기지 않은 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = RatingListFetchResponse.class)))))
+  public @interface FetchRatingList {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "특정 위스키에 내가 준 별점을 조회한다",
+      description = "로그인한 사용자가 그 위스키에 준 별점을 반환합니다. 아직 별점을 주지 않았으면 값이 비어 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "내가 준 별점",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = UserRatingResponse.class))))
+  public @interface FetchUserRating {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/rating/controller/docs/RatingApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/rating/controller/docs/RatingApiDocs.java
@@ -13,7 +13,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 별점 엔드포인트의 문서 설명. */
 public final class RatingApiDocs {
@@ -39,10 +38,7 @@ public final class RatingApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "등록된 별점 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = RatingRegisterResponse.class))))
+              content = @Content(schema = @Schema(implementation = RatingRegisterResponse.class))))
   public @interface RegisterRating {}
 
   @Target(ElementType.METHOD)
@@ -62,7 +58,6 @@ public final class RatingApiDocs {
               description = "별점을 매기지 않은 위스키 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = RatingListFetchResponse.class)))))
@@ -77,9 +72,6 @@ public final class RatingApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "내가 준 별점",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = UserRatingResponse.class))))
+              content = @Content(schema = @Schema(implementation = UserRatingResponse.class))))
   public @interface FetchUserRating {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/ReviewController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/ReviewController.java
@@ -8,6 +8,7 @@ import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.global.service.meta.MetaService;
+import app.bottlenote.review.controller.docs.ReviewApiDocs;
 import app.bottlenote.review.dto.request.ReviewCreateRequest;
 import app.bottlenote.review.dto.request.ReviewModifyRequest;
 import app.bottlenote.review.dto.request.ReviewPageableRequest;
@@ -33,12 +34,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reviews")
+@ReviewApiDocs.ApiTag
 public class ReviewController {
 
   private final ReviewService reviewService;
 
+  @ReviewApiDocs.CreateReview
   @PostMapping
-  public ResponseEntity<?> createReview(
+  public ResponseEntity<GlobalResponse> createReview(
       @RequestBody @Valid ReviewCreateRequest reviewCreateRequest) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
@@ -47,8 +50,9 @@ public class ReviewController {
   }
 
   @SecurityPolicy(auth = OPTIONAL_AUTH)
+  @ReviewApiDocs.GetReviews
   @GetMapping("/{alcoholId}")
-  public ResponseEntity<?> getReviews(
+  public ResponseEntity<GlobalResponse> getReviews(
       @PathVariable Long alcoholId, @ModelAttribute ReviewPageableRequest reviewPageableRequest) {
     Long currentUserId = SecurityContextUtil.getUserIdByContext().orElse(-1L);
     PageResponse<ReviewListResponse> pageResponse =
@@ -60,16 +64,18 @@ public class ReviewController {
   }
 
   @SecurityPolicy(auth = OPTIONAL_AUTH)
+  @ReviewApiDocs.GetReviewDetail
   @GetMapping("/detail/{reviewId}")
-  public ResponseEntity<?> getDetailReview(@PathVariable Long reviewId) {
+  public ResponseEntity<GlobalResponse> getDetailReview(@PathVariable Long reviewId) {
 
     Long currentUserId = SecurityContextUtil.getUserIdByContext().orElse(-1L);
 
     return GlobalResponse.ok(reviewService.getDetailReview(reviewId, currentUserId));
   }
 
+  @ReviewApiDocs.GetMyReviews
   @GetMapping("/me/{alcoholId}")
-  public ResponseEntity<?> getMyReviews(
+  public ResponseEntity<GlobalResponse> getMyReviews(
       @ModelAttribute ReviewPageableRequest reviewPageableRequest, @PathVariable Long alcoholId) {
 
     Long currentUserId =
@@ -84,8 +90,9 @@ public class ReviewController {
         MetaService.createMetaInfo().add("pageable", myReviews.cursorPageable()));
   }
 
+  @ReviewApiDocs.ModifyReview
   @PatchMapping("/{reviewId}")
-  public ResponseEntity<?> modifyReview(
+  public ResponseEntity<GlobalResponse> modifyReview(
       @RequestBody @Valid ReviewModifyRequest reviewModifyRequest, @PathVariable Long reviewId) {
 
     Long currentUserId =
@@ -96,8 +103,9 @@ public class ReviewController {
         reviewService.modifyReview(reviewModifyRequest, reviewId, currentUserId));
   }
 
+  @ReviewApiDocs.ChangeReviewStatus
   @PatchMapping("/{reviewId}/display")
-  public ResponseEntity<?> changeStatus(
+  public ResponseEntity<GlobalResponse> changeStatus(
       @PathVariable Long reviewId, @Valid @RequestBody ReviewStatusChangeRequest status) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
@@ -106,8 +114,9 @@ public class ReviewController {
     return GlobalResponse.ok(reviewService.changeStatus(reviewId, status, currentUserId));
   }
 
+  @ReviewApiDocs.DeleteReview
   @DeleteMapping("/{reviewId}")
-  public ResponseEntity<?> deleteReview(@PathVariable Long reviewId) {
+  public ResponseEntity<GlobalResponse> deleteReview(@PathVariable Long reviewId) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new UserException(REQUIRED_USER_ID));

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/ReviewExploreController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/ReviewExploreController.java
@@ -6,6 +6,7 @@ import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.global.service.cursor.CursorResponse;
+import app.bottlenote.review.controller.docs.ReviewExploreApiDocs;
 import app.bottlenote.review.dto.response.ReviewExploreItem;
 import app.bottlenote.review.service.ReviewExploreService;
 import java.util.Collections;
@@ -25,12 +26,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/reviews/explore")
 @SecurityPolicy(auth = OPTIONAL_AUTH)
+@ReviewExploreApiDocs.ApiTag
 public class ReviewExploreController {
 
   private final ReviewExploreService reviewExploreService;
 
+  @ReviewExploreApiDocs.GetStandardExplore
   @GetMapping("/standard")
-  public ResponseEntity<?> getStandardExplore(
+  public ResponseEntity<GlobalResponse> getStandardExplore(
       @RequestParam(required = false) List<String> keywords,
       @RequestParam(required = false, defaultValue = "20") Integer size,
       @RequestParam(required = false, defaultValue = "0") Long cursor) {

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/ReviewReplyController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/ReviewReplyController.java
@@ -5,6 +5,7 @@ import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.OPTIONAL_
 import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
+import app.bottlenote.review.controller.docs.ReviewReplyApiDocs;
 import app.bottlenote.review.dto.request.ReviewReplyRegisterRequest;
 import app.bottlenote.review.service.ReviewReplyService;
 import app.bottlenote.user.exception.UserException;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/review/reply")
+@ReviewReplyApiDocs.ApiTag
 public class ReviewReplyController {
 
   private final ReviewReplyService reviewReplyService;
@@ -37,8 +39,9 @@ public class ReviewReplyController {
    * @param request 요청(댓글 내용 String content, Long parentReplyId)
    * @return 결과 메시지
    */
+  @ReviewReplyApiDocs.RegisterReply
   @PostMapping("/register/{reviewId}")
-  public ResponseEntity<?> registerReviewReply(
+  public ResponseEntity<GlobalResponse> registerReviewReply(
       @PathVariable Long reviewId, @RequestBody @Valid ReviewReplyRegisterRequest request) {
     Long userId =
         SecurityContextUtil.getUserIdByContext()
@@ -47,8 +50,9 @@ public class ReviewReplyController {
     return GlobalResponse.ok(reviewReplyService.registerReviewReply(reviewId, userId, request));
   }
 
+  @ReviewReplyApiDocs.DeleteReply
   @DeleteMapping("/{reviewId}/{replyId}")
-  public ResponseEntity<?> deleteReviewReply(
+  public ResponseEntity<GlobalResponse> deleteReviewReply(
       @PathVariable Long reviewId, @PathVariable Long replyId) {
     Long userId =
         SecurityContextUtil.getUserIdByContext()
@@ -58,8 +62,9 @@ public class ReviewReplyController {
   }
 
   @SecurityPolicy(auth = OPTIONAL_AUTH)
+  @ReviewReplyApiDocs.GetRootReplies
   @GetMapping("/{reviewId}")
-  public ResponseEntity<?> getReviewReplyList(
+  public ResponseEntity<GlobalResponse> getReviewReplyList(
       @PathVariable Long reviewId,
       @RequestParam(required = false, defaultValue = "0") Long cursor,
       @RequestParam(required = false, defaultValue = "50") Long pageSize) {
@@ -67,8 +72,9 @@ public class ReviewReplyController {
   }
 
   @SecurityPolicy(auth = OPTIONAL_AUTH)
+  @ReviewReplyApiDocs.GetSubReplies
   @GetMapping("/{reviewId}/sub/{rootReplyId}")
-  public ResponseEntity<?> getSubReviewReplies(
+  public ResponseEntity<GlobalResponse> getSubReviewReplies(
       @PathVariable Long reviewId,
       @PathVariable Long rootReplyId,
       @RequestParam(required = false, defaultValue = "0") Long cursor,

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewApiDocs.java
@@ -40,6 +40,35 @@ public final class ReviewApiDocs {
 
           별점은 리뷰와 별개로 관리되므로 이 요청만으로는 별점이 등록되지 않습니다.
           비공개로 작성하면 목록과 상세 조회에서 작성자 본인에게만 보입니다.
+
+          **요청 값 오류 코드**
+
+          | 코드 | 상태 코드 | 발생 조건 | 설명 |
+          | --- | --- | --- | --- |
+          | `REVIEW_ID_REQUIRED` | 400 | alcoholId를 보내지 않았을 때 | reviewId(식별자)는 필수입니다. |
+          | `REVIEW_ID_MINIMUM` | 400 | alcoholId가 1 미만일 때 | 리뷰 식별자는 최소 1 이상이어야 합니다. |
+          | `REVIEW_CONTENT_REQUIRED` | 400 | content가 비어 있을 때 | 리뷰 내용은 필수입니다. |
+          | `REVIEW_CONTENT_MAXIMUM` | 400 | content가 700자를 넘을 때 | 리뷰 내용의 최대 글자수를 초과했습니다. |
+          | `PRICE_MINIMUM` | 400 | price가 0 미만일 때 | 가격은 0원 이상이어야 합니다. |
+          | `PRICE_MAXIMUM` | 400 | price가 1조를 넘을 때 | 입력할 수 있는 가격의 범위가 아닙니다. |
+          | `INVALID_ZIP_CODE_PATTERN` | 400 | locationInfo.zipCode가 숫자 5자리가 아닐 때 | 우편번호는 숫자 5자리 형식입니다. |
+          | `REVIEW_IMAGE_ORDER_REQUIRED` | 400 | imageUrlList 항목에 order가 없을 때 | 리뷰 이미지 Order 값은 필수입니다 |
+          | `REVIEW_IMAGE_URL_REQUIRED` | 400 | imageUrlList 항목에 viewUrl이 없을 때 | 리뷰 이미지 URL은 필수입니다 |
+
+          **처리 중 오류 코드**
+
+          | 코드 | 상태 코드 | 발생 조건 | 설명 |
+          | --- | --- | --- | --- |
+          | `REQUIRED_USER_ID` | 400 | 액세스 토큰에서 사용자 식별자를 얻지 못했을 때 | 유저 아이디가 필요합니다. |
+          | `ALCOHOL_NOT_FOUND` | 404 | alcoholId에 해당하는 위스키가 없을 때 | 위스키를 찾을 수 없습니다. |
+          | `USER_NOT_FOUND` | 404 | 토큰이 가리키는 사용자가 없을 때 | 유저를 찾을 수 없습니다. |
+          | `INVALID_RESOURCE_URL` | 400 | 이미지 주소에서 리소스 키를 뽑지 못했을 때 | 유효하지 않은 리소스 URL입니다. |
+          | `RESOURCE_NOT_FOUND` | 400 | 업로드 기록이 없는 이미지일 때 | 등록되지 않은 리소스입니다. |
+          | `RESOURCE_OWNER_MISMATCH` | 400 | 다른 사용자가 올린 이미지일 때 | 리소스 소유자가 일치하지 않습니다. |
+          | `RESOURCE_ALREADY_USED` | 400 | 이미 다른 곳에 쓰인 이미지일 때 | 사용할 수 없는 리소스 상태입니다. |
+          | `INVALID_RATING_POINT` | 400 | rating이 0.0~5.0의 0.5 단위 값이 아닐 때 | 평점은 0.0/1.0/1.5/2.0/2.5/3.0/3.5/4.0/4.5/5.0 중 하나의 값을 가질 수 있습니다. |
+          | `INVALID_IMAGE_URL_MAX_SIZE` | 400 | 이미지가 5장을 넘을 때 | 이미지는 최대 5장까지만 업로드 할 수 있습니다 |
+          | `INVALID_TASTING_TAG_LIST_SIZE` | 400 | 테이스팅 태그가 15개를 넘을 때 | 테이스팅 태그는 15개까지만 작성할 수 있습니다. |
           """,
       responses =
           @ApiResponse(
@@ -114,7 +143,18 @@ public final class ReviewApiDocs {
   @Retention(RetentionPolicy.RUNTIME)
   @Operation(
       summary = "리뷰의 공개 여부를 변경한다",
-      description = "공개로 바꾸면 다른 사용자에게 보이고, 비공개로 바꾸면 작성자 본인에게만 보입니다. 본인이 작성한 리뷰만 변경할 수 있습니다.",
+      description =
+          """
+          공개로 바꾸면 다른 사용자에게 보이고, 비공개로 바꾸면 작성자 본인에게만 보입니다. 본인이 작성한 리뷰만 변경할 수 있습니다.
+
+          **오류 코드**
+
+          | 코드 | 상태 코드 | 발생 조건 | 설명 |
+          | --- | --- | --- | --- |
+          | `REVIEW_DISPLAY_STATUS_NOT_EMPTY` | 400 | status를 보내지 않았을 때 | 리뷰 공개/비공개상태는 필수입니다. |
+          | `REQUIRED_USER_ID` | 400 | 액세스 토큰에서 사용자 식별자를 얻지 못했을 때 | 유저 아이디가 필요합니다. |
+          | `REVIEW_NOT_FOUND` | 400 | 리뷰가 없거나 본인이 쓴 리뷰가 아닐 때 | 리뷰를 찾을 수 없습니다 |
+          """,
       responses =
           @ApiResponse(
               responseCode = "200",

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewApiDocs.java
@@ -1,0 +1,154 @@
+package app.bottlenote.review.controller.docs;
+
+import app.bottlenote.review.dto.response.ReviewCreateResponse;
+import app.bottlenote.review.dto.response.ReviewDetailResponse;
+import app.bottlenote.review.dto.response.ReviewListResponse;
+import app.bottlenote.review.dto.response.ReviewResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/**
+ * 리뷰 엔드포인트의 문서 설명을 모아둔다.
+ *
+ * <p>컨트롤러 본문에는 어노테이션 한 줄만 붙어 문서와 코드가 서로를 가리지 않게 한다. 여기 적는 문장은 API 문서 화면에 그대로 노출되므로 식별자가 아닌 사람이 읽는
+ * 문장으로 쓴다.
+ */
+public final class ReviewApiDocs {
+
+  private ReviewApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "리뷰", description = "위스키에 대한 리뷰를 작성하고 조회하고 수정한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰를 작성한다",
+      description =
+          """
+          특정 위스키에 대한 리뷰를 남깁니다.
+
+          별점은 리뷰와 별개로 관리되므로 이 요청만으로는 별점이 등록되지 않습니다.
+          비공개로 작성하면 목록과 상세 조회에서 작성자 본인에게만 보입니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "작성된 리뷰의 식별자",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewCreateResponse.class))))
+  public @interface CreateReview {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "위스키의 리뷰 목록을 조회한다",
+      description =
+          """
+          해당 위스키에 달린 리뷰를 커서 방식으로 나눠 가져옵니다.
+
+          로그인하지 않아도 조회할 수 있습니다. 로그인한 경우에는 각 리뷰에 본인이 좋아요를 눌렀는지가 함께 표시됩니다.
+          다음 페이지 정보는 응답의 meta.pageable에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "리뷰 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = ReviewListResponse.class)))))
+  public @interface GetReviews {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰 하나를 상세히 조회한다",
+      description = "리뷰 본문과 작성자 정보, 좋아요와 댓글 수를 함께 반환합니다. 로그인하지 않아도 조회할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "리뷰 상세 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewDetailResponse.class))))
+  public @interface GetReviewDetail {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "내가 쓴 리뷰 목록을 조회한다",
+      description = "해당 위스키에 내가 남긴 리뷰만 커서 방식으로 가져옵니다. 비공개로 작성한 리뷰도 포함됩니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "내가 작성한 리뷰 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = ReviewListResponse.class)))))
+  public @interface GetMyReviews {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰를 수정한다",
+      description = "본인이 작성한 리뷰만 수정할 수 있습니다. 본문, 가격 정보, 함께한 자리 정보를 바꿀 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "수정 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewResultResponse.class))))
+  public @interface ModifyReview {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰의 공개 여부를 변경한다",
+      description = "공개로 바꾸면 다른 사용자에게 보이고, 비공개로 바꾸면 작성자 본인에게만 보입니다. 본인이 작성한 리뷰만 변경할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "변경 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewResultResponse.class))))
+  public @interface ChangeReviewStatus {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰를 삭제한다",
+      description = "본인이 작성한 리뷰만 삭제할 수 있습니다. 삭제한 리뷰는 목록과 상세 조회에서 더 이상 보이지 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "삭제 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewResultResponse.class))))
+  public @interface DeleteReview {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewApiDocs.java
@@ -14,7 +14,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /**
  * 리뷰 엔드포인트의 문서 설명을 모아둔다.
@@ -46,10 +45,7 @@ public final class ReviewApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "작성된 리뷰의 식별자",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewCreateResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewCreateResponse.class))))
   public @interface CreateReview {}
 
   @Target(ElementType.METHOD)
@@ -69,7 +65,6 @@ public final class ReviewApiDocs {
               description = "리뷰 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = ReviewListResponse.class)))))
@@ -84,10 +79,7 @@ public final class ReviewApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "리뷰 상세 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewDetailResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewDetailResponse.class))))
   public @interface GetReviewDetail {}
 
   @Target(ElementType.METHOD)
@@ -101,7 +93,6 @@ public final class ReviewApiDocs {
               description = "내가 작성한 리뷰 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = ReviewListResponse.class)))))
@@ -116,10 +107,7 @@ public final class ReviewApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "수정 처리 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewResultResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewResultResponse.class))))
   public @interface ModifyReview {}
 
   @Target(ElementType.METHOD)
@@ -131,10 +119,7 @@ public final class ReviewApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "변경 처리 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewResultResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewResultResponse.class))))
   public @interface ChangeReviewStatus {}
 
   @Target(ElementType.METHOD)
@@ -146,9 +131,6 @@ public final class ReviewApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "삭제 처리 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewResultResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewResultResponse.class))))
   public @interface DeleteReview {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
@@ -11,7 +11,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 리뷰 탐색 엔드포인트의 문서 설명. */
 public final class ReviewExploreApiDocs {
@@ -39,10 +38,7 @@ public final class ReviewExploreApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "전체 건수와 이번 페이지의 리뷰 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ExploreResult.class))))
+              content = @Content(schema = @Schema(implementation = ExploreResult.class))))
   public @interface GetStandardExplore {}
 
   /**

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
@@ -11,6 +11,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.List;
 
 /** 리뷰 탐색 엔드포인트의 문서 설명. */
 public final class ReviewExploreApiDocs {
@@ -38,7 +39,7 @@ public final class ReviewExploreApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "전체 건수와 이번 페이지의 리뷰 목록",
-              content = @Content(schema = @Schema(implementation = ExploreResult.class))))
+              content = @Content(schema = @Schema(implementation = ReviewExploreResult.class))))
   public @interface GetStandardExplore {}
 
   /**
@@ -51,8 +52,8 @@ public final class ReviewExploreApiDocs {
       name = "ReviewExploreResult",
       title = "리뷰 탐색 결과",
       description = "조건에 맞는 전체 건수와 이번 페이지의 리뷰 목록")
-  private record ExploreResult(
+  private record ReviewExploreResult(
       @Schema(description = "조건에 맞는 리뷰의 전체 건수", example = "500") long totalCount,
       @ArraySchema(schema = @Schema(implementation = ReviewExploreItem.class))
-          java.util.List<ReviewExploreItem> items) {}
+          List<ReviewExploreItem> items) {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
@@ -1,0 +1,59 @@
+package app.bottlenote.review.controller.docs;
+
+import app.bottlenote.review.dto.response.ReviewExploreItem;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 리뷰 탐색 엔드포인트의 문서 설명. */
+public final class ReviewExploreApiDocs {
+
+  private ReviewExploreApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "리뷰 탐색", description = "키워드로 리뷰를 찾아본다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "키워드로 리뷰를 탐색한다",
+      description =
+          """
+          입력한 키워드가 담긴 리뷰를 커서 방식으로 찾아옵니다.
+
+          키워드를 여러 개 보내면 그중 하나라도 걸리는 리뷰를 가져오고, 키워드를 생략하면 전체 리뷰를 대상으로 합니다.
+          응답의 data.totalCount는 조건에 맞는 전체 건수이고, data.items가 이번 페이지의 리뷰입니다.
+          다음 페이지 정보는 meta.pageable, 검색에 사용한 키워드는 meta.searchParameters에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "전체 건수와 이번 페이지의 리뷰 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ExploreResult.class))))
+  public @interface GetStandardExplore {}
+
+  /**
+   * 탐색 응답의 data 형태를 문서에 드러내기 위한 선언.
+   *
+   * <p>실제 응답은 {@code CollectionResponse<ReviewExploreItem>}이지만 제네릭 타입은 어노테이션으로 표현할 수 없어, 같은 모양을 갖는
+   * 타입을 문서용으로 따로 둔다.
+   */
+  @Schema(name = "리뷰 탐색 결과", description = "조건에 맞는 전체 건수와 이번 페이지의 리뷰 목록")
+  private record ExploreResult(
+      @Schema(description = "조건에 맞는 리뷰의 전체 건수", example = "500") long totalCount,
+      @ArraySchema(schema = @Schema(implementation = ReviewExploreItem.class))
+          java.util.List<ReviewExploreItem> items) {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewExploreApiDocs.java
@@ -51,7 +51,10 @@ public final class ReviewExploreApiDocs {
    * <p>실제 응답은 {@code CollectionResponse<ReviewExploreItem>}이지만 제네릭 타입은 어노테이션으로 표현할 수 없어, 같은 모양을 갖는
    * 타입을 문서용으로 따로 둔다.
    */
-  @Schema(name = "리뷰 탐색 결과", description = "조건에 맞는 전체 건수와 이번 페이지의 리뷰 목록")
+  @Schema(
+      name = "ReviewExploreResult",
+      title = "리뷰 탐색 결과",
+      description = "조건에 맞는 전체 건수와 이번 페이지의 리뷰 목록")
   private record ExploreResult(
       @Schema(description = "조건에 맞는 리뷰의 전체 건수", example = "500") long totalCount,
       @ArraySchema(schema = @Schema(implementation = ReviewExploreItem.class))

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewReplyApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewReplyApiDocs.java
@@ -1,0 +1,93 @@
+package app.bottlenote.review.controller.docs;
+
+import app.bottlenote.review.dto.response.ReviewReplyResponse;
+import app.bottlenote.review.dto.response.RootReviewReplyResponse;
+import app.bottlenote.review.dto.response.SubReviewReplyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 리뷰 댓글 엔드포인트의 문서 설명. */
+public final class ReviewReplyApiDocs {
+
+  private ReviewReplyApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "리뷰 댓글", description = "리뷰에 달리는 댓글과 대댓글을 관리한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰에 댓글을 등록한다",
+      description =
+          """
+          리뷰에 댓글을 남깁니다.
+
+          다른 댓글의 식별자를 함께 보내면 그 댓글에 대한 대댓글로 등록됩니다.
+          대댓글의 대댓글은 지원하지 않으므로 최상위 댓글의 식별자만 지정할 수 있습니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "등록된 댓글 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewReplyResponse.class))))
+  public @interface RegisterReply {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "댓글을 삭제한다",
+      description = "본인이 작성한 댓글만 삭제할 수 있습니다. 대댓글이 달린 댓글을 삭제하면 삭제된 댓글로 표시되고 대댓글은 남습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "삭제 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewReplyResponse.class))))
+  public @interface DeleteReply {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰의 댓글 목록을 조회한다",
+      description =
+          "대댓글을 제외한 최상위 댓글만 커서 방식으로 가져옵니다. 각 댓글에 달린 대댓글 수가 함께 표시됩니다. 로그인하지 않아도 조회할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "최상위 댓글 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = RootReviewReplyResponse.class))))
+  public @interface GetRootReplies {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "댓글에 달린 대댓글 목록을 조회한다",
+      description = "지정한 최상위 댓글에 달린 대댓글만 커서 방식으로 가져옵니다. 로그인하지 않아도 조회할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "대댓글 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = SubReviewReplyResponse.class))))
+  public @interface GetSubReplies {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewReplyApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/review/controller/docs/ReviewReplyApiDocs.java
@@ -12,7 +12,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 리뷰 댓글 엔드포인트의 문서 설명. */
 public final class ReviewReplyApiDocs {
@@ -39,10 +38,7 @@ public final class ReviewReplyApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "등록된 댓글 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewReplyResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewReplyResponse.class))))
   public @interface RegisterReply {}
 
   @Target(ElementType.METHOD)
@@ -54,10 +50,7 @@ public final class ReviewReplyApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "삭제 처리 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewReplyResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewReplyResponse.class))))
   public @interface DeleteReply {}
 
   @Target(ElementType.METHOD)
@@ -70,10 +63,7 @@ public final class ReviewReplyApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "최상위 댓글 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = RootReviewReplyResponse.class))))
+              content = @Content(schema = @Schema(implementation = RootReviewReplyResponse.class))))
   public @interface GetRootReplies {}
 
   @Target(ElementType.METHOD)
@@ -85,9 +75,6 @@ public final class ReviewReplyApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "대댓글 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = SubReviewReplyResponse.class))))
+              content = @Content(schema = @Schema(implementation = SubReviewReplyResponse.class))))
   public @interface GetSubReplies {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/BlockController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/BlockController.java
@@ -5,6 +5,7 @@ import static app.bottlenote.support.block.exception.BlockExceptionCode.REQUIRED
 import app.bottlenote.global.data.response.CollectionResponse;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
+import app.bottlenote.support.block.controller.docs.BlockApiDocs;
 import app.bottlenote.support.block.dto.request.BlockCreateRequest;
 import app.bottlenote.support.block.dto.response.UserBlockItem;
 import app.bottlenote.support.block.exception.BlockException;
@@ -25,12 +26,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/blocks")
+@BlockApiDocs.ApiTag
 public class BlockController {
 
   private final BlockService blockService;
 
+  @BlockApiDocs.CreateBlock
   @PostMapping
-  public ResponseEntity<?> createBlock(@RequestBody @Valid BlockCreateRequest request) {
+  public ResponseEntity<GlobalResponse> createBlock(
+      @RequestBody @Valid BlockCreateRequest request) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));
@@ -42,8 +46,9 @@ public class BlockController {
     return GlobalResponse.ok(blockedUsers);
   }
 
+  @BlockApiDocs.DeleteBlock
   @DeleteMapping("/{blockedUserId}")
-  public ResponseEntity<?> deleteBlock(@PathVariable Long blockedUserId) {
+  public ResponseEntity<GlobalResponse> deleteBlock(@PathVariable Long blockedUserId) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));
@@ -55,8 +60,9 @@ public class BlockController {
     return GlobalResponse.ok(blockedUsers);
   }
 
+  @BlockApiDocs.GetBlockedUsers
   @GetMapping
-  public ResponseEntity<?> getBlockedUsers() {
+  public ResponseEntity<GlobalResponse> getBlockedUsers() {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));
@@ -64,8 +70,9 @@ public class BlockController {
     return GlobalResponse.ok(blockService.getBlockedUserItems(currentUserId));
   }
 
+  @BlockApiDocs.GetBlockedUserIds
   @GetMapping("/ids")
-  public ResponseEntity<?> getBlockedUserIds() {
+  public ResponseEntity<GlobalResponse> getBlockedUserIds() {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));
@@ -73,8 +80,9 @@ public class BlockController {
     return GlobalResponse.ok(blockService.getBlockedUserIds(currentUserId));
   }
 
+  @BlockApiDocs.CheckBlocked
   @GetMapping("/check/{targetUserId}")
-  public ResponseEntity<?> checkBlocked(@PathVariable Long targetUserId) {
+  public ResponseEntity<GlobalResponse> checkBlocked(@PathVariable Long targetUserId) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));
@@ -83,8 +91,9 @@ public class BlockController {
     return GlobalResponse.ok(isBlocked);
   }
 
+  @BlockApiDocs.CheckMutualBlocked
   @GetMapping("/mutual-check/{targetUserId}")
-  public ResponseEntity<?> checkMutualBlocked(@PathVariable Long targetUserId) {
+  public ResponseEntity<GlobalResponse> checkMutualBlocked(@PathVariable Long targetUserId) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));
@@ -93,8 +102,9 @@ public class BlockController {
     return GlobalResponse.ok(isMutualBlocked);
   }
 
+  @BlockApiDocs.GetBlockedByCount
   @GetMapping("/stats/blocked-by-count")
-  public ResponseEntity<?> getBlockedByCount() {
+  public ResponseEntity<GlobalResponse> getBlockedByCount() {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));
@@ -103,8 +113,9 @@ public class BlockController {
     return GlobalResponse.ok(count);
   }
 
+  @BlockApiDocs.GetBlockingCount
   @GetMapping("/stats/blocking-count")
-  public ResponseEntity<?> getBlockingCount() {
+  public ResponseEntity<GlobalResponse> getBlockingCount() {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new BlockException(REQUIRED_USER_ID));

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
@@ -161,7 +161,7 @@ public final class BlockApiDocs {
   public @interface GetBlockingCount {}
 
   /** 실제로는 {@code CollectionResponse<UserBlockItem>}다. */
-  @Schema(name = "차단 목록", description = "차단한 사용자 수와 목록")
+  @Schema(name = "BlockedUserCollection", title = "차단 목록", description = "차단한 사용자 수와 목록")
   private record BlockedUserCollection(
       @Schema(description = "차단한 사용자 수", example = "5") long totalCount,
       @ArraySchema(schema = @Schema(implementation = UserBlockItem.class))

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
@@ -12,7 +12,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
-import org.springframework.http.MediaType;
 
 /** 사용자 차단 엔드포인트의 문서 설명. */
 public final class BlockApiDocs {
@@ -38,10 +37,7 @@ public final class BlockApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "차단 후의 전체 차단 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BlockedUserCollection.class))))
+              content = @Content(schema = @Schema(implementation = BlockedUserCollection.class))))
   public @interface CreateBlock {}
 
   @Target(ElementType.METHOD)
@@ -53,10 +49,7 @@ public final class BlockApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "해제 후의 전체 차단 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BlockedUserCollection.class))))
+              content = @Content(schema = @Schema(implementation = BlockedUserCollection.class))))
   public @interface DeleteBlock {}
 
   @Target(ElementType.METHOD)
@@ -68,10 +61,7 @@ public final class BlockApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "차단한 사용자 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BlockedUserCollection.class))))
+              content = @Content(schema = @Schema(implementation = BlockedUserCollection.class))))
   public @interface GetBlockedUsers {}
 
   @Target(ElementType.METHOD)
@@ -85,7 +75,6 @@ public final class BlockApiDocs {
               description = "차단한 사용자 식별자 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema =
@@ -103,7 +92,6 @@ public final class BlockApiDocs {
               description = "차단 여부",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       schema =
                           @Schema(
                               type = "boolean",
@@ -122,7 +110,6 @@ public final class BlockApiDocs {
               description = "상호 차단 여부",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       schema =
                           @Schema(
                               type = "boolean",
@@ -140,9 +127,7 @@ public final class BlockApiDocs {
               responseCode = "200",
               description = "나를 차단한 사용자 수",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(type = "integer", format = "int64", example = "3"))))
+                  @Content(schema = @Schema(type = "integer", format = "int64", example = "3"))))
   public @interface GetBlockedByCount {}
 
   @Target(ElementType.METHOD)
@@ -155,9 +140,7 @@ public final class BlockApiDocs {
               responseCode = "200",
               description = "내가 차단한 사용자 수",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(type = "integer", format = "int64", example = "5"))))
+                  @Content(schema = @Schema(type = "integer", format = "int64", example = "5"))))
   public @interface GetBlockingCount {}
 
   /** 실제로는 {@code CollectionResponse<UserBlockItem>}다. */

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
@@ -1,0 +1,169 @@
+package app.bottlenote.support.block.controller.docs;
+
+import app.bottlenote.support.block.dto.response.UserBlockItem;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import org.springframework.http.MediaType;
+
+/** 사용자 차단 엔드포인트의 문서 설명. */
+public final class BlockApiDocs {
+
+  private BlockApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "차단", description = "다른 사용자를 차단하고 차단 관계를 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "사용자를 차단한다",
+      description =
+          """
+          지정한 사용자를 차단하고, 차단 후의 전체 차단 목록을 돌려줍니다.
+
+          차단하면 상대의 리뷰와 댓글이 목록에서 보이지 않고 팔로우 관계도 정리됩니다. 차단 사유는 선택 사항입니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "차단 후의 전체 차단 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BlockedUserCollection.class))))
+  public @interface CreateBlock {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "차단을 해제한다",
+      description = "지정한 사용자의 차단을 풀고, 해제 후의 전체 차단 목록을 돌려줍니다. 차단 해제가 팔로우를 복원하지는 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "해제 후의 전체 차단 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BlockedUserCollection.class))))
+  public @interface DeleteBlock {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "내가 차단한 사용자 목록을 조회한다",
+      description = "내가 차단한 사용자들의 프로필과 차단 시점을 반환합니다. 설정 화면의 차단 목록에 쓰입니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "차단한 사용자 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BlockedUserCollection.class))))
+  public @interface GetBlockedUsers {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "내가 차단한 사용자의 식별자만 조회한다",
+      description = "프로필 정보 없이 식별자만 가볍게 가져옵니다. 클라이언트가 목록을 걸러낼 때 쓰는 용도입니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "차단한 사용자 식별자 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema =
+                                  @Schema(type = "integer", format = "int64", example = "42")))))
+  public @interface GetBlockedUserIds {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "특정 사용자를 내가 차단했는지 확인한다",
+      description = "내가 그 사용자를 차단한 상태인지 확인합니다. 상대가 나를 차단했는지는 알려주지 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "차단 여부",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema =
+                          @Schema(
+                              type = "boolean",
+                              example = "false",
+                              description = "차단했으면 true"))))
+  public @interface CheckBlocked {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "특정 사용자와 서로 차단 관계인지 확인한다",
+      description = "나와 상대 중 어느 쪽이라도 차단했으면 참입니다. 상호 작용이 가능한 상대인지 판단할 때 씁니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "상호 차단 여부",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema =
+                          @Schema(
+                              type = "boolean",
+                              example = "false",
+                              description = "어느 쪽이든 차단했으면 true"))))
+  public @interface CheckMutualBlocked {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "나를 차단한 사용자 수를 조회한다",
+      description = "나를 차단한 사용자의 수만 반환합니다. 누가 차단했는지는 알려주지 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "나를 차단한 사용자 수",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(type = "integer", format = "int64", example = "3"))))
+  public @interface GetBlockedByCount {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "내가 차단한 사용자 수를 조회한다",
+      description = "내가 차단한 사용자의 수를 반환합니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "내가 차단한 사용자 수",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(type = "integer", format = "int64", example = "5"))))
+  public @interface GetBlockingCount {}
+
+  /** 실제로는 {@code CollectionResponse<UserBlockItem>}다. */
+  @Schema(name = "차단 목록", description = "차단한 사용자 수와 목록")
+  private record BlockedUserCollection(
+      @Schema(description = "차단한 사용자 수", example = "5") long totalCount,
+      @ArraySchema(schema = @Schema(implementation = UserBlockItem.class))
+          List<UserBlockItem> items) {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/block/controller/docs/BlockApiDocs.java
@@ -56,7 +56,16 @@ public final class BlockApiDocs {
   @Retention(RetentionPolicy.RUNTIME)
   @Operation(
       summary = "내가 차단한 사용자 목록을 조회한다",
-      description = "내가 차단한 사용자들의 프로필과 차단 시점을 반환합니다. 설정 화면의 차단 목록에 쓰입니다.",
+      description =
+          """
+          내가 차단한 사용자들의 프로필과 차단 시점을 반환합니다. 설정 화면의 차단 목록에 쓰입니다.
+
+          **오류 코드**
+
+          | 코드 | 상태 코드 | 발생 조건 | 설명 |
+          | --- | --- | --- | --- |
+          | `REQUIRED_USER_ID` | 400 | 액세스 토큰에서 사용자 식별자를 얻지 못했을 때 | 유저 아이디가 필요합니다. |
+          """,
       responses =
           @ApiResponse(
               responseCode = "200",

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/BusinessSupportController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/BusinessSupportController.java
@@ -7,6 +7,7 @@ import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.CollectionResponse;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
+import app.bottlenote.support.business.controller.docs.BusinessSupportApiDocs;
 import app.bottlenote.support.business.dto.request.BusinessSupportPageableRequest;
 import app.bottlenote.support.business.dto.request.BusinessSupportUpsertRequest;
 import app.bottlenote.support.business.dto.response.BusinessInfoResponse;
@@ -30,20 +31,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/business-support")
 @SecurityPolicy(auth = REQUIRED_AUTH)
 @RequiredArgsConstructor
+@BusinessSupportApiDocs.ApiTag
 public class BusinessSupportController {
 
   private final BusinessSupportService service;
 
+  @BusinessSupportApiDocs.RegisterBusinessSupport
   @PostMapping
-  public ResponseEntity<?> register(@Valid @RequestBody BusinessSupportUpsertRequest req) {
+  public ResponseEntity<GlobalResponse> register(
+      @Valid @RequestBody BusinessSupportUpsertRequest req) {
     Long userId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new UserException(REQUIRED_USER_ID));
     return GlobalResponse.ok(service.register(req, userId));
   }
 
+  @BusinessSupportApiDocs.GetBusinessSupportList
   @GetMapping
-  public ResponseEntity<?> getAllList(@ModelAttribute BusinessSupportPageableRequest req) {
+  public ResponseEntity<GlobalResponse> getAllList(
+      @ModelAttribute BusinessSupportPageableRequest req) {
     Long userId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new UserException(REQUIRED_USER_ID));
@@ -51,8 +57,9 @@ public class BusinessSupportController {
     return GlobalResponse.ok(collection);
   }
 
+  @BusinessSupportApiDocs.GetBusinessSupportDetail
   @GetMapping("/{id}")
-  public ResponseEntity<?> getDetail(@PathVariable Long id) {
+  public ResponseEntity<GlobalResponse> getDetail(@PathVariable Long id) {
     Long userId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new UserException(REQUIRED_USER_ID));
@@ -60,8 +67,9 @@ public class BusinessSupportController {
     return GlobalResponse.ok(item);
   }
 
+  @BusinessSupportApiDocs.ModifyBusinessSupport
   @PatchMapping("/{id}")
-  public ResponseEntity<?> modify(
+  public ResponseEntity<GlobalResponse> modify(
       @PathVariable Long id, @Valid @RequestBody BusinessSupportUpsertRequest req) {
     Long userId =
         SecurityContextUtil.getUserIdByContext()
@@ -69,8 +77,9 @@ public class BusinessSupportController {
     return GlobalResponse.ok(service.modify(id, req, userId));
   }
 
+  @BusinessSupportApiDocs.DeleteBusinessSupport
   @DeleteMapping("/{id}")
-  public ResponseEntity<?> delete(@PathVariable Long id) {
+  public ResponseEntity<GlobalResponse> delete(@PathVariable Long id) {
     Long userId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new UserException(REQUIRED_USER_ID));

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/docs/BusinessSupportApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/docs/BusinessSupportApiDocs.java
@@ -14,7 +14,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
-import org.springframework.http.MediaType;
 
 /** 비즈니스 제휴 문의 엔드포인트의 문서 설명. */
 public final class BusinessSupportApiDocs {
@@ -41,9 +40,7 @@ public final class BusinessSupportApiDocs {
               responseCode = "200",
               description = "등록 처리 결과",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BusinessSupportResultResponse.class))))
+                  @Content(schema = @Schema(implementation = BusinessSupportResultResponse.class))))
   public @interface RegisterBusinessSupport {}
 
   @Target(ElementType.METHOD)
@@ -56,9 +53,7 @@ public final class BusinessSupportApiDocs {
               responseCode = "200",
               description = "전체 건수와 문의 목록",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BusinessSupportCollection.class))))
+                  @Content(schema = @Schema(implementation = BusinessSupportCollection.class))))
   public @interface GetBusinessSupportList {}
 
   @Target(ElementType.METHOD)
@@ -71,9 +66,7 @@ public final class BusinessSupportApiDocs {
               responseCode = "200",
               description = "문의 상세 정보",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BusinessSupportDetailItem.class))))
+                  @Content(schema = @Schema(implementation = BusinessSupportDetailItem.class))))
   public @interface GetBusinessSupportDetail {}
 
   @Target(ElementType.METHOD)
@@ -86,9 +79,7 @@ public final class BusinessSupportApiDocs {
               responseCode = "200",
               description = "수정 처리 결과",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BusinessSupportResultResponse.class))))
+                  @Content(schema = @Schema(implementation = BusinessSupportResultResponse.class))))
   public @interface ModifyBusinessSupport {}
 
   @Target(ElementType.METHOD)
@@ -101,9 +92,7 @@ public final class BusinessSupportApiDocs {
               responseCode = "200",
               description = "삭제 처리 결과",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = BusinessSupportResultResponse.class))))
+                  @Content(schema = @Schema(implementation = BusinessSupportResultResponse.class))))
   public @interface DeleteBusinessSupport {}
 
   /** 실제로는 {@code CollectionResponse<BusinessInfoResponse>}다. */

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/docs/BusinessSupportApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/docs/BusinessSupportApiDocs.java
@@ -107,7 +107,7 @@ public final class BusinessSupportApiDocs {
   public @interface DeleteBusinessSupport {}
 
   /** 실제로는 {@code CollectionResponse<BusinessInfoResponse>}다. */
-  @Schema(name = "비즈니스 문의 목록", description = "전체 건수와 문의 목록")
+  @Schema(name = "BusinessSupportCollection", title = "비즈니스 문의 목록", description = "전체 건수와 문의 목록")
   private record BusinessSupportCollection(
       @Schema(description = "문의 전체 건수", example = "3") long totalCount,
       @ArraySchema(schema = @Schema(implementation = BusinessInfoResponse.class))

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/docs/BusinessSupportApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/business/controller/docs/BusinessSupportApiDocs.java
@@ -1,0 +1,115 @@
+package app.bottlenote.support.business.controller.docs;
+
+import app.bottlenote.support.business.dto.response.BusinessInfoResponse;
+import app.bottlenote.support.business.dto.response.BusinessSupportDetailItem;
+import app.bottlenote.support.business.dto.response.BusinessSupportResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import org.springframework.http.MediaType;
+
+/** 비즈니스 제휴 문의 엔드포인트의 문서 설명. */
+public final class BusinessSupportApiDocs {
+
+  private BusinessSupportApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "비즈니스 문의", description = "제휴와 협업 문의를 등록하고 관리한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "비즈니스 문의를 등록한다",
+      description =
+          """
+          제휴나 협업을 제안하는 문의를 남깁니다.
+
+          업체 정보와 문의 내용을 함께 보내며, 등록 후에는 운영자가 확인하고 답변합니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "등록 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BusinessSupportResultResponse.class))))
+  public @interface RegisterBusinessSupport {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "내가 등록한 비즈니스 문의 목록을 조회한다",
+      description = "로그인한 사용자가 남긴 문의를 전체 건수와 함께 가져옵니다. 다른 사용자의 문의는 보이지 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "전체 건수와 문의 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BusinessSupportCollection.class))))
+  public @interface GetBusinessSupportList {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "비즈니스 문의 상세를 조회한다",
+      description = "문의 내용과 운영자 답변을 함께 반환합니다. 본인이 등록한 문의만 조회할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "문의 상세 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BusinessSupportDetailItem.class))))
+  public @interface GetBusinessSupportDetail {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "비즈니스 문의를 수정한다",
+      description = "본인이 등록한 문의만 수정할 수 있습니다. 운영자가 답변을 남긴 뒤에는 수정이 제한될 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "수정 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BusinessSupportResultResponse.class))))
+  public @interface ModifyBusinessSupport {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "비즈니스 문의를 삭제한다",
+      description = "본인이 등록한 문의만 삭제할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "삭제 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = BusinessSupportResultResponse.class))))
+  public @interface DeleteBusinessSupport {}
+
+  /** 실제로는 {@code CollectionResponse<BusinessInfoResponse>}다. */
+  @Schema(name = "비즈니스 문의 목록", description = "전체 건수와 문의 목록")
+  private record BusinessSupportCollection(
+      @Schema(description = "문의 전체 건수", example = "3") long totalCount,
+      @ArraySchema(schema = @Schema(implementation = BusinessInfoResponse.class))
+          List<BusinessInfoResponse> items) {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/help/controller/HelpCommandController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/help/controller/HelpCommandController.java
@@ -6,6 +6,7 @@ import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.global.service.meta.MetaService;
+import app.bottlenote.support.help.controller.docs.HelpApiDocs;
 import app.bottlenote.support.help.dto.request.HelpPageableRequest;
 import app.bottlenote.support.help.dto.request.HelpUpsertRequest;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
@@ -28,12 +29,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/help")
 @RequiredArgsConstructor
+@HelpApiDocs.ApiTag
 public class HelpCommandController {
 
   private final HelpService helpService;
 
+  @HelpApiDocs.RegisterHelp
   @PostMapping
-  public ResponseEntity<?> registerHelp(@Valid @RequestBody HelpUpsertRequest helpUpsertRequest) {
+  public ResponseEntity<GlobalResponse> registerHelp(
+      @Valid @RequestBody HelpUpsertRequest helpUpsertRequest) {
 
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
@@ -42,8 +46,10 @@ public class HelpCommandController {
     return GlobalResponse.ok(helpService.registerHelp(helpUpsertRequest, currentUserId));
   }
 
+  @HelpApiDocs.GetHelpList
   @GetMapping
-  public ResponseEntity<?> getHelpList(@ModelAttribute HelpPageableRequest helpPageableRequest) {
+  public ResponseEntity<GlobalResponse> getHelpList(
+      @ModelAttribute HelpPageableRequest helpPageableRequest) {
 
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
@@ -57,8 +63,9 @@ public class HelpCommandController {
         MetaService.createMetaInfo().add("pageable", pageResponse.cursorPageable()));
   }
 
+  @HelpApiDocs.GetHelpDetail
   @GetMapping("/{helpId}")
-  public ResponseEntity<?> getDetailHelp(@PathVariable Long helpId) {
+  public ResponseEntity<GlobalResponse> getDetailHelp(@PathVariable Long helpId) {
 
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
@@ -67,8 +74,9 @@ public class HelpCommandController {
     return GlobalResponse.ok(helpService.getDetailHelp(helpId, currentUserId));
   }
 
+  @HelpApiDocs.ModifyHelp
   @PatchMapping("/{helpId}")
-  public ResponseEntity<?> modifyHelp(
+  public ResponseEntity<GlobalResponse> modifyHelp(
       @Valid @RequestBody HelpUpsertRequest helpUpsertRequest, @PathVariable Long helpId) {
 
     Long currentUserId =
@@ -78,8 +86,9 @@ public class HelpCommandController {
     return GlobalResponse.ok(helpService.modifyHelp(helpUpsertRequest, currentUserId, helpId));
   }
 
+  @HelpApiDocs.DeleteHelp
   @DeleteMapping("/{helpId}")
-  public ResponseEntity<?> deleteHelp(@PathVariable Long helpId) {
+  public ResponseEntity<GlobalResponse> deleteHelp(@PathVariable Long helpId) {
 
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/help/controller/docs/HelpApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/help/controller/docs/HelpApiDocs.java
@@ -1,0 +1,113 @@
+package app.bottlenote.support.help.controller.docs;
+
+import app.bottlenote.support.help.dto.response.HelpDetailItem;
+import app.bottlenote.support.help.dto.response.HelpListResponse;
+import app.bottlenote.support.help.dto.response.HelpResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 고객 문의 엔드포인트의 문서 설명. */
+public final class HelpApiDocs {
+
+  private HelpApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "문의", description = "서비스 이용 중 생긴 문의를 남기고 답변을 확인한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "문의를 등록한다",
+      description =
+          """
+          서비스 이용 중 생긴 문의를 남깁니다.
+
+          문의 유형과 내용을 함께 보내며, 이미지를 첨부할 수 있습니다. 운영자가 확인 후 답변을 등록합니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "등록 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = HelpResultResponse.class))))
+  public @interface RegisterHelp {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "내가 등록한 문의 목록을 조회한다",
+      description =
+          """
+          로그인한 사용자가 남긴 문의를 커서 방식으로 가져옵니다.
+
+          각 항목에 답변 완료 여부가 표시됩니다. 다음 페이지 정보는 meta.pageable에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "문의 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(schema = @Schema(implementation = HelpListResponse.class)))))
+  public @interface GetHelpList {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "문의 상세를 조회한다",
+      description = "문의 내용과 운영자 답변을 함께 반환합니다. 본인이 등록한 문의만 조회할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "문의 상세 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = HelpDetailItem.class))))
+  public @interface GetHelpDetail {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "문의를 수정한다",
+      description = "본인이 등록한 문의만 수정할 수 있습니다. 답변이 등록된 뒤에는 수정할 수 없습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "수정 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = HelpResultResponse.class))))
+  public @interface ModifyHelp {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "문의를 삭제한다",
+      description = "본인이 등록한 문의만 삭제할 수 있습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "삭제 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = HelpResultResponse.class))))
+  public @interface DeleteHelp {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/help/controller/docs/HelpApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/help/controller/docs/HelpApiDocs.java
@@ -13,7 +13,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 고객 문의 엔드포인트의 문서 설명. */
 public final class HelpApiDocs {
@@ -39,10 +38,7 @@ public final class HelpApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "등록 처리 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = HelpResultResponse.class))))
+              content = @Content(schema = @Schema(implementation = HelpResultResponse.class))))
   public @interface RegisterHelp {}
 
   @Target(ElementType.METHOD)
@@ -61,7 +57,6 @@ public final class HelpApiDocs {
               description = "문의 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(schema = @Schema(implementation = HelpListResponse.class)))))
   public @interface GetHelpList {}
@@ -75,10 +70,7 @@ public final class HelpApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "문의 상세 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = HelpDetailItem.class))))
+              content = @Content(schema = @Schema(implementation = HelpDetailItem.class))))
   public @interface GetHelpDetail {}
 
   @Target(ElementType.METHOD)
@@ -90,10 +82,7 @@ public final class HelpApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "수정 처리 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = HelpResultResponse.class))))
+              content = @Content(schema = @Schema(implementation = HelpResultResponse.class))))
   public @interface ModifyHelp {}
 
   @Target(ElementType.METHOD)
@@ -105,9 +94,6 @@ public final class HelpApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "삭제 처리 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = HelpResultResponse.class))))
+              content = @Content(schema = @Schema(implementation = HelpResultResponse.class))))
   public @interface DeleteHelp {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/report/controller/ReportCommandController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/report/controller/ReportCommandController.java
@@ -6,6 +6,7 @@ import static app.bottlenote.user.exception.UserExceptionCode.REQUIRED_USER_ID;
 
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
+import app.bottlenote.support.report.controller.docs.ReportApiDocs;
 import app.bottlenote.support.report.dto.request.ReviewReportRequest;
 import app.bottlenote.support.report.dto.request.UserReportRequest;
 import app.bottlenote.support.report.dto.response.UserReportResponse;
@@ -26,13 +27,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/reports")
+@ReportApiDocs.ApiTag
 public class ReportCommandController {
 
   private final UserReportService userReportService;
   private final ReviewReportService reviewReportService;
 
+  @ReportApiDocs.ReportUser
   @PostMapping("/user")
-  public ResponseEntity<?> reportUser(@RequestBody @Valid UserReportRequest userReportRequest) {
+  public ResponseEntity<GlobalResponse> reportUser(
+      @RequestBody @Valid UserReportRequest userReportRequest) {
 
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
@@ -46,8 +50,9 @@ public class ReportCommandController {
     return GlobalResponse.ok(userReportService.userReport(currentUserId, userReportRequest));
   }
 
+  @ReportApiDocs.ReportReview
   @PostMapping("/review")
-  public ResponseEntity<?> reportReview(
+  public ResponseEntity<GlobalResponse> reportReview(
       @RequestBody @Valid ReviewReportRequest reviewReportRequest, HttpServletRequest request) {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/report/controller/docs/ReportApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/report/controller/docs/ReportApiDocs.java
@@ -11,7 +11,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 신고 엔드포인트의 문서 설명. */
 public final class ReportApiDocs {
@@ -37,10 +36,7 @@ public final class ReportApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "신고 접수 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = UserReportResponse.class))))
+              content = @Content(schema = @Schema(implementation = UserReportResponse.class))))
   public @interface ReportUser {}
 
   @Target(ElementType.METHOD)
@@ -52,9 +48,6 @@ public final class ReportApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "신고 접수 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ReviewReportResponse.class))))
+              content = @Content(schema = @Schema(implementation = ReviewReportResponse.class))))
   public @interface ReportReview {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/support/report/controller/docs/ReportApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/support/report/controller/docs/ReportApiDocs.java
@@ -1,0 +1,60 @@
+package app.bottlenote.support.report.controller.docs;
+
+import app.bottlenote.support.report.dto.response.ReviewReportResponse;
+import app.bottlenote.support.report.dto.response.UserReportResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 신고 엔드포인트의 문서 설명. */
+public final class ReportApiDocs {
+
+  private ReportApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "신고", description = "부적절한 사용자나 리뷰를 신고한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "사용자를 신고한다",
+      description =
+          """
+          부적절한 활동을 하는 사용자를 신고합니다.
+
+          자기 자신은 신고할 수 없습니다. 같은 사용자를 반복 신고하면 횟수가 누적되며, 일정 기준을 넘으면 운영자가 확인합니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "신고 접수 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = UserReportResponse.class))))
+  public @interface ReportUser {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰를 신고한다",
+      description = "부적절한 내용의 리뷰를 신고합니다. 본인이 쓴 리뷰는 신고할 수 없고, 같은 리뷰를 중복 신고할 수 없습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "신고 접수 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ReviewReportResponse.class))))
+  public @interface ReportReview {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/AuthV2Controller.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/AuthV2Controller.java
@@ -7,6 +7,7 @@ import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.user.config.OauthConfigProperties;
+import app.bottlenote.user.controller.docs.AuthApiDocs;
 import app.bottlenote.user.dto.request.AppleLoginRequest;
 import app.bottlenote.user.dto.request.KakaoLoginRequest;
 import app.bottlenote.user.dto.request.TokenVerifyRequest;
@@ -35,14 +36,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/auth")
+@AuthApiDocs.ApiTag
 public class AuthV2Controller {
   private final AuthService authService;
   private final NonceService nonceService;
   private final OauthConfigProperties configProperties;
   private static final String REFRESH_TOKEN_HEADER_PREFIX = "refresh-token";
 
+  @AuthApiDocs.CheckAdminStatus
   @GetMapping("/admin/permissions")
-  public ResponseEntity<?> checkAdminStatus() {
+  public ResponseEntity<GlobalResponse> checkAdminStatus() {
     Long currentUserId =
         SecurityContextUtil.getUserIdByContext()
             .orElseThrow(() -> new UserException(REQUIRED_USER_ID));
@@ -53,6 +56,7 @@ public class AuthV2Controller {
 
   /** Apple 로그인 전, 클라이언트에게 일회성 Nonce 값을 발급 */
   @SecurityPolicy(auth = PUBLIC)
+  @AuthApiDocs.GetAppleNonce
   @GetMapping("/apple/nonce")
   public ResponseEntity<NonceResponse> getAppleNonce() {
     return ResponseEntity.ok(new NonceResponse(nonceService.generateNonce()));
@@ -60,8 +64,9 @@ public class AuthV2Controller {
 
   /** Apple 로그인 v2 */
   @SecurityPolicy(auth = PUBLIC)
+  @AuthApiDocs.ExecuteAppleLogin
   @PostMapping("/apple")
-  public ResponseEntity<?> executeAppleLogin(
+  public ResponseEntity<OauthResponse> executeAppleLogin(
       @RequestBody @Valid AppleLoginRequest appleLoginRequest, HttpServletResponse response) {
     AuthResponse result =
         authService.loginWithApple(appleLoginRequest.idToken(), appleLoginRequest.nonce());
@@ -72,8 +77,9 @@ public class AuthV2Controller {
 
   /** 카카오 로그인 v2 */
   @SecurityPolicy(auth = PUBLIC)
+  @AuthApiDocs.ExecuteKakaoLogin
   @PostMapping("/kakao")
-  public ResponseEntity<?> executeKakaoLogin(
+  public ResponseEntity<OauthResponse> executeKakaoLogin(
       @RequestBody @Valid KakaoLoginRequest kakaoLoginRequest, HttpServletResponse response) {
     AuthResponse result = authService.loginWithKakao(kakaoLoginRequest.accessToken());
     setRefreshTokenInCookie(response, result.token().refreshToken());
@@ -83,8 +89,10 @@ public class AuthV2Controller {
 
   /** 토큰 재발급 */
   @SecurityPolicy(auth = PUBLIC)
+  @AuthApiDocs.ReissueToken
   @PostMapping("/reissue")
-  public ResponseEntity<?> reissueToken(HttpServletRequest request, HttpServletResponse response) {
+  public ResponseEntity<GlobalResponse> reissueToken(
+      HttpServletRequest request, HttpServletResponse response) {
     String refreshToken = request.getHeader(REFRESH_TOKEN_HEADER_PREFIX);
     TokenItem token = authService.reissue(refreshToken);
     setRefreshTokenInCookie(response, token.refreshToken());
@@ -93,8 +101,10 @@ public class AuthV2Controller {
 
   /** 토큰 유효성 검증 */
   @SecurityPolicy(auth = PUBLIC)
+  @AuthApiDocs.VerifyToken
   @PutMapping("/token/verify")
-  public ResponseEntity<?> verifyToken(@RequestBody @Valid TokenVerifyRequest request) {
+  public ResponseEntity<GlobalResponse> verifyToken(
+      @RequestBody @Valid TokenVerifyRequest request) {
     return GlobalResponse.ok(authService.verifyToken(request.token()));
   }
 

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/FollowController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/FollowController.java
@@ -7,6 +7,7 @@ import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.global.service.meta.MetaService;
+import app.bottlenote.user.controller.docs.FollowApiDocs;
 import app.bottlenote.user.dto.request.FollowPageableRequest;
 import app.bottlenote.user.dto.request.FollowUpdateRequest;
 import app.bottlenote.user.dto.response.FollowerSearchResponse;
@@ -28,12 +29,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/follow")
 @RequiredArgsConstructor
+@FollowApiDocs.ApiTag
 public class FollowController {
 
   private final FollowService followService;
 
+  @FollowApiDocs.GetFollowingList
   @GetMapping("/{targetUserId}/following-list")
-  public ResponseEntity<?> findFollowingList(
+  public ResponseEntity<GlobalResponse> findFollowingList(
       @PathVariable Long targetUserId, @ModelAttribute FollowPageableRequest pageableRequest) {
 
     Long currentUserId =
@@ -47,8 +50,9 @@ public class FollowController {
         MetaService.createMetaInfo().add("pageable", followingPageResponse.cursorPageable()));
   }
 
+  @FollowApiDocs.GetFollowerList
   @GetMapping("/{targetUserId}/follower-list")
-  public ResponseEntity<?> findFollowerList(
+  public ResponseEntity<GlobalResponse> findFollowerList(
       @PathVariable Long targetUserId, @ModelAttribute FollowPageableRequest pageableRequest) {
 
     Long currentUserId =
@@ -62,8 +66,10 @@ public class FollowController {
         MetaService.createMetaInfo().add("pageable", followerPageResponse.cursorPageable()));
   }
 
+  @FollowApiDocs.UpdateFollowStatus
   @PostMapping
-  public ResponseEntity<?> updateFollowStatus(@RequestBody @Valid FollowUpdateRequest request) {
+  public ResponseEntity<GlobalResponse> updateFollowStatus(
+      @RequestBody @Valid FollowUpdateRequest request) {
     Long userId =
         getUserIdByContext().orElseThrow(() -> new UserException(UserExceptionCode.USER_NOT_FOUND));
 

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/UserBasicController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/UserBasicController.java
@@ -4,6 +4,7 @@ import static app.bottlenote.global.security.SecurityContextUtil.getUserIdByCont
 import static app.bottlenote.user.exception.UserExceptionCode.REQUIRED_USER_ID;
 
 import app.bottlenote.global.data.response.GlobalResponse;
+import app.bottlenote.user.controller.docs.UserBasicApiDocs;
 import app.bottlenote.user.dto.request.NicknameChangeRequest;
 import app.bottlenote.user.dto.request.ProfileImageChangeRequest;
 import app.bottlenote.user.dto.response.NicknameChangeResponse;
@@ -27,13 +28,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/users")
+@UserBasicApiDocs.ApiTag
 public class UserBasicController {
 
   private final UserBasicService userBasicService;
   private final DefaultUserFacade userFacade;
 
+  @UserBasicApiDocs.ChangeNickname
   @PatchMapping("/nickname")
-  public ResponseEntity<?> changeNickname(
+  public ResponseEntity<GlobalResponse> changeNickname(
       @RequestBody @Valid NicknameChangeRequest nicknameChangeRequest) {
 
     Long userId = getUserIdByContext().orElseThrow(() -> new UserException(REQUIRED_USER_ID));
@@ -43,8 +46,9 @@ public class UserBasicController {
     return GlobalResponse.ok(response);
   }
 
+  @UserBasicApiDocs.ChangeProfileImage
   @PatchMapping("/profile-image")
-  public ResponseEntity<?> changeProfileImage(
+  public ResponseEntity<GlobalResponse> changeProfileImage(
       @RequestBody @Valid ProfileImageChangeRequest request) {
 
     Long userId = getUserIdByContext().orElseThrow(() -> new UserException(REQUIRED_USER_ID));
@@ -55,8 +59,9 @@ public class UserBasicController {
     return GlobalResponse.ok(response);
   }
 
+  @UserBasicApiDocs.WithdrawUser
   @DeleteMapping
-  public ResponseEntity<?> withdrawUser() {
+  public ResponseEntity<GlobalResponse> withdrawUser() {
 
     Long userId = getUserIdByContext().orElseThrow(() -> new UserException(REQUIRED_USER_ID));
 
@@ -65,8 +70,9 @@ public class UserBasicController {
     return GlobalResponse.ok(response);
   }
 
+  @UserBasicApiDocs.GetCurrentUser
   @GetMapping("/current")
-  public ResponseEntity<?> getCurrentUser() {
+  public ResponseEntity<GlobalResponse> getCurrentUser() {
     Long userId = getUserIdByContext().orElseThrow(() -> new UserException(REQUIRED_USER_ID));
     return GlobalResponse.ok(userFacade.getUserProfileInfo(userId));
   }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/UserMyPageController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/UserMyPageController.java
@@ -10,6 +10,7 @@ import app.bottlenote.global.security.SecurityContextUtil;
 import app.bottlenote.global.service.cursor.PageResponse;
 import app.bottlenote.global.service.meta.MetaService;
 import app.bottlenote.user.constant.MyBottleType;
+import app.bottlenote.user.controller.docs.UserMyPageApiDocs;
 import app.bottlenote.user.dto.request.MyBottleRequest;
 import app.bottlenote.user.dto.response.MyBottleResponse;
 import app.bottlenote.user.exception.UserException;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/my-page")
+@UserMyPageApiDocs.ApiTag
 public class UserMyPageController {
 
   private final UserBasicService userBasicService;
@@ -33,15 +35,17 @@ public class UserMyPageController {
 
   /** 마이 페이지 조회 API 모든 유저가 조회 가능 */
   @SecurityPolicy(auth = OPTIONAL_AUTH)
+  @UserMyPageApiDocs.GetMyPage
   @GetMapping("/{userId}")
-  public ResponseEntity<?> getMyPage(@PathVariable Long userId) {
+  public ResponseEntity<GlobalResponse> getMyPage(@PathVariable Long userId) {
     final Long currentUserId = SecurityContextUtil.getUserIdByContext().orElse(-1L);
     return GlobalResponse.ok(userBasicService.getMyPage(userId, currentUserId));
   }
 
   @SecurityPolicy(auth = REQUIRED_AUTH)
+  @UserMyPageApiDocs.GetReviewMyBottle
   @GetMapping("/{userId}/my-bottle/reviews")
-  public ResponseEntity<?> getReviewMyBottle(
+  public ResponseEntity<GlobalResponse> getReviewMyBottle(
       @PathVariable(name = "userId") Long userId,
       @ModelAttribute(name = "myBottleRequest") MyBottleRequest myBottleRequest) {
     final Long currentUserId =
@@ -59,8 +63,9 @@ public class UserMyPageController {
   }
 
   @SecurityPolicy(auth = REQUIRED_AUTH)
+  @UserMyPageApiDocs.GetRatingMyBottle
   @GetMapping("/{userId}/my-bottle/ratings")
-  public ResponseEntity<?> getRatingMyBottle(
+  public ResponseEntity<GlobalResponse> getRatingMyBottle(
       @PathVariable(name = "userId") Long userId,
       @ModelAttribute(name = "myBottleRequest") MyBottleRequest myBottleRequest) {
     final Long currentUserId =
@@ -78,8 +83,9 @@ public class UserMyPageController {
   }
 
   @SecurityPolicy(auth = REQUIRED_AUTH)
+  @UserMyPageApiDocs.GetPicksMyBottle
   @GetMapping("/{userId}/my-bottle/picks")
-  public ResponseEntity<?> getPicksMyBottle(
+  public ResponseEntity<GlobalResponse> getPicksMyBottle(
       @PathVariable(name = "userId") Long userId,
       @ModelAttribute(name = "myBottleRequest") MyBottleRequest myBottleRequest) {
     final Long currentUserId =

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/AuthApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/AuthApiDocs.java
@@ -11,7 +11,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 로그인과 토큰 관리 엔드포인트의 문서 설명. */
 public final class AuthApiDocs {
@@ -34,7 +33,6 @@ public final class AuthApiDocs {
               description = "관리자 여부",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       schema =
                           @Schema(type = "boolean", example = "false", description = "관리자면 true"))))
   public @interface CheckAdminStatus {}
@@ -54,10 +52,7 @@ public final class AuthApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "발급된 일회성 값",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = NonceResponse.class))))
+              content = @Content(schema = @Schema(implementation = NonceResponse.class))))
   public @interface GetAppleNonce {}
 
   @Target(ElementType.METHOD)
@@ -75,10 +70,7 @@ public final class AuthApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "액세스 토큰과 첫 로그인 여부",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = OauthResponse.class))))
+              content = @Content(schema = @Schema(implementation = OauthResponse.class))))
   public @interface ExecuteAppleLogin {}
 
   @Target(ElementType.METHOD)
@@ -96,10 +88,7 @@ public final class AuthApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "액세스 토큰과 첫 로그인 여부",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = OauthResponse.class))))
+              content = @Content(schema = @Schema(implementation = OauthResponse.class))))
   public @interface ExecuteKakaoLogin {}
 
   @Target(ElementType.METHOD)
@@ -116,10 +105,7 @@ public final class AuthApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "새로 발급된 액세스 토큰",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = OauthResponse.class))))
+              content = @Content(schema = @Schema(implementation = OauthResponse.class))))
   public @interface ReissueToken {}
 
   @Target(ElementType.METHOD)
@@ -131,9 +117,6 @@ public final class AuthApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "검증 결과",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(type = "string", description = "검증 결과 메시지"))))
+              content = @Content(schema = @Schema(type = "string", description = "검증 결과 메시지"))))
   public @interface VerifyToken {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/AuthApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/AuthApiDocs.java
@@ -1,0 +1,139 @@
+package app.bottlenote.user.controller.docs;
+
+import app.bottlenote.user.dto.response.NonceResponse;
+import app.bottlenote.user.dto.response.OauthResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 로그인과 토큰 관리 엔드포인트의 문서 설명. */
+public final class AuthApiDocs {
+
+  private AuthApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "인증", description = "소셜 로그인과 토큰 발급·검증을 처리한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "관리자 권한이 있는지 확인한다",
+      description = "현재 로그인한 사용자가 관리자 권한을 가졌는지 확인합니다. 앱에서 관리자 전용 화면을 노출할지 판단할 때 씁니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "관리자 여부",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema =
+                          @Schema(type = "boolean", example = "false", description = "관리자면 true"))))
+  public @interface CheckAdminStatus {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "애플 로그인용 일회성 값을 발급한다",
+      description =
+          """
+          애플 로그인을 시작하기 전에 받아야 하는 일회성 값(nonce)을 발급합니다.
+
+          이 값을 애플 로그인 요청에 포함시켜야 서버가 재사용 공격을 걸러낼 수 있습니다. 한 번 쓰면 무효가 됩니다.
+          이 응답은 공통 형식으로 감싸지 않고 값을 그대로 내려줍니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "발급된 일회성 값",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = NonceResponse.class))))
+  public @interface GetAppleNonce {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "애플 계정으로 로그인한다",
+      description =
+          """
+          애플에서 받은 인증 토큰과 앞서 발급받은 일회성 값으로 로그인합니다.
+
+          처음 로그인하는 계정이면 회원을 새로 만들고 응답에 첫 로그인 여부를 표시합니다.
+          리프레시 토큰은 응답 본문이 아니라 쿠키로 내려갑니다. 이 응답은 공통 형식으로 감싸지 않습니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "액세스 토큰과 첫 로그인 여부",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = OauthResponse.class))))
+  public @interface ExecuteAppleLogin {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "카카오 계정으로 로그인한다",
+      description =
+          """
+          카카오에서 받은 액세스 토큰으로 로그인합니다.
+
+          서버는 그 토큰이 우리 앱에서 발급된 것인지 확인한 뒤 처리합니다.
+          처음 로그인하는 계정이면 회원을 새로 만듭니다. 리프레시 토큰은 쿠키로 내려가며 이 응답은 공통 형식으로 감싸지 않습니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "액세스 토큰과 첫 로그인 여부",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = OauthResponse.class))))
+  public @interface ExecuteKakaoLogin {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "액세스 토큰을 다시 발급한다",
+      description =
+          """
+          액세스 토큰이 만료됐을 때 리프레시 토큰으로 새 토큰을 받습니다.
+
+          리프레시 토큰은 요청 헤더로 보내며, 새로 발급된 리프레시 토큰은 쿠키로 내려갑니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "새로 발급된 액세스 토큰",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = OauthResponse.class))))
+  public @interface ReissueToken {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "토큰이 유효한지 검증한다",
+      description = "전달한 토큰이 우리 서버가 발급한 유효한 토큰인지 확인합니다. 만료됐거나 위조된 토큰이면 검증에 실패합니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "검증 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(type = "string", description = "검증 결과 메시지"))))
+  public @interface VerifyToken {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/FollowApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/FollowApiDocs.java
@@ -1,0 +1,81 @@
+package app.bottlenote.user.controller.docs;
+
+import app.bottlenote.user.dto.response.FollowUpdateResponse;
+import app.bottlenote.user.dto.response.FollowerSearchResponse;
+import app.bottlenote.user.dto.response.FollowingSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 팔로우 엔드포인트의 문서 설명. */
+public final class FollowApiDocs {
+
+  private FollowApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "팔로우", description = "다른 사용자를 팔로우하고 목록을 조회한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "특정 사용자가 팔로우하는 사람 목록을 조회한다",
+      description =
+          """
+          대상 사용자가 팔로우하고 있는 사람들을 커서 방식으로 가져옵니다.
+
+          각 항목에는 내가 그 사람을 팔로우하고 있는지도 함께 표시됩니다. 다음 페이지 정보는 meta.pageable에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "팔로잉 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = FollowingSearchResponse.class)))))
+  public @interface GetFollowingList {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "특정 사용자를 팔로우하는 사람 목록을 조회한다",
+      description = "대상 사용자를 팔로우하는 사람들을 커서 방식으로 가져옵니다. 각 항목에 내가 그 사람을 팔로우하는지 함께 표시됩니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "팔로워 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array =
+                          @ArraySchema(
+                              schema = @Schema(implementation = FollowerSearchResponse.class)))))
+  public @interface GetFollowerList {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "팔로우 상태를 변경한다",
+      description = "대상 사용자를 팔로우하거나 팔로우를 취소합니다. 자기 자신은 팔로우할 수 없고, 차단한 사용자와는 팔로우가 성립하지 않습니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "변경된 팔로우 상태",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = FollowUpdateResponse.class))))
+  public @interface UpdateFollowStatus {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/FollowApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/FollowApiDocs.java
@@ -13,7 +13,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 팔로우 엔드포인트의 문서 설명. */
 public final class FollowApiDocs {
@@ -41,7 +40,6 @@ public final class FollowApiDocs {
               description = "팔로잉 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = FollowingSearchResponse.class)))))
@@ -58,7 +56,6 @@ public final class FollowApiDocs {
               description = "팔로워 목록",
               content =
                   @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
                       array =
                           @ArraySchema(
                               schema = @Schema(implementation = FollowerSearchResponse.class)))))
@@ -73,9 +70,6 @@ public final class FollowApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "변경된 팔로우 상태",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = FollowUpdateResponse.class))))
+              content = @Content(schema = @Schema(implementation = FollowUpdateResponse.class))))
   public @interface UpdateFollowStatus {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserBasicApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserBasicApiDocs.java
@@ -1,0 +1,92 @@
+package app.bottlenote.user.controller.docs;
+
+import app.bottlenote.user.dto.response.NicknameChangeResponse;
+import app.bottlenote.user.dto.response.ProfileImageChangeResponse;
+import app.bottlenote.user.dto.response.WithdrawUserResultResponse;
+import app.bottlenote.user.facade.payload.UserProfileItem;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 회원 정보 관리 엔드포인트의 문서 설명. */
+public final class UserBasicApiDocs {
+
+  private UserBasicApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "회원 정보", description = "닉네임과 프로필 이미지를 바꾸고 탈퇴를 처리한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "닉네임을 변경한다",
+      description =
+          """
+          로그인한 사용자의 닉네임을 바꿉니다.
+
+          이미 다른 사용자가 쓰고 있는 닉네임이면 변경할 수 없습니다. 변경 이력은 별도로 기록됩니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "변경된 닉네임",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = NicknameChangeResponse.class))))
+  public @interface ChangeNickname {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "프로필 이미지를 변경한다",
+      description = "미리 업로드해 받은 이미지 주소로 프로필 이미지를 바꿉니다. 파일 업로드는 별도 엔드포인트에서 처리합니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "변경된 프로필 이미지 주소",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = ProfileImageChangeResponse.class))))
+  public @interface ChangeProfileImage {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "회원을 탈퇴한다",
+      description = "로그인한 사용자의 계정을 탈퇴 처리합니다. 작성한 리뷰와 별점 등 활동 기록의 처리 방식은 서비스 정책을 따릅니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "탈퇴 처리 결과",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = WithdrawUserResultResponse.class))))
+  public @interface WithdrawUser {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "로그인한 사용자의 프로필을 조회한다",
+      description = "현재 로그인한 사용자의 식별자, 닉네임, 프로필 이미지를 반환합니다. 앱 상단이나 설정 화면에 표시할 정보입니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "사용자 프로필",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = UserProfileItem.class))))
+  public @interface GetCurrentUser {}
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserBasicApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserBasicApiDocs.java
@@ -13,7 +13,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 회원 정보 관리 엔드포인트의 문서 설명. */
 public final class UserBasicApiDocs {
@@ -39,10 +38,7 @@ public final class UserBasicApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "변경된 닉네임",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = NicknameChangeResponse.class))))
+              content = @Content(schema = @Schema(implementation = NicknameChangeResponse.class))))
   public @interface ChangeNickname {}
 
   @Target(ElementType.METHOD)
@@ -55,9 +51,7 @@ public final class UserBasicApiDocs {
               responseCode = "200",
               description = "변경된 프로필 이미지 주소",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = ProfileImageChangeResponse.class))))
+                  @Content(schema = @Schema(implementation = ProfileImageChangeResponse.class))))
   public @interface ChangeProfileImage {}
 
   @Target(ElementType.METHOD)
@@ -70,9 +64,7 @@ public final class UserBasicApiDocs {
               responseCode = "200",
               description = "탈퇴 처리 결과",
               content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = WithdrawUserResultResponse.class))))
+                  @Content(schema = @Schema(implementation = WithdrawUserResultResponse.class))))
   public @interface WithdrawUser {}
 
   @Target(ElementType.METHOD)
@@ -84,9 +76,6 @@ public final class UserBasicApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "사용자 프로필",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = UserProfileItem.class))))
+              content = @Content(schema = @Schema(implementation = UserProfileItem.class))))
   public @interface GetCurrentUser {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserMyPageApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserMyPageApiDocs.java
@@ -11,7 +11,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 마이페이지 엔드포인트의 문서 설명. */
 public final class UserMyPageApiDocs {
@@ -37,10 +36,7 @@ public final class UserMyPageApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "마이페이지 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = MyPageResponse.class))))
+              content = @Content(schema = @Schema(implementation = MyPageResponse.class))))
   public @interface GetMyPage {}
 
   @Target(ElementType.METHOD)
@@ -58,10 +54,7 @@ public final class UserMyPageApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "리뷰를 남긴 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = MyBottleResponse.class))))
+              content = @Content(schema = @Schema(implementation = MyBottleResponse.class))))
   public @interface GetReviewMyBottle {}
 
   @Target(ElementType.METHOD)
@@ -73,10 +66,7 @@ public final class UserMyPageApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "별점을 남긴 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = MyBottleResponse.class))))
+              content = @Content(schema = @Schema(implementation = MyBottleResponse.class))))
   public @interface GetRatingMyBottle {}
 
   @Target(ElementType.METHOD)
@@ -93,9 +83,6 @@ public final class UserMyPageApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "찜한 위스키 목록",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = MyBottleResponse.class))))
+              content = @Content(schema = @Schema(implementation = MyBottleResponse.class))))
   public @interface GetPicksMyBottle {}
 }

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserMyPageApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/docs/UserMyPageApiDocs.java
@@ -1,0 +1,101 @@
+package app.bottlenote.user.controller.docs;
+
+import app.bottlenote.user.dto.response.MyBottleResponse;
+import app.bottlenote.user.dto.response.MyPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 마이페이지 엔드포인트의 문서 설명. */
+public final class UserMyPageApiDocs {
+
+  private UserMyPageApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "마이페이지", description = "사용자가 남긴 리뷰·별점·찜 기록을 모아 보여준다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "마이페이지 정보를 조회한다",
+      description =
+          """
+          대상 사용자의 프로필과 활동 요약(리뷰 수, 별점 수, 팔로워·팔로잉 수)을 반환합니다.
+
+          다른 사용자의 마이페이지도 조회할 수 있고, 본인 페이지인지 여부가 응답에 표시됩니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "마이페이지 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = MyPageResponse.class))))
+  public @interface GetMyPage {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "리뷰를 남긴 위스키 목록을 조회한다",
+      description =
+          """
+          대상 사용자가 리뷰를 쓴 위스키를 커서 방식으로 가져옵니다.
+
+          다른 사용자의 목록을 볼 때는 비공개 리뷰가 제외됩니다.
+          다음 페이지 정보는 meta.pageable, 조회 조건은 meta.searchParameters에 담깁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "리뷰를 남긴 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = MyBottleResponse.class))))
+  public @interface GetReviewMyBottle {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "별점을 남긴 위스키 목록을 조회한다",
+      description = "대상 사용자가 별점을 준 위스키를 커서 방식으로 가져옵니다. 각 항목에 그 사용자가 준 별점이 함께 담깁니다.",
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "별점을 남긴 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = MyBottleResponse.class))))
+  public @interface GetRatingMyBottle {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "찜한 위스키 목록을 조회한다",
+      description =
+          """
+          대상 사용자가 찜한 위스키를 커서 방식으로 가져옵니다.
+
+          다른 사용자의 목록을 볼 때는 각 항목에 나도 그 위스키를 찜했는지가 함께 표시됩니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "찜한 위스키 목록",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = MyBottleResponse.class))))
+  public @interface GetPicksMyBottle {}
+}

--- a/bottlenote-product-api/src/main/java/app/external/version/presentation/AppInfoController.java
+++ b/bottlenote-product-api/src/main/java/app/external/version/presentation/AppInfoController.java
@@ -5,6 +5,7 @@ import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.external.version.config.AppInfoConfig;
+import app.external.version.presentation.docs.AppInfoApiDocs;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -22,11 +23,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/app-info")
 @RequiredArgsConstructor
 @SecurityPolicy(auth = PUBLIC)
+@AppInfoApiDocs.ApiTag
 public class AppInfoController {
   private final AppInfoConfig info;
 
+  @AppInfoApiDocs.GetAppInfo
   @GetMapping
-  public ResponseEntity<?> getAppInfo() {
+  public ResponseEntity<GlobalResponse> getAppInfo() {
     Map<String, Object> infoMap = new HashMap<>();
     infoMap.put("serverName", info.getServerName());
     infoMap.put("environment", info.getEnvironment());

--- a/bottlenote-product-api/src/main/java/app/external/version/presentation/docs/AppInfoApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/external/version/presentation/docs/AppInfoApiDocs.java
@@ -1,0 +1,53 @@
+package app.external.version.presentation.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.http.MediaType;
+
+/** 서버 정보 엔드포인트의 문서 설명. */
+public final class AppInfoApiDocs {
+
+  private AppInfoApiDocs() {}
+
+  @Target(ElementType.TYPE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Tag(name = "서버 정보", description = "현재 배포된 서버의 버전과 환경 정보를 확인한다")
+  public @interface ApiTag {}
+
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.RUNTIME)
+  @Operation(
+      summary = "서버 배포 정보를 조회한다",
+      description =
+          """
+          현재 실행 중인 서버의 이름, 환경, 배포된 커밋과 빌드 시각을 반환합니다.
+
+          장애를 확인하거나 클라이언트가 어느 버전과 통신하는지 파악할 때 씁니다.
+          """,
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              description = "서버 배포 정보",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      schema = @Schema(implementation = AppInfoResult.class))))
+  public @interface GetAppInfo {}
+
+  /** 실제 응답은 문자열 맵이다. 담기는 키를 문서에 드러내기 위해 같은 모양의 타입을 선언한다. */
+  @Schema(name = "서버 배포 정보", description = "서버 이름과 배포된 코드의 출처")
+  private record AppInfoResult(
+      @Schema(description = "서버 이름", example = "product-api") String serverName,
+      @Schema(description = "실행 환경", example = "prod") String environment,
+      @Schema(description = "배포된 브랜치", example = "main") String gitBranch,
+      @Schema(description = "커밋 해시 앞 7자리", example = "a1b2c3d") String gitCommitHash,
+      @Schema(description = "커밋 해시 전체") String gitCommitFullHash,
+      @Schema(description = "빌드 시각", example = "2026-07-26 18:00:00") String gitBuildTime) {}
+}

--- a/bottlenote-product-api/src/main/java/app/external/version/presentation/docs/AppInfoApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/external/version/presentation/docs/AppInfoApiDocs.java
@@ -42,7 +42,7 @@ public final class AppInfoApiDocs {
   public @interface GetAppInfo {}
 
   /** 실제 응답은 문자열 맵이다. 담기는 키를 문서에 드러내기 위해 같은 모양의 타입을 선언한다. */
-  @Schema(name = "서버 배포 정보", description = "서버 이름과 배포된 코드의 출처")
+  @Schema(name = "AppInfoResult", title = "서버 배포 정보", description = "서버 이름과 배포된 코드의 출처")
   private record AppInfoResult(
       @Schema(description = "서버 이름", example = "product-api") String serverName,
       @Schema(description = "실행 환경", example = "prod") String environment,

--- a/bottlenote-product-api/src/main/java/app/external/version/presentation/docs/AppInfoApiDocs.java
+++ b/bottlenote-product-api/src/main/java/app/external/version/presentation/docs/AppInfoApiDocs.java
@@ -9,7 +9,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.http.MediaType;
 
 /** 서버 정보 엔드포인트의 문서 설명. */
 public final class AppInfoApiDocs {
@@ -35,10 +34,7 @@ public final class AppInfoApiDocs {
           @ApiResponse(
               responseCode = "200",
               description = "서버 배포 정보",
-              content =
-                  @Content(
-                      mediaType = MediaType.APPLICATION_JSON_VALUE,
-                      schema = @Schema(implementation = AppInfoResult.class))))
+              content = @Content(schema = @Schema(implementation = AppInfoResult.class))))
   public @interface GetAppInfo {}
 
   /** 실제 응답은 문자열 맵이다. 담기는 키를 문서에 드러내기 위해 같은 모양의 타입을 선언한다. */

--- a/bottlenote-product-api/src/main/java/app/global/config/CommonErrorResponseCustomizer.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/CommonErrorResponseCustomizer.java
@@ -1,0 +1,75 @@
+package app.global.config;
+
+import app.bottlenote.global.annotation.SecurityPolicy.AuthType;
+import app.bottlenote.global.exception.custom.code.ExceptionCode;
+import app.bottlenote.global.exception.custom.code.ValidExceptionCode;
+import app.bottlenote.global.security.jwt.JwtExceptionType;
+import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector;
+import app.global.security.SecurityPolicyConfig;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * 어느 엔드포인트에서나 돌아올 수 있는 공통 오류 응답을 문서에 싣는다.
+ *
+ * <p>대상은 전역 예외 처리기가 도메인과 무관하게 만들어내는 응답뿐이다. 요청 값 검증 실패, 토큰 문제, 처리하지 못한 서버 오류가 여기에 해당한다. 도메인마다 다른 업무
+ * 규칙 위반은 각 엔드포인트가 직접 문서화한다.
+ *
+ * <p>엔드포인트가 같은 상태 코드를 이미 설명해 두었다면 그 설명을 덮지 않는다.
+ */
+@Component
+public class CommonErrorResponseCustomizer implements OperationCustomizer, OpenApiCustomizer {
+
+  private static final String BAD_REQUEST = "400";
+  private static final String UNAUTHORIZED = "401";
+  private static final String FORBIDDEN = "403";
+  private static final String SERVER_ERROR = "500";
+
+  @Override
+  public void customise(OpenAPI openApi) {
+    if (openApi.getComponents() == null) {
+      openApi.setComponents(new Components());
+    }
+    ErrorResponseSchema.registerInto(openApi.getComponents());
+  }
+
+  @Override
+  public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+    ApiResponses responses = operation.getResponses();
+    if (responses == null) {
+      return operation;
+    }
+
+    describe(
+        responses,
+        BAD_REQUEST,
+        ValidExceptionCode.TYPE_MISMATCH,
+        "요청 값이 올바르지 않습니다. 필수값 누락, 타입 불일치, 본문 파싱 실패가 여기에 해당합니다.");
+    if (requiresToken(handlerMethod)) {
+      describe(responses, UNAUTHORIZED, JwtExceptionType.MALFORMED_TOKEN, "액세스 토큰이 없거나 유효하지 않습니다.");
+      // 만료된 토큰만 유일하게 403이다. JwtExceptionType.EXPIRED_TOKEN 참고
+      describe(responses, FORBIDDEN, JwtExceptionType.EXPIRED_TOKEN, "액세스 토큰이 만료되었습니다.");
+    }
+    describe(responses, SERVER_ERROR, ValidExceptionCode.UNKNOWN_ERROR, "서버가 처리하지 못한 오류입니다.");
+
+    return operation;
+  }
+
+  private void describe(
+      ApiResponses responses, String status, ExceptionCode sample, String description) {
+    responses.computeIfAbsent(status, code -> ErrorResponseSchema.response(sample, description));
+  }
+
+  /** 토큰을 요구하는 엔드포인트만 401을 낼 수 있다. 판정 근거는 실제 인증과 같은 {@code @SecurityPolicy}다. */
+  private boolean requiresToken(HandlerMethod handlerMethod) {
+    return SecurityPolicyRouteCollector.resolveAuthType(
+            handlerMethod, SecurityPolicyConfig.FALLBACK_AUTH_TYPE)
+        != AuthType.PUBLIC;
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/global/config/ErrorResponseSchema.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/ErrorResponseSchema.java
@@ -1,0 +1,143 @@
+package app.global.config;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import app.bottlenote.global.exception.custom.code.ExceptionCode;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 오류가 실리는 자리의 스키마를 한곳에 모은다.
+ *
+ * <p>같은 모양이 두 곳에 나온다. 성공 응답의 {@code errors}는 비어 있는 같은 배열이고, 실패 응답은 그 배열에 항목이 담긴 본문이다. 한곳에서 만들어야 둘이
+ * 어긋나지 않는다.
+ */
+final class ErrorResponseSchema {
+
+  /** 오류 항목 하나. */
+  private static final String ITEM_NAME = "Error";
+
+  /** 실패 응답 본문 전체. */
+  private static final String ENVELOPE_NAME = "ErrorResponse";
+
+  private static final String ITEM_REF = Components.COMPONENTS_SCHEMAS_REF + ITEM_NAME;
+  private static final String ENVELOPE_REF = Components.COMPONENTS_SCHEMAS_REF + ENVELOPE_NAME;
+
+  /**
+   * meta 자리의 예시.
+   *
+   * <p>{@code MetaService.createMetaInfo()}를 그대로 쓰면 스펙을 만들 때마다 시각이 바뀌어 문서가 매번 달라진다. 값은 고정하되 키가 실제와
+   * 어긋나지 않는지는 테스트가 지킨다.
+   */
+  static final Map<String, Object> EXAMPLE_META = exampleMeta();
+
+  private static Map<String, Object> exampleMeta() {
+    // Map.of는 순회 순서가 실행마다 달라져 스펙이 흔들린다
+    Map<String, Object> meta = new LinkedHashMap<>();
+    meta.put("serverVersion", "1.0.0");
+    meta.put("serverPathVersion", "v1");
+    meta.put("serverEncoding", "UTF-8");
+    meta.put("serverResponseTime", "2026-01-01T00:00:00");
+    return Collections.unmodifiableMap(meta);
+  }
+
+  private ErrorResponseSchema() {}
+
+  /** 스펙 전체에서 한 번만 정의하고 각 응답은 참조만 한다. */
+  static void registerInto(Components components) {
+    components.addSchemas(ITEM_NAME, errorItem());
+    components.addSchemas(ENVELOPE_NAME, envelope());
+  }
+
+  /**
+   * 실패 응답 하나. 본문 예시는 실제 예외 코드로 만든다.
+   *
+   * <p>스키마만 주면 문서 도구가 배열마다 항목을 하나씩 지어내 {@code data}가 비어 있지 않은 것처럼 보인다. 본문 전체를 예시로 박아 실제로 돌아오는 모양을
+   * 그대로 보여준다.
+   */
+  static ApiResponse response(ExceptionCode sample, String description) {
+    return new ApiResponse()
+        .description(description)
+        .content(
+            new Content()
+                .addMediaType(
+                    APPLICATION_JSON_VALUE,
+                    new MediaType()
+                        .schema(new Schema<>().$ref(ENVELOPE_REF))
+                        .example(exampleBody(sample))));
+  }
+
+  /** {@code GlobalResponse.error(Error)}가 만드는 본문과 같은 모양. */
+  private static Map<String, Object> exampleBody(ExceptionCode sample) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("success", false);
+    body.put("code", sample.getHttpStatus().value());
+    body.put("data", List.of());
+    body.put("errors", List.of(exampleItem(sample)));
+    body.put("meta", EXAMPLE_META);
+    return body;
+  }
+
+  private static Map<String, Object> exampleItem(ExceptionCode sample) {
+    Map<String, Object> item = new LinkedHashMap<>();
+    item.put("code", ((Enum<?>) sample).name());
+    item.put("status", sample.getHttpStatus().name());
+    item.put("message", sample.getMessage());
+    return item;
+  }
+
+  /** 오류가 담기는 배열. */
+  static Schema<?> errors() {
+    return new ArraySchema().items(new Schema<>().$ref(ITEM_REF));
+  }
+
+  /**
+   * 성공 응답에 실리는 {@code errors}. 항상 비어 있다.
+   *
+   * <p>담길 항목의 모양을 {@code items}로 적지 않는다. 담기는 것이 없기 때문이다. 적어두면 문서 도구가 그 모양으로 항목을 하나 지어내 성공 예시에 오류가
+   * 담긴 것처럼 보여준다. 오류 항목의 모양은 실패 응답이 설명한다.
+   */
+  static Schema<?> emptyErrors() {
+    return new ArraySchema().maxItems(0);
+  }
+
+  private static Schema<?> errorItem() {
+    return new ObjectSchema()
+        .title("오류 항목")
+        .addProperty(
+            "code",
+            new StringSchema()
+                .description("오류 코드. 클라이언트가 화면 분기에 쓰는 값이다")
+                .example("ALCOHOL_ID_REQUIRED"))
+        .addProperty("status", new StringSchema().description("HTTP 상태 이름").example("BAD_REQUEST"))
+        .addProperty(
+            "message", new StringSchema().description("사람이 읽는 오류 설명").example("알코올 식별자는 필수입니다."));
+  }
+
+  private static Schema<?> envelope() {
+    return new ObjectSchema()
+        .title("오류 응답")
+        .addProperty("success", new BooleanSchema().description("요청 처리 성공 여부").example(false))
+        .addProperty("code", new IntegerSchema().description("HTTP 상태 코드").example(400))
+        .addProperty(
+            "data",
+            new ArraySchema()
+                .items(new ObjectSchema())
+                .maxItems(0)
+                .description("오류 응답에서는 항상 빈 배열이다"))
+        .addProperty("errors", errors().description("발생한 오류 목록"))
+        .addProperty("meta", new ObjectSchema().description("서버 버전, 응답 시각 등 부가 정보"));
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/global/config/GlobalResponseSchemaCustomizer.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/GlobalResponseSchemaCustomizer.java
@@ -1,0 +1,131 @@
+package app.global.config;
+
+import app.bottlenote.global.data.response.GlobalResponse;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * 성공 응답을 {@code GlobalResponse} 공통 형식으로 감싼다.
+ *
+ * <p>대부분의 컨트롤러는 {@code ResponseEntity<?>}를 반환해 스펙 생성기가 응답 타입을 알아낼 수 없다. 그래서 각 엔드포인트는 {@code data}에
+ * 담길 타입만 표준 {@code @ApiResponse}로 알려주고, 이 클래스가 그 타입을 {@code data} 자리로 옮긴 뒤 공통 필드를 덧붙인다. 덕분에 공통 형식을
+ * 엔드포인트마다 반복해서 적지 않아도 된다.
+ *
+ * <p>공통 형식을 쓰지 않고 DTO를 그대로 내보내는 엔드포인트도 있다. 이들은 컨트롤러가 반환 타입에 본문 타입을 구체적으로 선언하고, 이 클래스는 그 선언을 보고 감싸기를
+ * 건너뛴다. 예외 목록을 따로 두지 않으므로 코드와 문서가 어긋날 수 없다.
+ */
+@Component
+public class GlobalResponseSchemaCustomizer implements OperationCustomizer {
+
+  private static final String JSON = org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+  private static final String DATA = "data";
+
+  /**
+   * 일부 컨트롤러는 {@code ResponseEntity<GlobalResponse>}를 반환한다. 이때 추론되는 스키마는 공통 형식 그 자체이므로 {@code data}에
+   * 담길 타입이 아니다. 그대로 두면 공통 형식 안에 공통 형식이 중첩된다.
+   */
+  private static final String ENVELOPE_SCHEMA_NAME = "GlobalResponse";
+
+  @Override
+  public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+    if (operation.getResponses() == null || returnsBareDto(handlerMethod)) {
+      return operation;
+    }
+    operation.getResponses().forEach((statusCode, response) -> wrapIfSuccess(statusCode, response));
+    return operation;
+  }
+
+  /**
+   * 공통 형식을 거치지 않고 DTO를 그대로 내보내는 엔드포인트인지 판단한다.
+   *
+   * <p>판단 근거는 컨트롤러가 선언한 반환 타입이다. {@code ResponseEntity<NonceResponse>}처럼 본문 타입을 구체적으로 적어두면 그 타입이 곧
+   * 응답 본문이라는 뜻이므로 감싸지 않는다. {@code ResponseEntity<?>}나 {@code ResponseEntity<GlobalResponse>}는 공통
+   * 형식을 쓴다는 뜻이다. 덕분에 예외 목록을 따로 관리하지 않고 코드 자체가 문서의 근거가 된다.
+   */
+  private boolean returnsBareDto(HandlerMethod handlerMethod) {
+    ResolvableType returnType = ResolvableType.forMethodReturnType(handlerMethod.getMethod());
+    if (!ResponseEntity.class.isAssignableFrom(returnType.toClass())) {
+      return false;
+    }
+    Class<?> bodyType = returnType.getGeneric(0).resolve();
+    return bodyType != null
+        && bodyType != Object.class
+        && !GlobalResponse.class.isAssignableFrom(bodyType);
+  }
+
+  private void wrapIfSuccess(String statusCode, ApiResponse response) {
+    if (!statusCode.startsWith("2")) {
+      return;
+    }
+    Schema<?> declared = declaredSchema(response);
+    if (alreadyWrapped(declared)) {
+      return;
+    }
+    response.setContent(
+        new Content().addMediaType(JSON, new MediaType().schema(commonEnvelope(declared))));
+  }
+
+  /** 엔드포인트가 알려준 data 타입. 알려주지 않았으면 null. */
+  private Schema<?> declaredSchema(ApiResponse response) {
+    Content content = response.getContent();
+    if (content == null || content.isEmpty()) {
+      return null;
+    }
+    return content.values().stream()
+        .map(MediaType::getSchema)
+        .filter(this::isMeaningful)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /** 타입 정보가 없는 빈 object와 공통 형식 자체는 힌트로 취급하지 않는다. */
+  private boolean isMeaningful(Schema<?> schema) {
+    if (schema == null) {
+      return false;
+    }
+    if (isEnvelopeItself(schema)) {
+      return false;
+    }
+    boolean emptyObject =
+        "object".equals(schema.getType())
+            && schema.get$ref() == null
+            && (schema.getProperties() == null || schema.getProperties().isEmpty());
+    return !emptyObject;
+  }
+
+  private boolean isEnvelopeItself(Schema<?> schema) {
+    String ref = schema.get$ref();
+    return ref != null && ref.endsWith("/" + ENVELOPE_SCHEMA_NAME);
+  }
+
+  private boolean alreadyWrapped(Schema<?> schema) {
+    return schema != null
+        && schema.getProperties() != null
+        && schema.getProperties().containsKey(DATA);
+  }
+
+  private Schema<?> commonEnvelope(Schema<?> dataSchema) {
+    Schema<?> data = dataSchema != null ? dataSchema : new ObjectSchema();
+    return new ObjectSchema()
+        .addProperty("success", new BooleanSchema().description("요청 처리 성공 여부"))
+        .addProperty("code", new IntegerSchema().description("HTTP 상태 코드"))
+        .addProperty("data", data.description("요청 결과 값"))
+        .addProperty(
+            "errors",
+            new ArraySchema().items(new StringSchema()).description("오류 메시지 목록. 성공 시 비어 있다"))
+        .addProperty("meta", new ObjectSchema().description("서버 버전, 응답 시각, 페이징 정보 등 부가 정보"));
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/global/config/GlobalResponseSchemaCustomizer.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/GlobalResponseSchemaCustomizer.java
@@ -5,14 +5,12 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import app.bottlenote.global.data.response.GlobalResponse;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import java.util.Optional;
 import org.springdoc.core.customizers.OperationCustomizer;
@@ -36,6 +34,9 @@ public class GlobalResponseSchemaCustomizer implements OperationCustomizer {
 
   private static final String SUCCESS_STATUS_PREFIX = "2";
   private static final String OBJECT_TYPE = "object";
+
+  /** 공통 형식의 code에 담기는 값. 성공 응답은 항상 200이다. */
+  private static final int HTTP_OK = 200;
 
   private static final String SUCCESS = "success";
   private static final String CODE = "code";
@@ -125,12 +126,14 @@ public class GlobalResponseSchemaCustomizer implements OperationCustomizer {
 
   private Schema<?> commonEnvelope(Schema<?> data) {
     return new ObjectSchema()
-        .addProperty(SUCCESS, new BooleanSchema().description("요청 처리 성공 여부"))
-        .addProperty(CODE, new IntegerSchema().description("HTTP 상태 코드"))
+        .addProperty(SUCCESS, new BooleanSchema().description("요청 처리 성공 여부").example(true))
+        .addProperty(CODE, new IntegerSchema().description("HTTP 상태 코드").example(HTTP_OK))
         .addProperty(DATA, data.description("요청 결과 값"))
+        .addProperty(ERRORS, ErrorResponseSchema.emptyErrors().description("오류 목록. 성공 시 비어 있다"))
         .addProperty(
-            ERRORS,
-            new ArraySchema().items(new StringSchema()).description("오류 메시지 목록. 성공 시 비어 있다"))
-        .addProperty(META, new ObjectSchema().description("서버 버전, 응답 시각, 페이징 정보 등 부가 정보"));
+            META,
+            new ObjectSchema()
+                .description("서버 버전, 응답 시각, 페이징 정보 등 부가 정보")
+                .example(ErrorResponseSchema.EXAMPLE_META));
   }
 }

--- a/bottlenote-product-api/src/main/java/app/global/config/GlobalResponseSchemaCustomizer.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/GlobalResponseSchemaCustomizer.java
@@ -1,6 +1,9 @@
 package app.global.config;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import app.bottlenote.global.data.response.GlobalResponse;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
@@ -11,6 +14,7 @@ import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import java.util.Optional;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.core.ResolvableType;
 import org.springframework.http.ResponseEntity;
@@ -20,9 +24,9 @@ import org.springframework.web.method.HandlerMethod;
 /**
  * 성공 응답을 {@code GlobalResponse} 공통 형식으로 감싼다.
  *
- * <p>대부분의 컨트롤러는 {@code ResponseEntity<?>}를 반환해 스펙 생성기가 응답 타입을 알아낼 수 없다. 그래서 각 엔드포인트는 {@code data}에
- * 담길 타입만 표준 {@code @ApiResponse}로 알려주고, 이 클래스가 그 타입을 {@code data} 자리로 옮긴 뒤 공통 필드를 덧붙인다. 덕분에 공통 형식을
- * 엔드포인트마다 반복해서 적지 않아도 된다.
+ * <p>대부분의 컨트롤러는 {@code ResponseEntity<GlobalResponse>}를 반환해 스펙 생성기가 {@code data}에 담길 타입을 알아낼 수 없다.
+ * 그래서 각 엔드포인트는 그 타입만 표준 {@code @ApiResponse}로 알려주고, 이 클래스가 그 타입을 {@code data} 자리로 옮긴 뒤 공통 필드를 덧붙인다.
+ * 덕분에 공통 형식을 엔드포인트마다 반복해서 적지 않아도 된다.
  *
  * <p>공통 형식을 쓰지 않고 DTO를 그대로 내보내는 엔드포인트도 있다. 이들은 컨트롤러가 반환 타입에 본문 타입을 구체적으로 선언하고, 이 클래스는 그 선언을 보고 감싸기를
  * 건너뛴다. 예외 목록을 따로 두지 않으므로 코드와 문서가 어긋날 수 없다.
@@ -30,21 +34,28 @@ import org.springframework.web.method.HandlerMethod;
 @Component
 public class GlobalResponseSchemaCustomizer implements OperationCustomizer {
 
-  private static final String JSON = org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+  private static final String SUCCESS_STATUS_PREFIX = "2";
+  private static final String OBJECT_TYPE = "object";
+
+  private static final String SUCCESS = "success";
+  private static final String CODE = "code";
   private static final String DATA = "data";
+  private static final String ERRORS = "errors";
+  private static final String META = "meta";
 
   /**
    * 일부 컨트롤러는 {@code ResponseEntity<GlobalResponse>}를 반환한다. 이때 추론되는 스키마는 공통 형식 그 자체이므로 {@code data}에
    * 담길 타입이 아니다. 그대로 두면 공통 형식 안에 공통 형식이 중첩된다.
    */
-  private static final String ENVELOPE_SCHEMA_NAME = "GlobalResponse";
+  private static final String ENVELOPE_SCHEMA_REF =
+      Components.COMPONENTS_SCHEMAS_REF + GlobalResponse.class.getSimpleName();
 
   @Override
   public Operation customize(Operation operation, HandlerMethod handlerMethod) {
     if (operation.getResponses() == null || returnsBareDto(handlerMethod)) {
       return operation;
     }
-    operation.getResponses().forEach((statusCode, response) -> wrapIfSuccess(statusCode, response));
+    operation.getResponses().forEach(this::wrapIfSuccess);
     return operation;
   }
 
@@ -52,8 +63,8 @@ public class GlobalResponseSchemaCustomizer implements OperationCustomizer {
    * 공통 형식을 거치지 않고 DTO를 그대로 내보내는 엔드포인트인지 판단한다.
    *
    * <p>판단 근거는 컨트롤러가 선언한 반환 타입이다. {@code ResponseEntity<NonceResponse>}처럼 본문 타입을 구체적으로 적어두면 그 타입이 곧
-   * 응답 본문이라는 뜻이므로 감싸지 않는다. {@code ResponseEntity<?>}나 {@code ResponseEntity<GlobalResponse>}는 공통
-   * 형식을 쓴다는 뜻이다. 덕분에 예외 목록을 따로 관리하지 않고 코드 자체가 문서의 근거가 된다.
+   * 응답 본문이라는 뜻이므로 감싸지 않는다. {@code ResponseEntity<GlobalResponse>}는 공통 형식을 쓴다는 뜻이다. 덕분에 예외 목록을 따로
+   * 관리하지 않고 코드 자체가 문서의 근거가 된다.
    */
   private boolean returnsBareDto(HandlerMethod handlerMethod) {
     ResolvableType returnType = ResolvableType.forMethodReturnType(handlerMethod.getMethod());
@@ -67,65 +78,59 @@ public class GlobalResponseSchemaCustomizer implements OperationCustomizer {
   }
 
   private void wrapIfSuccess(String statusCode, ApiResponse response) {
-    if (!statusCode.startsWith("2")) {
+    if (!statusCode.startsWith(SUCCESS_STATUS_PREFIX)) {
       return;
     }
-    Schema<?> declared = declaredSchema(response);
-    if (alreadyWrapped(declared)) {
+    Optional<Schema<?>> declared = declaredSchema(response);
+    if (declared.filter(this::alreadyWrapped).isPresent()) {
       return;
     }
+    Schema<?> envelope = commonEnvelope(declared.orElseGet(ObjectSchema::new));
     response.setContent(
-        new Content().addMediaType(JSON, new MediaType().schema(commonEnvelope(declared))));
+        new Content().addMediaType(APPLICATION_JSON_VALUE, new MediaType().schema(envelope)));
   }
 
-  /** 엔드포인트가 알려준 data 타입. 알려주지 않았으면 null. */
-  private Schema<?> declaredSchema(ApiResponse response) {
+  /** 엔드포인트가 알려준 data 타입. */
+  private Optional<Schema<?>> declaredSchema(ApiResponse response) {
     Content content = response.getContent();
-    if (content == null || content.isEmpty()) {
-      return null;
+    if (content == null) {
+      return Optional.empty();
     }
+    // MediaType#getSchema가 raw 타입이라 witness가 필요하다
     return content.values().stream()
-        .map(MediaType::getSchema)
+        .<Schema<?>>map(MediaType::getSchema)
         .filter(this::isMeaningful)
-        .findFirst()
-        .orElse(null);
+        .findFirst();
   }
 
   /** 타입 정보가 없는 빈 object와 공통 형식 자체는 힌트로 취급하지 않는다. */
   private boolean isMeaningful(Schema<?> schema) {
-    if (schema == null) {
-      return false;
-    }
-    if (isEnvelopeItself(schema)) {
-      return false;
-    }
-    boolean emptyObject =
-        "object".equals(schema.getType())
-            && schema.get$ref() == null
-            && (schema.getProperties() == null || schema.getProperties().isEmpty());
-    return !emptyObject;
+    return schema != null && !isEnvelopeItself(schema) && !isEmptyObject(schema);
+  }
+
+  private boolean isEmptyObject(Schema<?> schema) {
+    return OBJECT_TYPE.equals(schema.getType())
+        && schema.get$ref() == null
+        && (schema.getProperties() == null || schema.getProperties().isEmpty());
   }
 
   private boolean isEnvelopeItself(Schema<?> schema) {
-    String ref = schema.get$ref();
-    return ref != null && ref.endsWith("/" + ENVELOPE_SCHEMA_NAME);
+    return ENVELOPE_SCHEMA_REF.equals(schema.get$ref());
   }
 
+  /** 이미 공통 형식으로 적혀 있는지. {@link #isEnvelopeItself}와 달리 참조가 아닌 펼쳐진 스키마를 본다. */
   private boolean alreadyWrapped(Schema<?> schema) {
-    return schema != null
-        && schema.getProperties() != null
-        && schema.getProperties().containsKey(DATA);
+    return schema.getProperties() != null && schema.getProperties().containsKey(DATA);
   }
 
-  private Schema<?> commonEnvelope(Schema<?> dataSchema) {
-    Schema<?> data = dataSchema != null ? dataSchema : new ObjectSchema();
+  private Schema<?> commonEnvelope(Schema<?> data) {
     return new ObjectSchema()
-        .addProperty("success", new BooleanSchema().description("요청 처리 성공 여부"))
-        .addProperty("code", new IntegerSchema().description("HTTP 상태 코드"))
-        .addProperty("data", data.description("요청 결과 값"))
+        .addProperty(SUCCESS, new BooleanSchema().description("요청 처리 성공 여부"))
+        .addProperty(CODE, new IntegerSchema().description("HTTP 상태 코드"))
+        .addProperty(DATA, data.description("요청 결과 값"))
         .addProperty(
-            "errors",
+            ERRORS,
             new ArraySchema().items(new StringSchema()).description("오류 메시지 목록. 성공 시 비어 있다"))
-        .addProperty("meta", new ObjectSchema().description("서버 버전, 응답 시각, 페이징 정보 등 부가 정보"));
+        .addProperty(META, new ObjectSchema().description("서버 버전, 응답 시각, 페이징 정보 등 부가 정보"));
   }
 }

--- a/bottlenote-product-api/src/main/java/app/global/config/OpenApiConfig.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/OpenApiConfig.java
@@ -1,0 +1,47 @@
+package app.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** 스펙 문서의 최상단 정보와 인증 방식을 정의한다. 개별 엔드포인트 설명은 각 도메인의 문서 어노테이션이 담당한다. */
+@Configuration
+public class OpenApiConfig {
+
+  /** 액세스 토큰을 Authorization 헤더로 전달하는 방식을 가리키는 이름. */
+  public static final String BEARER_AUTH = "액세스 토큰";
+
+  @Bean
+  OpenAPI productOpenApi() {
+    return new OpenAPI().info(productApiInfo()).components(securityComponents());
+  }
+
+  private Info productApiInfo() {
+    return new Info()
+        .title("보틀노트 Product API")
+        .version("v1")
+        .description(
+            """
+            보틀노트 앱이 사용하는 공개 API입니다.
+
+            모든 응답은 success, code, data, errors, meta를 갖는 공통 형식으로 감싸여 있고, \
+            실제 결과값은 data 안에 담깁니다.
+
+            인증이 필요한 엔드포인트는 로그인 후 발급받은 액세스 토큰을 Authorization 헤더에 \
+            "Bearer {토큰}" 형태로 담아 호출합니다.""");
+  }
+
+  private Components securityComponents() {
+    return new Components()
+        .addSecuritySchemes(
+            BEARER_AUTH,
+            new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .description("로그인 응답으로 받은 액세스 토큰을 그대로 입력합니다."));
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/global/config/OpenApiConfig.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/OpenApiConfig.java
@@ -11,8 +11,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
-  /** 액세스 토큰을 Authorization 헤더로 전달하는 방식을 가리키는 이름. */
-  public static final String BEARER_AUTH = "액세스 토큰";
+  /**
+   * 액세스 토큰을 Authorization 헤더로 전달하는 방식을 가리키는 이름.
+   *
+   * <p>components 하위 키는 OpenAPI 규칙상 영문 식별자여야 한다. 사람이 읽을 설명은 description에 담는다.
+   */
+  public static final String BEARER_AUTH = "bearerAuth";
 
   @Bean
   OpenAPI productOpenApi() {

--- a/bottlenote-product-api/src/main/java/app/global/config/SecurityRequirementCustomizer.java
+++ b/bottlenote-product-api/src/main/java/app/global/config/SecurityRequirementCustomizer.java
@@ -1,0 +1,39 @@
+package app.global.config;
+
+import static app.global.config.OpenApiConfig.BEARER_AUTH;
+
+import app.bottlenote.global.annotation.SecurityPolicy.AuthType;
+import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector;
+import app.global.security.SecurityPolicyConfig;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * 엔드포인트가 액세스 토큰을 요구하는지 문서에 표시한다.
+ *
+ * <p>판정 근거는 실제 인증과 같은 {@code @SecurityPolicy}다. 문서에 따로 적지 않으므로 정책을 바꾸면 문서도 함께 바뀐다.
+ */
+@Component
+public class SecurityRequirementCustomizer implements OperationCustomizer {
+
+  @Override
+  public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+    AuthType auth =
+        SecurityPolicyRouteCollector.resolveAuthType(
+            handlerMethod, SecurityPolicyConfig.FALLBACK_AUTH_TYPE);
+
+    if (auth == AuthType.PUBLIC) {
+      return operation;
+    }
+
+    operation.addSecurityItem(new SecurityRequirement().addList(BEARER_AUTH));
+    if (auth == AuthType.OPTIONAL_AUTH) {
+      // 토큰 없이 호출해도 동작한다는 사실을 빈 요구사항으로 함께 알린다
+      operation.addSecurityItem(new SecurityRequirement());
+    }
+    return operation;
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/global/security/SecurityPolicyConfig.java
+++ b/bottlenote-product-api/src/main/java/app/global/security/SecurityPolicyConfig.java
@@ -23,6 +23,8 @@ public class SecurityPolicyConfig {
         REQUIRED_AUTH,
         List.of(
             SecurityPolicyRoute.explicit(null, "/actuator/**", PUBLIC),
-            SecurityPolicyRoute.explicit(null, "/error", PUBLIC)));
+            SecurityPolicyRoute.explicit(null, "/error", PUBLIC),
+            // API 스펙은 클라이언트 개발자가 인증 없이 받아갈 수 있어야 한다
+            SecurityPolicyRoute.explicit(null, "/openapi.product.json", PUBLIC)));
   }
 }

--- a/bottlenote-product-api/src/main/java/app/global/security/SecurityPolicyConfig.java
+++ b/bottlenote-product-api/src/main/java/app/global/security/SecurityPolicyConfig.java
@@ -3,11 +3,13 @@ package app.global.security;
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.REQUIRED_AUTH;
 
+import app.bottlenote.global.annotation.SecurityPolicy.AuthType;
 import app.bottlenote.global.security.policy.SecurityPolicyRegistry;
 import app.bottlenote.global.security.policy.SecurityPolicyRoute;
 import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -15,16 +17,25 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 @Configuration
 public class SecurityPolicyConfig {
 
+  /** {@code @SecurityPolicy}를 선언하지 않은 엔드포인트에 적용되는 인증 방식. */
+  public static final AuthType FALLBACK_AUTH_TYPE = REQUIRED_AUTH;
+
   @Bean
   SecurityPolicyRegistry securityPolicyRegistry(
-      @Qualifier("requestMappingHandlerMapping") RequestMappingHandlerMapping handlerMapping) {
+      @Qualifier("requestMappingHandlerMapping") RequestMappingHandlerMapping handlerMapping,
+      @Value("${springdoc.api-docs.path}") String specPath) {
     return SecurityPolicyRouteCollector.collect(
         handlerMapping,
-        REQUIRED_AUTH,
+        FALLBACK_AUTH_TYPE,
         List.of(
-            SecurityPolicyRoute.explicit(null, "/actuator/**", PUBLIC),
-            SecurityPolicyRoute.explicit(null, "/error", PUBLIC),
+            publicRoute("/actuator/**"),
+            publicRoute("/error"),
             // API 스펙은 클라이언트 개발자가 인증 없이 받아갈 수 있어야 한다
-            SecurityPolicyRoute.explicit(null, "/openapi.product.json", PUBLIC)));
+            publicRoute(specPath)));
+  }
+
+  /** HTTP 메서드를 구분하지 않고 전체 공개하는 경로. */
+  private static SecurityPolicyRoute publicRoute(String pattern) {
+    return SecurityPolicyRoute.explicit(null, pattern, PUBLIC);
   }
 }

--- a/bottlenote-product-api/src/main/resources/application.yml
+++ b/bottlenote-product-api/src/main/resources/application.yml
@@ -62,6 +62,13 @@ bottlenote:
     visitor-telemetry:
       enabled: false
 
+# OpenAPI 문서 (스펙 JSON만 노출하고 swagger-ui는 사용하지 않는다)
+springdoc:
+  api-docs:
+    path: /openapi.product.json
+  swagger-ui:
+    enabled: false
+
 # Spring Security
 security:
   jwt:

--- a/bottlenote-product-api/src/main/resources/application.yml
+++ b/bottlenote-product-api/src/main/resources/application.yml
@@ -68,6 +68,8 @@ springdoc:
     path: /openapi.product.json
   swagger-ui:
     enabled: false
+  # 응답은 모두 JSON이므로 @Content마다 미디어 타입을 적지 않는다
+  default-produces-media-type: application/json
 
 # Spring Security
 security:

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -1,0 +1,91 @@
+package app.bottlenote.global.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("integration")
+@DisplayName("[integration] OpenAPI 스펙 문서 노출")
+class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
+
+  /**
+   * 공통 응답 형식을 쓰지 않고 DTO를 그대로 내보내는 엔드포인트.
+   *
+   * <p>이 목록은 예외를 허용하기 위한 것이 아니라 예외를 고정하기 위한 것이다. 여기 없는 엔드포인트가 공통 형식을 벗어나면 아래 검사가 실패한다.
+   */
+  private static final Set<String> BARE_RESPONSE_OPERATIONS =
+      Set.of("GET /api/v2/auth/apple/nonce", "POST /api/v2/auth/apple", "POST /api/v2/auth/kakao");
+
+  private static final List<String> ENVELOPE_FIELDS =
+      List.of("success", "code", "data", "errors", "meta");
+
+  @Test
+  @DisplayName("인증 없이 스펙 문서를 조회할 수 있다")
+  void 인증_없이_스펙_문서를_조회할_수_있다() {
+    assertThat(mockMvcTester.get().uri(SPEC_PATH))
+        .hasStatusOk()
+        .bodyJson()
+        .extractingPath("$.info.title")
+        .isEqualTo("보틀노트 Product API");
+  }
+
+  @Test
+  @DisplayName("스펙 문서는 OpenAPI 3.1 형식이다")
+  void 스펙_문서는_OpenAPI_3_1_형식이다() {
+    assertThat(mockMvcTester.get().uri(SPEC_PATH))
+        .hasStatusOk()
+        .bodyJson()
+        .extractingPath("$.openapi")
+        .asString()
+        .startsWith("3.1");
+  }
+
+  @Test
+  @DisplayName("swagger-ui는 비활성화되어 접근할 수 없다")
+  void swagger_ui는_비활성화되어_접근할_수_없다() {
+    var result = mockMvcTester.get().uri("/swagger-ui/index.html").exchange();
+
+    assertThat(result.getResponse().getStatus()).isNotEqualTo(200);
+  }
+
+  @Test
+  @DisplayName("공통 형식을 쓰는 엔드포인트의 성공 응답은 공통 필드를 갖는다")
+  void 공통_형식을_쓰는_응답은_공통_필드를_갖는다() throws Exception {
+    var envelopeOperations =
+        operationsOf(fetchSpec()).stream().filter(operation -> !isBare(operation)).toList();
+
+    assertThat(envelopeOperations).isNotEmpty();
+    assertThat(envelopeOperations)
+        .allSatisfy(
+            operation ->
+                assertThat(fieldNamesOf(operation.successSchema()))
+                    .withFailMessage("%s 의 성공 응답이 공통 형식이 아닙니다", operation)
+                    .containsExactlyInAnyOrderElementsOf(ENVELOPE_FIELDS));
+  }
+
+  @Test
+  @DisplayName("공통 형식을 쓰지 않는 엔드포인트는 응답 본문이 곧 DTO다")
+  void 공통_형식을_쓰지_않는_응답은_DTO를_직접_가리킨다() throws Exception {
+    var bareOperations = operationsOf(fetchSpec()).stream().filter(this::isBare).toList();
+
+    assertThat(bareOperations).hasSameSizeAs(BARE_RESPONSE_OPERATIONS);
+    assertThat(bareOperations)
+        .allSatisfy(
+            operation -> {
+              var schema = operation.successSchema();
+              assertThat(schema.has("$ref"))
+                  .withFailMessage("%s 의 응답이 DTO를 가리키지 않습니다", operation)
+                  .isTrue();
+              assertThat(fieldNamesOf(schema)).doesNotContainAnyElementsOf(ENVELOPE_FIELDS);
+            });
+  }
+
+  private boolean isBare(SpecOperation operation) {
+    return BARE_RESPONSE_OPERATIONS.contains(
+        "%s %s".formatted(operation.method().toUpperCase(), operation.path()));
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -54,7 +54,7 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("공통 형식을 쓰는 엔드포인트의 성공 응답은 공통 필드를 갖는다")
-  void 공통_형식을_쓰는_응답은_공통_필드를_갖는다() throws Exception {
+  void 공통_형식을_쓰는_응답은_공통_필드를_갖는다() {
     var envelopeOperations =
         operationsOf(fetchSpec()).stream().filter(operation -> !isBare(operation)).toList();
 
@@ -69,7 +69,7 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("공통 형식을 쓰지 않는 엔드포인트는 응답 본문이 곧 DTO다")
-  void 공통_형식을_쓰지_않는_응답은_DTO를_직접_가리킨다() throws Exception {
+  void 공통_형식을_쓰지_않는_응답은_DTO를_직접_가리킨다() {
     var bareOperations = operationsOf(fetchSpec()).stream().filter(this::isBare).toList();
 
     assertThat(bareOperations).hasSameSizeAs(BARE_RESPONSE_OPERATIONS);

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -85,7 +85,6 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
   }
 
   private boolean isBare(SpecOperation operation) {
-    return BARE_RESPONSE_OPERATIONS.contains(
-        "%s %s".formatted(operation.method().toUpperCase(), operation.path()));
+    return BARE_RESPONSE_OPERATIONS.contains(operation.endpoint());
   }
 }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -62,7 +62,7 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
     assertThat(envelopeOperations)
         .allSatisfy(
             operation ->
-                assertThat(fieldNamesOf(operation.successSchema()))
+                assertThat(propertyNamesOf(operation.successSchema()))
                     .withFailMessage("%s 의 성공 응답이 공통 형식이 아닙니다", operation)
                     .containsExactlyInAnyOrderElementsOf(ENVELOPE_FIELDS));
   }
@@ -80,7 +80,7 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
               assertThat(schema.has("$ref"))
                   .withFailMessage("%s 의 응답이 DTO를 가리키지 않습니다", operation)
                   .isTrue();
-              assertThat(fieldNamesOf(schema)).doesNotContainAnyElementsOf(ENVELOPE_FIELDS);
+              assertThat(propertyNamesOf(schema)).doesNotContainAnyElementsOf(ENVELOPE_FIELDS);
             });
   }
 

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSecurityRequirementTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSecurityRequirementTest.java
@@ -1,0 +1,138 @@
+package app.bottlenote.global.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.bottlenote.global.annotation.SecurityPolicy.AuthType;
+import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector;
+import app.global.security.SecurityPolicyConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/** 문서에 표시된 인증 요구가 실제 보안 정책과 어긋나지 않는지 검사한다. */
+@Tag("integration")
+@DisplayName("[integration] OpenAPI 인증 요구 표시")
+class OpenApiSecurityRequirementTest extends OpenApiSpecTestSupport {
+
+  private static final String BEARER_AUTH = "bearerAuth";
+
+  @Autowired
+  @Qualifier("requestMappingHandlerMapping")
+  private RequestMappingHandlerMapping handlerMapping;
+
+  @Test
+  @DisplayName("문서의 토큰 요구는 실제 인증 정책과 일치한다")
+  void 문서의_토큰_요구가_실제_정책과_일치한다() throws Exception {
+    var policies = authTypesByEndpoint();
+    var operations = operationsOf(fetchSpec());
+
+    // 경로 매칭이 실패하면 아래 검사가 조용히 비어버리므로 먼저 고정한다
+    var unmatched =
+        operations.stream()
+            .map(SpecOperation::endpoint)
+            .filter(endpoint -> !policies.containsKey(endpoint))
+            .toList();
+    assertThat(unmatched)
+        .withFailMessage("실제 정책을 찾지 못한 엔드포인트가 있습니다:%n%s", joined(unmatched))
+        .isEmpty();
+
+    var violations =
+        operations.stream()
+            .filter(
+                operation ->
+                    requiresBearer(operation)
+                        != (policies.get(operation.endpoint()) != AuthType.PUBLIC))
+            .map(
+                operation ->
+                    "%s (정책 %s)"
+                        .formatted(operation.endpoint(), policies.get(operation.endpoint())))
+            .toList();
+
+    assertThat(violations)
+        .withFailMessage("문서의 토큰 요구가 실제 정책과 다릅니다:%n%s", joined(violations))
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("토큰을 요구하는 엔드포인트가 문서에 실제로 존재한다")
+  void 토큰을_요구하는_엔드포인트가_존재한다() throws Exception {
+    var requiring = operationsOf(fetchSpec()).stream().filter(this::requiresBearer).toList();
+
+    assertThat(requiring)
+        .withFailMessage("토큰 요구가 하나도 실리지 않았습니다. 보안 스키마가 연결되지 않은 상태입니다")
+        .isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("토큰이 있으면 쓰고 없어도 동작하는 엔드포인트는 익명 호출도 허용으로 표시된다")
+  void 선택적_인증은_익명_호출도_허용으로_표시된다() throws Exception {
+    var policies = authTypesByEndpoint();
+
+    var violations =
+        operationsOf(fetchSpec()).stream()
+            .filter(operation -> policies.get(operation.endpoint()) == AuthType.OPTIONAL_AUTH)
+            .filter(operation -> !allowsAnonymous(operation))
+            .map(SpecOperation::endpoint)
+            .toList();
+
+    assertThat(violations)
+        .withFailMessage("선택적 인증인데 익명 호출 허용이 빠졌습니다:%n%s", joined(violations))
+        .isEmpty();
+  }
+
+  /** 실제 보안 정책이 판정한 엔드포인트별 인증 방식. */
+  private Map<String, AuthType> authTypesByEndpoint() {
+    Map<String, AuthType> policies = new HashMap<>();
+    handlerMapping
+        .getHandlerMethods()
+        .forEach(
+            (mapping, handlerMethod) -> {
+              var patterns = mapping.getPathPatternsCondition();
+              if (patterns == null) {
+                return;
+              }
+              AuthType auth =
+                  SecurityPolicyRouteCollector.resolveAuthType(
+                      handlerMethod, SecurityPolicyConfig.FALLBACK_AUTH_TYPE);
+              mapping
+                  .getMethodsCondition()
+                  .getMethods()
+                  .forEach(
+                      method ->
+                          patterns
+                              .getPatterns()
+                              .forEach(
+                                  pattern ->
+                                      policies.put(
+                                          "%s %s"
+                                              .formatted(method.name(), pattern.getPatternString()),
+                                          auth)));
+            });
+    return policies;
+  }
+
+  private boolean requiresBearer(SpecOperation operation) {
+    for (JsonNode item : operation.security()) {
+      if (item.has(BEARER_AUTH)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** 토큰 없이 호출해도 된다는 표시(빈 요구사항)를 함께 갖는지. */
+  private boolean allowsAnonymous(SpecOperation operation) {
+    for (JsonNode item : operation.security()) {
+      if (item.isEmpty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSecurityRequirementTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSecurityRequirementTest.java
@@ -28,7 +28,7 @@ class OpenApiSecurityRequirementTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("문서의 토큰 요구는 실제 인증 정책과 일치한다")
-  void 문서의_토큰_요구가_실제_정책과_일치한다() throws Exception {
+  void 문서의_토큰_요구가_실제_정책과_일치한다() {
     var policies = authTypesByEndpoint();
     var operations = operationsOf(fetchSpec());
 
@@ -61,7 +61,7 @@ class OpenApiSecurityRequirementTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("토큰을 요구하는 엔드포인트가 문서에 실제로 존재한다")
-  void 토큰을_요구하는_엔드포인트가_존재한다() throws Exception {
+  void 토큰을_요구하는_엔드포인트가_존재한다() {
     var requiring = operationsOf(fetchSpec()).stream().filter(this::requiresBearer).toList();
 
     assertThat(requiring)
@@ -71,7 +71,7 @@ class OpenApiSecurityRequirementTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("토큰이 있으면 쓰고 없어도 동작하는 엔드포인트는 익명 호출도 허용으로 표시된다")
-  void 선택적_인증은_익명_호출도_허용으로_표시된다() throws Exception {
+  void 선택적_인증은_익명_호출도_허용으로_표시된다() {
     var policies = authTypesByEndpoint();
 
     var violations =

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
@@ -1,0 +1,103 @@
+package app.bottlenote.global.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 스펙 문서의 품질을 전수 검사한다.
+ *
+ * <p>문서 어노테이션을 붙이지 않은 컨트롤러는 {@link #PENDING_TAGS}에 등재해 검사를 건너뛴다. 도메인 문서화를 마칠 때마다 해당 항목을 지우면 그 시점부터
+ * 이 테스트가 감시를 시작한다. 목록이 비면 전수 검사가 예외 없이 통과하는 상태가 된다.
+ */
+@Tag("integration")
+@DisplayName("[integration] OpenAPI 스펙 품질")
+class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
+
+  /**
+   * 아직 문서 어노테이션을 붙이지 않은 컨트롤러의 기본 태그 이름.
+   *
+   * <p>springdoc은 태그를 지정하지 않으면 컨트롤러 클래스명을 kebab-case로 바꿔 태그로 쓴다. 이 목록이 곧 남은 작업량이다.
+   */
+  private static final Set<String> PENDING_TAGS = Set.of();
+
+  @Test
+  @DisplayName("문서화한 엔드포인트의 태그는 클래스 이름이 아닌 도메인 이름이다")
+  void 태그는_클래스_이름이_아니다() throws Exception {
+    var violations =
+        documentedOperations().stream()
+            .filter(operation -> operation.tag().endsWith("-controller"))
+            .map(SpecOperation::toString)
+            .toList();
+
+    assertThat(violations)
+        .withFailMessage(
+            "태그가 컨트롤러 클래스명으로 남아 있습니다. 도메인 이름을 지정하세요:%n%s", String.join("%n", violations))
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("문서화한 엔드포인트는 모두 요약 문장을 갖는다")
+  void 모든_엔드포인트가_요약을_갖는다() throws Exception {
+    var violations =
+        documentedOperations().stream()
+            .filter(operation -> operation.summary().isBlank())
+            .map(SpecOperation::toString)
+            .toList();
+
+    assertThat(violations)
+        .withFailMessage("요약(summary)이 없습니다:%n%s", String.join("%n", violations))
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("요약은 메서드 이름을 그대로 옮긴 것이 아니다")
+  void 요약은_메서드_이름이_아니다() throws Exception {
+    var violations =
+        documentedOperations().stream()
+            .filter(operation -> operation.summary().equals(operation.operationId()))
+            .map(SpecOperation::toString)
+            .toList();
+
+    assertThat(violations)
+        .withFailMessage("요약이 메서드 이름과 같습니다. 사람이 읽는 문장으로 쓰세요:%n%s", String.join("%n", violations))
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("문서화한 엔드포인트의 응답 data는 실제 타입을 가리킨다")
+  void 응답_data가_실제_타입을_가리킨다() throws Exception {
+    var violations =
+        documentedOperations().stream()
+            .filter(SpecOperation::hasEmptyDataSchema)
+            .map(SpecOperation::toString)
+            .toList();
+
+    assertThat(violations)
+        .withFailMessage("응답 data가 빈 object입니다. 담기는 타입을 알려주세요:%n%s", String.join("%n", violations))
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("미문서화 목록에 이미 문서화된 태그가 남아 있지 않다")
+  void 미문서화_목록이_최신_상태다() throws Exception {
+    var liveTags = operationsOf(fetchSpec()).stream().map(SpecOperation::tag).toList();
+    var stale = PENDING_TAGS.stream().filter(tag -> !liveTags.contains(tag)).sorted().toList();
+
+    assertThat(stale)
+        .withFailMessage(
+            "이미 문서화된 태그가 미문서화 목록에 남아 있습니다. PENDING_TAGS에서 지우세요:%n%s", String.join("%n", stale))
+        .isEmpty();
+  }
+
+  /** 미문서화 목록에 없는, 즉 검사 대상인 엔드포인트. */
+  private List<SpecOperation> documentedOperations() throws Exception {
+    return operationsOf(fetchSpec()).stream()
+        .filter(operation -> !PENDING_TAGS.contains(operation.tag()))
+        .toList();
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -18,10 +19,13 @@ import org.junit.jupiter.api.Test;
 @DisplayName("[integration] OpenAPI 스펙 품질")
 class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
 
+  /** OpenAPI가 components 하위 키에 허용하는 형식. */
+  private static final Pattern COMPONENT_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
+
   /**
    * 아직 문서 어노테이션을 붙이지 않은 컨트롤러의 기본 태그 이름.
    *
-   * <p>springdoc은 태그를 지정하지 않으면 컨트롤러 클래스명을 kebab-case로 바꿔 태그로 쓴다. 이 목록이 곧 남은 작업량이다.
+   * <p>springdoc은 태그를 지정하지 않으면 컨트롤러 클래스명을 kebab-case로 바꿔 태그로 쓴다. 목록이 비었다는 것은 전수 문서화가 끝났다는 뜻이다.
    */
   private static final Set<String> PENDING_TAGS = Set.of();
 
@@ -79,6 +83,29 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
 
     assertThat(violations)
         .withFailMessage("응답 data가 빈 object입니다. 담기는 타입을 알려주세요:%n%s", String.join("%n", violations))
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("components 하위 이름은 OpenAPI가 허용하는 식별자 형식이다")
+  void components_이름이_식별자_형식이다() throws Exception {
+    var components = fetchSpec().at("/components");
+    var violations =
+        fieldNamesOf(components).stream()
+            .flatMap(
+                group ->
+                    fieldNamesOf(components, group).stream()
+                        .filter(name -> !COMPONENT_NAME_PATTERN.matcher(name).matches())
+                        .map(name -> group + "." + name))
+            .toList();
+
+    assertThat(violations)
+        .withFailMessage(
+            """
+            components 하위 이름이 OpenAPI 규칙(%s)을 위반합니다. \
+            @Schema(name=...)이나 보안 스키마 이름에는 영문 식별자를 쓰고 한국어는 title이나 \
+            description으로 옮기세요. 위반하면 Scalar 같은 문서 도구가 스펙을 거부합니다:%n%s""",
+            COMPONENT_NAME_PATTERN.pattern(), String.join("%n", violations))
         .isEmpty();
   }
 

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
@@ -2,7 +2,6 @@ package app.bottlenote.global.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
@@ -75,9 +74,5 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
         operationsOf(fetchSpec()).stream().filter(violating).map(SpecOperation::toString).toList();
 
     assertThat(violations).withFailMessage("%s:%n%s", reason, joined(violations)).isEmpty();
-  }
-
-  private String joined(List<String> violations) {
-    return String.join(System.lineSeparator(), violations);
   }
 }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
@@ -18,7 +18,7 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("엔드포인트의 태그는 클래스 이름이 아닌 도메인 이름이다")
-  void 태그는_클래스_이름이_아니다() throws Exception {
+  void 태그는_클래스_이름이_아니다() {
     assertNoOperation(
         "태그가 컨트롤러 클래스명으로 남아 있습니다. 도메인 이름을 지정하세요",
         operation -> operation.tag().endsWith("-controller"));
@@ -26,13 +26,13 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("모든 엔드포인트는 요약 문장을 갖는다")
-  void 모든_엔드포인트가_요약을_갖는다() throws Exception {
+  void 모든_엔드포인트가_요약을_갖는다() {
     assertNoOperation("요약(summary)이 없습니다", operation -> operation.summary().isBlank());
   }
 
   @Test
   @DisplayName("요약은 메서드 이름을 그대로 옮긴 것이 아니다")
-  void 요약은_메서드_이름이_아니다() throws Exception {
+  void 요약은_메서드_이름이_아니다() {
     assertNoOperation(
         "요약이 메서드 이름과 같습니다. 사람이 읽는 문장으로 쓰세요",
         operation -> operation.summary().equals(operation.operationId()));
@@ -40,13 +40,13 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
 
   @Test
   @DisplayName("응답 data는 실제 타입을 가리킨다")
-  void 응답_data가_실제_타입을_가리킨다() throws Exception {
+  void 응답_data가_실제_타입을_가리킨다() {
     assertNoOperation("응답 data가 빈 object입니다. 담기는 타입을 알려주세요", SpecOperation::hasEmptyDataSchema);
   }
 
   @Test
   @DisplayName("components 하위 이름은 OpenAPI가 허용하는 식별자 형식이다")
-  void components_이름이_식별자_형식이다() throws Exception {
+  void components_이름이_식별자_형식이다() {
     var components = fetchSpec().at("/components");
     var violations =
         components.properties().stream()
@@ -68,8 +68,7 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
   }
 
   /** 조건을 위반하는 엔드포인트가 하나도 없어야 한다. */
-  private void assertNoOperation(String reason, Predicate<SpecOperation> violating)
-      throws Exception {
+  private void assertNoOperation(String reason, Predicate<SpecOperation> violating) {
     var violations =
         operationsOf(fetchSpec()).stream().filter(violating).map(SpecOperation::toString).toList();
 

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecQualityTest.java
@@ -3,18 +3,13 @@ package app.bottlenote.global.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-/**
- * 스펙 문서의 품질을 전수 검사한다.
- *
- * <p>문서 어노테이션을 붙이지 않은 컨트롤러는 {@link #PENDING_TAGS}에 등재해 검사를 건너뛴다. 도메인 문서화를 마칠 때마다 해당 항목을 지우면 그 시점부터
- * 이 테스트가 감시를 시작한다. 목록이 비면 전수 검사가 예외 없이 통과하는 상태가 된다.
- */
+/** 스펙 문서의 품질을 전수 검사한다. 예외를 두지 않으므로 모든 엔드포인트가 검사 대상이다. */
 @Tag("integration")
 @DisplayName("[integration] OpenAPI 스펙 품질")
 class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
@@ -22,68 +17,32 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
   /** OpenAPI가 components 하위 키에 허용하는 형식. */
   private static final Pattern COMPONENT_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
 
-  /**
-   * 아직 문서 어노테이션을 붙이지 않은 컨트롤러의 기본 태그 이름.
-   *
-   * <p>springdoc은 태그를 지정하지 않으면 컨트롤러 클래스명을 kebab-case로 바꿔 태그로 쓴다. 목록이 비었다는 것은 전수 문서화가 끝났다는 뜻이다.
-   */
-  private static final Set<String> PENDING_TAGS = Set.of();
-
   @Test
-  @DisplayName("문서화한 엔드포인트의 태그는 클래스 이름이 아닌 도메인 이름이다")
+  @DisplayName("엔드포인트의 태그는 클래스 이름이 아닌 도메인 이름이다")
   void 태그는_클래스_이름이_아니다() throws Exception {
-    var violations =
-        documentedOperations().stream()
-            .filter(operation -> operation.tag().endsWith("-controller"))
-            .map(SpecOperation::toString)
-            .toList();
-
-    assertThat(violations)
-        .withFailMessage(
-            "태그가 컨트롤러 클래스명으로 남아 있습니다. 도메인 이름을 지정하세요:%n%s", String.join("%n", violations))
-        .isEmpty();
+    assertNoOperation(
+        "태그가 컨트롤러 클래스명으로 남아 있습니다. 도메인 이름을 지정하세요",
+        operation -> operation.tag().endsWith("-controller"));
   }
 
   @Test
-  @DisplayName("문서화한 엔드포인트는 모두 요약 문장을 갖는다")
+  @DisplayName("모든 엔드포인트는 요약 문장을 갖는다")
   void 모든_엔드포인트가_요약을_갖는다() throws Exception {
-    var violations =
-        documentedOperations().stream()
-            .filter(operation -> operation.summary().isBlank())
-            .map(SpecOperation::toString)
-            .toList();
-
-    assertThat(violations)
-        .withFailMessage("요약(summary)이 없습니다:%n%s", String.join("%n", violations))
-        .isEmpty();
+    assertNoOperation("요약(summary)이 없습니다", operation -> operation.summary().isBlank());
   }
 
   @Test
   @DisplayName("요약은 메서드 이름을 그대로 옮긴 것이 아니다")
   void 요약은_메서드_이름이_아니다() throws Exception {
-    var violations =
-        documentedOperations().stream()
-            .filter(operation -> operation.summary().equals(operation.operationId()))
-            .map(SpecOperation::toString)
-            .toList();
-
-    assertThat(violations)
-        .withFailMessage("요약이 메서드 이름과 같습니다. 사람이 읽는 문장으로 쓰세요:%n%s", String.join("%n", violations))
-        .isEmpty();
+    assertNoOperation(
+        "요약이 메서드 이름과 같습니다. 사람이 읽는 문장으로 쓰세요",
+        operation -> operation.summary().equals(operation.operationId()));
   }
 
   @Test
-  @DisplayName("문서화한 엔드포인트의 응답 data는 실제 타입을 가리킨다")
+  @DisplayName("응답 data는 실제 타입을 가리킨다")
   void 응답_data가_실제_타입을_가리킨다() throws Exception {
-    var violations =
-        documentedOperations().stream()
-            .filter(SpecOperation::hasEmptyDataSchema)
-            .map(SpecOperation::toString)
-            .toList();
-
-    assertThat(violations)
-        .withFailMessage("응답 data가 빈 object입니다. 담기는 타입을 알려주세요:%n%s", String.join("%n", violations))
-        .isEmpty();
+    assertNoOperation("응답 data가 빈 object입니다. 담기는 타입을 알려주세요", SpecOperation::hasEmptyDataSchema);
   }
 
   @Test
@@ -91,12 +50,12 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
   void components_이름이_식별자_형식이다() throws Exception {
     var components = fetchSpec().at("/components");
     var violations =
-        fieldNamesOf(components).stream()
+        components.properties().stream()
             .flatMap(
                 group ->
-                    fieldNamesOf(components, group).stream()
+                    childNamesOf(group.getValue())
                         .filter(name -> !COMPONENT_NAME_PATTERN.matcher(name).matches())
-                        .map(name -> group + "." + name))
+                        .map(name -> group.getKey() + "." + name))
             .toList();
 
     assertThat(violations)
@@ -105,26 +64,20 @@ class OpenApiSpecQualityTest extends OpenApiSpecTestSupport {
             components 하위 이름이 OpenAPI 규칙(%s)을 위반합니다. \
             @Schema(name=...)이나 보안 스키마 이름에는 영문 식별자를 쓰고 한국어는 title이나 \
             description으로 옮기세요. 위반하면 Scalar 같은 문서 도구가 스펙을 거부합니다:%n%s""",
-            COMPONENT_NAME_PATTERN.pattern(), String.join("%n", violations))
+            COMPONENT_NAME_PATTERN.pattern(), joined(violations))
         .isEmpty();
   }
 
-  @Test
-  @DisplayName("미문서화 목록에 이미 문서화된 태그가 남아 있지 않다")
-  void 미문서화_목록이_최신_상태다() throws Exception {
-    var liveTags = operationsOf(fetchSpec()).stream().map(SpecOperation::tag).toList();
-    var stale = PENDING_TAGS.stream().filter(tag -> !liveTags.contains(tag)).sorted().toList();
+  /** 조건을 위반하는 엔드포인트가 하나도 없어야 한다. */
+  private void assertNoOperation(String reason, Predicate<SpecOperation> violating)
+      throws Exception {
+    var violations =
+        operationsOf(fetchSpec()).stream().filter(violating).map(SpecOperation::toString).toList();
 
-    assertThat(stale)
-        .withFailMessage(
-            "이미 문서화된 태그가 미문서화 목록에 남아 있습니다. PENDING_TAGS에서 지우세요:%n%s", String.join("%n", stale))
-        .isEmpty();
+    assertThat(violations).withFailMessage("%s:%n%s", reason, joined(violations)).isEmpty();
   }
 
-  /** 미문서화 목록에 없는, 즉 검사 대상인 엔드포인트. */
-  private List<SpecOperation> documentedOperations() throws Exception {
-    return operationsOf(fetchSpec()).stream()
-        .filter(operation -> !PENDING_TAGS.contains(operation.tag()))
-        .toList();
+  private String joined(List<String> violations) {
+    return String.join(System.lineSeparator(), violations);
   }
 }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
@@ -39,6 +39,13 @@ abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
     return operations;
   }
 
+  /** 지정한 자식 노드의 필드 이름 목록. */
+  protected List<String> fieldNamesOf(JsonNode node, String childName) {
+    List<String> names = new ArrayList<>();
+    node.path(childName).fieldNames().forEachRemaining(names::add);
+    return names;
+  }
+
   protected List<String> fieldNamesOf(JsonNode node) {
     List<String> names = new ArrayList<>();
     node.path("properties").fieldNames().forEachRemaining(names::add);

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
@@ -41,6 +41,11 @@ abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
     return operations;
   }
 
+  /** 위반 목록을 실패 메시지에 담을 형태로 잇는다. */
+  protected String joined(List<String> violations) {
+    return String.join(System.lineSeparator(), violations);
+  }
+
   /** 노드의 직접 자식 이름. */
   protected Stream<String> childNamesOf(JsonNode node) {
     return node.properties().stream().map(Map.Entry::getKey);
@@ -61,6 +66,16 @@ abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
         return MissingNode.getInstance();
       }
       return content.properties().iterator().next().getValue().path("schema");
+    }
+
+    /** HTTP 메서드와 경로를 합친 식별자. */
+    String endpoint() {
+      return "%s %s".formatted(method.toUpperCase(), path);
+    }
+
+    /** 문서에 선언된 보안 요구사항. 선언이 없으면 missing 노드. */
+    JsonNode security() {
+      return definition.path("security");
     }
 
     String tag() {

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
@@ -5,7 +5,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import app.bottlenote.IntegrationTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
-import java.util.ArrayList;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -14,31 +15,26 @@ import java.util.stream.Stream;
 abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
 
   protected static final String SPEC_PATH = "/openapi.product.json";
-  protected static final String JSON_SCHEMA = "/content/application~1json/schema";
 
-  protected JsonNode fetchSpec() throws Exception {
+  protected JsonNode fetchSpec() {
     var result = mockMvcTester.get().uri(SPEC_PATH).exchange();
-    return mapper.readTree(result.getResponse().getContentAsString(UTF_8));
+    try {
+      return mapper.readTree(result.getResponse().getContentAsString(UTF_8));
+    } catch (IOException e) {
+      throw new UncheckedIOException("OpenAPI 스펙을 읽지 못했습니다", e);
+    }
   }
 
   /** 스펙의 모든 엔드포인트를 평탄하게 펼친다. */
   protected List<SpecOperation> operationsOf(JsonNode spec) {
-    List<SpecOperation> operations = new ArrayList<>();
-    spec.at("/paths")
-        .properties()
-        .forEach(
-            pathEntry ->
-                pathEntry
-                    .getValue()
-                    .properties()
-                    .forEach(
-                        methodEntry ->
-                            operations.add(
-                                new SpecOperation(
-                                    pathEntry.getKey(),
-                                    methodEntry.getKey(),
-                                    methodEntry.getValue()))));
-    return operations;
+    return spec.at("/paths").properties().stream()
+        .flatMap(
+            path ->
+                path.getValue().properties().stream()
+                    .map(
+                        method ->
+                            new SpecOperation(path.getKey(), method.getKey(), method.getValue())))
+        .toList();
   }
 
   /** 위반 목록을 실패 메시지에 담을 형태로 잇는다. */
@@ -58,6 +54,8 @@ abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
 
   /** 스펙에 실린 하나의 엔드포인트. */
   protected record SpecOperation(String path, String method, JsonNode definition) {
+
+    private static final String OBJECT_TYPE = "object";
 
     /** 200 응답 본문의 스키마. 공통 형식이면 그 형식, 아니면 DTO 참조. */
     JsonNode successSchema() {
@@ -91,13 +89,14 @@ abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
       return definition.path("operationId").asText("");
     }
 
-    JsonNode dataSchema() {
-      return definition.at("/responses/200" + JSON_SCHEMA + "/properties/data");
+    /** 공통 형식의 data 자리에 담긴 스키마. */
+    private JsonNode dataSchema() {
+      return successSchema().path("properties").path("data");
     }
 
     boolean hasEmptyDataSchema() {
       JsonNode data = dataSchema();
-      return "object".equals(data.path("type").asText())
+      return OBJECT_TYPE.equals(data.path("type").asText())
           && !data.has("$ref")
           && !data.has("properties");
     }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 /** 생성된 OpenAPI 스펙을 읽어 검사하는 테스트들의 공통 기반. */
 abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
@@ -39,17 +41,14 @@ abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
     return operations;
   }
 
-  /** 지정한 자식 노드의 필드 이름 목록. */
-  protected List<String> fieldNamesOf(JsonNode node, String childName) {
-    List<String> names = new ArrayList<>();
-    node.path(childName).fieldNames().forEachRemaining(names::add);
-    return names;
+  /** 노드의 직접 자식 이름. */
+  protected Stream<String> childNamesOf(JsonNode node) {
+    return node.properties().stream().map(Map.Entry::getKey);
   }
 
-  protected List<String> fieldNamesOf(JsonNode node) {
-    List<String> names = new ArrayList<>();
-    node.path("properties").fieldNames().forEachRemaining(names::add);
-    return names;
+  /** 스키마 노드가 선언한 property 이름. */
+  protected List<String> propertyNamesOf(JsonNode node) {
+    return childNamesOf(node.path("properties")).toList();
   }
 
   /** 스펙에 실린 하나의 엔드포인트. */

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
@@ -1,0 +1,89 @@
+package app.bottlenote.global.integration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import app.bottlenote.IntegrationTestSupport;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import java.util.ArrayList;
+import java.util.List;
+
+/** 생성된 OpenAPI 스펙을 읽어 검사하는 테스트들의 공통 기반. */
+abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
+
+  protected static final String SPEC_PATH = "/openapi.product.json";
+  protected static final String JSON_SCHEMA = "/content/application~1json/schema";
+
+  protected JsonNode fetchSpec() throws Exception {
+    var result = mockMvcTester.get().uri(SPEC_PATH).exchange();
+    return mapper.readTree(result.getResponse().getContentAsString(UTF_8));
+  }
+
+  /** 스펙의 모든 엔드포인트를 평탄하게 펼친다. */
+  protected List<SpecOperation> operationsOf(JsonNode spec) {
+    List<SpecOperation> operations = new ArrayList<>();
+    spec.at("/paths")
+        .properties()
+        .forEach(
+            pathEntry ->
+                pathEntry
+                    .getValue()
+                    .properties()
+                    .forEach(
+                        methodEntry ->
+                            operations.add(
+                                new SpecOperation(
+                                    pathEntry.getKey(),
+                                    methodEntry.getKey(),
+                                    methodEntry.getValue()))));
+    return operations;
+  }
+
+  protected List<String> fieldNamesOf(JsonNode node) {
+    List<String> names = new ArrayList<>();
+    node.path("properties").fieldNames().forEachRemaining(names::add);
+    return names;
+  }
+
+  /** 스펙에 실린 하나의 엔드포인트. */
+  protected record SpecOperation(String path, String method, JsonNode definition) {
+
+    /** 200 응답 본문의 스키마. 공통 형식이면 그 형식, 아니면 DTO 참조. */
+    JsonNode successSchema() {
+      JsonNode content = definition.at("/responses/200/content");
+      if (content.isMissingNode() || content.isEmpty()) {
+        return MissingNode.getInstance();
+      }
+      return content.properties().iterator().next().getValue().path("schema");
+    }
+
+    String tag() {
+      JsonNode tags = definition.at("/tags");
+      return tags.isArray() && !tags.isEmpty() ? tags.get(0).asText() : "";
+    }
+
+    String summary() {
+      return definition.path("summary").asText("");
+    }
+
+    String operationId() {
+      return definition.path("operationId").asText("");
+    }
+
+    JsonNode dataSchema() {
+      return definition.at("/responses/200" + JSON_SCHEMA + "/properties/data");
+    }
+
+    boolean hasEmptyDataSchema() {
+      JsonNode data = dataSchema();
+      return "object".equals(data.path("type").asText())
+          && !data.has("$ref")
+          && !data.has("properties");
+    }
+
+    @Override
+    public String toString() {
+      return "%s %s (%s)".formatted(method.toUpperCase(), path, tag());
+    }
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/docs/DEPRECATED.md
+++ b/bottlenote-product-api/src/test/java/app/docs/DEPRECATED.md
@@ -1,0 +1,30 @@
+# 삭제 예정 — RestDocs 기반 문서화
+
+이 디렉터리의 문서화 테스트는 **삭제 예정**입니다. 새 엔드포인트를 추가할 때 여기에 테스트를 추가하지 마세요.
+
+## 대체 수단
+
+API 문서는 springdoc OpenAPI 어노테이션으로 생성합니다.
+
+- 스펙: `GET /openapi.product.json` (앱 실행 중 조회)
+- 문서 작성 위치: `app.bottlenote.{도메인}.controller.docs.{컨트롤러}ApiDocs`
+- 품질 검증: `OpenApiSpecQualityTest` — 태그·요약·응답 스키마 누락을 전수 검사합니다
+
+새 엔드포인트를 만들면 해당 도메인의 `*ApiDocs`에 설명을 추가하고 컨트롤러에 어노테이션을 한 줄 붙이면 됩니다. 문서화를 빠뜨리면 `OpenApiSpecQualityTest`가 실패합니다.
+
+## 함께 삭제될 자산
+
+| 자산 | 위치 |
+|---|---|
+| 문서화 테스트 | `bottlenote-product-api/src/test/java/app/docs/**`, `app/external/docs/**` |
+| AsciiDoc 원본 | `bottlenote-product-api/src/docs/asciidoc/**` |
+| Antora 사이트 | 저장소 루트 `docs/` |
+| 의존성 | `spring-restdocs`, `restdocs-api-spec` (`gradle/libs.versions.toml`) |
+| Gradle 태스크 | `asciidoctor`, `restDocsTest`, `openapi3` |
+| 워크플로 | GitHub Pages 배포 (있는 경우) |
+
+## 왜 아직 남겨두는가
+
+두 문서 체계를 한 번에 갈아치우면 전환 기간에 문서 공백이 생깁니다. 클라이언트가 새 스펙으로 옮겨갈 시간을 두기 위해 당분간 양쪽을 함께 유지합니다. 두 체계 모두 CI에서 계속 통과해야 합니다.
+
+실제 제거 시점과 조건은 `plan/openapi-annotation-docs.md`의 가정 3·4를 참고하세요.

--- a/bottlenote-product-api/src/test/java/app/global/config/ErrorResponseSchemaTest.java
+++ b/bottlenote-product-api/src/test/java/app/global/config/ErrorResponseSchemaTest.java
@@ -1,0 +1,25 @@
+package app.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.bottlenote.global.service.meta.MetaService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("[unit] 오류 응답 예시")
+class ErrorResponseSchemaTest {
+
+  @Test
+  @DisplayName("meta 예시의 키는 실제 메타 정보의 키와 같다")
+  void meta_예시의_키가_실제와_같다() {
+    var actual = MetaService.createMetaInfo().getMetaInfos().keySet();
+
+    assertThat(ErrorResponseSchema.EXAMPLE_META.keySet())
+        .withFailMessage(
+            "문서의 meta 예시가 실제 메타 정보와 어긋납니다. 예시 %s, 실제 %s",
+            ErrorResponseSchema.EXAMPLE_META.keySet(), actual)
+        .containsExactlyInAnyOrderElementsOf(actual);
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/rule/api/ControllerLayerRules.java
+++ b/bottlenote-product-api/src/test/java/app/rule/api/ControllerLayerRules.java
@@ -10,6 +10,8 @@ import app.rule.AbstractRules;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameterizedType;
+import com.tngtech.archunit.core.domain.JavaWildcardType;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
@@ -413,6 +415,53 @@ public class ControllerLayerRules extends AbstractRules {
                   method, "메서드 이름 '" + methodName + "'은(는) 명명 규칙을 따르지 않습니다"));
         } else {
           events.add(SimpleConditionEvent.satisfied(method, "메서드 이름이 명명 규칙을 따릅니다"));
+        }
+      }
+    };
+  }
+
+  /**
+   * 컨트롤러가 응답 본문 타입을 명시하는지 검증합니다.
+   *
+   * <p>{@code ResponseEntity<?>}로 두면 스펙 생성기가 응답 타입을 알 수 없습니다. 공통 응답 형식을 쓰면 {@code
+   * ResponseEntity<GlobalResponse>}, 형식을 거치지 않고 DTO를 그대로 내보내면 그 DTO를 적습니다. 이 선언이 API 문서에서 응답 형식을
+   * 판단하는 근거이므로 와일드카드를 허용하면 문서가 실제 응답과 달라질 수 있습니다.
+   */
+  @Test
+  public void 컨트롤러_응답_타입_명시_검증() {
+    ArchRule rule =
+        methods()
+            .that()
+            .areDeclaredInClassesThat()
+            .areAnnotatedWith(RestController.class)
+            .and()
+            .arePublic()
+            .should(declareResponseBodyType())
+            .because("응답 본문 타입은 API 문서 생성의 근거이므로 ResponseEntity<?> 대신 실제 타입을 선언해야 합니다");
+
+    rule.check(importedClasses);
+  }
+
+  private ArchCondition<JavaMethod> declareResponseBodyType() {
+    return new ArchCondition<>("ResponseEntity의 본문 타입을 구체적으로 선언한다") {
+      @Override
+      public void check(JavaMethod method, ConditionEvents events) {
+        if (!method.getRawReturnType().isAssignableTo(ResponseEntity.class)) {
+          return;
+        }
+        if (!(method.getReturnType() instanceof JavaParameterizedType parameterized)) {
+          return;
+        }
+        boolean hasWildcard =
+            parameterized.getActualTypeArguments().stream()
+                .anyMatch(argument -> argument instanceof JavaWildcardType);
+        if (hasWildcard) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  method,
+                  method.getFullName() + " 이(가) ResponseEntity<?> 를 반환합니다. 실제 본문 타입을 선언하세요"));
+        } else {
+          events.add(SimpleConditionEvent.satisfied(method, "응답 본문 타입을 선언했습니다"));
         }
       }
     };

--- a/bottlenote-product-api/src/test/java/app/rule/api/ControllerLayerRules.java
+++ b/bottlenote-product-api/src/test/java/app/rule/api/ControllerLayerRules.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 /** 컨트롤러 계층의 아키텍처 규칙을 검증하는 테스트 클래스입니다. */
 @Tag("rule")
@@ -426,20 +427,32 @@ public class ControllerLayerRules extends AbstractRules {
    * <p>{@code ResponseEntity<?>}로 두면 스펙 생성기가 응답 타입을 알 수 없습니다. 공통 응답 형식을 쓰면 {@code
    * ResponseEntity<GlobalResponse>}, 형식을 거치지 않고 DTO를 그대로 내보내면 그 DTO를 적습니다. 이 선언이 API 문서에서 응답 형식을
    * 판단하는 근거이므로 와일드카드를 허용하면 문서가 실제 응답과 달라질 수 있습니다.
+   *
+   * <p>에러 응답을 만드는 {@code @RestControllerAdvice}도 같은 근거를 따르므로 함께 검사합니다.
    */
   @Test
   public void 컨트롤러_응답_타입_명시_검증() {
     ArchRule rule =
         methods()
             .that()
-            .areDeclaredInClassesThat()
-            .areAnnotatedWith(RestController.class)
-            .and()
             .arePublic()
+            .and()
+            .areDeclaredInClassesThat(respondToClients())
             .should(declareResponseBodyType())
             .because("응답 본문 타입은 API 문서 생성의 근거이므로 ResponseEntity<?> 대신 실제 타입을 선언해야 합니다");
 
     rule.check(importedClasses);
+  }
+
+  /** 클라이언트에게 응답 본문을 직접 내보내는 클래스. */
+  private DescribedPredicate<JavaClass> respondToClients() {
+    return new DescribedPredicate<>("@RestController 또는 @RestControllerAdvice 로 선언된") {
+      @Override
+      public boolean test(JavaClass javaClass) {
+        return javaClass.isAnnotatedWith(RestController.class)
+            || javaClass.isAnnotatedWith(RestControllerAdvice.class);
+      }
+    };
   }
 
   private ArchCondition<JavaMethod> declareResponseBodyType() {
@@ -450,6 +463,10 @@ public class ControllerLayerRules extends AbstractRules {
           return;
         }
         if (!(method.getReturnType() instanceof JavaParameterizedType parameterized)) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  method,
+                  method.getFullName() + " 이(가) 타입 인자 없는 ResponseEntity 를 반환합니다. 본문 타입을 선언하세요"));
           return;
         }
         boolean hasWildcard =

--- a/bottlenote-product-api/src/test/resources/application-test.yml
+++ b/bottlenote-product-api/src/test/resources/application-test.yml
@@ -60,6 +60,7 @@ springdoc:
     path: /openapi.product.json
   swagger-ui:
     enabled: false
+  default-produces-media-type: application/json
 
 # Spring Security
 security:

--- a/bottlenote-product-api/src/test/resources/application-test.yml
+++ b/bottlenote-product-api/src/test/resources/application-test.yml
@@ -54,6 +54,13 @@ app:
     allowed-origins:
       - https://bottle-note.com
 
+# OpenAPI 문서 (운영 설정과 같은 경로를 유지해 스펙을 그대로 검증한다)
+springdoc:
+  api-docs:
+    path: /openapi.product.json
+  swagger-ui:
+    enabled: false
+
 # Spring Security
 security:
   jwt:

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ subprojects {
 		systemProperty 'testcontainers.db.name', 'bottlenote_admin'
 	}
 
-	// REST Docs 테스트 (app.docs 패키지)
+	// [삭제 예정] REST Docs 테스트 (app.docs 패키지) — springdoc OpenAPI로 대체됨
 	if (project.name in ['bottlenote-product-api', 'bottlenote-admin-api']) {
 		tasks.register('restDocsTest', Test) {
 			description = 'REST Docs snippets 생성을 위한 테스트'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,8 @@ archunit = "1.4.0"
 # Documentation
 spring-restdocs = "3.0.3"
 restdocs-api-spec = "0.19.4"
+# 2.8.x가 Spring Boot 3.x 지원 라인 (3.0.x는 Boot 4 전용)
+springdoc-openapi = "2.8.17"
 
 # Scheduling
 quartz = "2.3.2"
@@ -162,6 +164,7 @@ archunit = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "arc
 spring-restdocs-asciidoctor = { module = "org.springframework.restdocs:spring-restdocs-asciidoctor", version.ref = "spring-restdocs" }
 spring-restdocs-mockmvc = { module = "org.springframework.restdocs:spring-restdocs-mockmvc", version.ref = "spring-restdocs" }
 restdocs-api-spec-mockmvc = { module = "com.epages:restdocs-api-spec-mockmvc", version.ref = "restdocs-api-spec" }
+springdoc-openapi-starter-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc-openapi" }
 
 # Jackson - Spring Boot에서 관리하는 버전 사용
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }

--- a/plan/openapi-annotation-docs.md
+++ b/plan/openapi-annotation-docs.md
@@ -1,0 +1,263 @@
+# Plan: OpenAPI 어노테이션 기반 API 문서화 (product-api)
+
+## Overview
+
+**무엇을**: product-api에 springdoc-openapi를 도입하고, 26개 컨트롤러 71개 endpoint에 문서 어노테이션을 부여해 `GET /openapi.product.json`으로 OpenAPI 3.1 스펙을 제공한다.
+
+**왜**: 현재 문서 체계는 RestDocs 테스트 41개 → asciidoc 92개 → Antora 정적 사이트다. 세 단계를 사람이 수동으로 동기화해야 하고 산출물이 HTML이라 기계가 읽을 수 없다. OpenAPI 스펙으로 바꾸면 클라이언트 코드 생성, Scalar UI, API 테스트 도구를 그 위에 붙일 수 있다.
+
+**방식 결정 배경**: main에는 이미 `restdocs-api-spec` 0.19.4 플러그인이 양쪽 API 모듈에 적용되어 있고 파일럿 테스트 1개(`OpenApiAuthV2ControllerTest`)가 존재한다. 즉 "테스트 기반 OpenAPI" 경로가 절반쯤 깔려 있었으나, 이 경로는 endpoint마다 문서화 테스트를 유지해야 하고 Mockito 의존(레이어 표준 10 위반)이라 확장을 포기했다. 대신 런타임 어노테이션 방식(springdoc)으로 통일한다.
+
+### Assumptions
+
+**범위**
+
+1. 대상은 **product-api만**. admin-api(13개 컨트롤러, Kotlin)는 이번 범위 밖 — product에서 패턴을 확정한 뒤 후속 작업으로 분리한다.
+2. `springdoc-openapi-starter-webmvc-ui` **2.8.17을 신규 추가**한다. main에는 springdoc 의존성이 없다. 2.8.x가 Spring Boot 3.x 지원 라인이며 3.0.x는 Boot 4 전용이다.
+3. **기존 RestDocs 자산은 제거하지 않는다.** `.adoc` 92개, docs 테스트 41개, Antora `docs/`, `restdocs`·`restdocs-api-spec` 의존성, `asciidoctor`·`openapi3` 태스크를 모두 유지한다. 삭제 예정 표시만 남기고 실제 제거는 후속 작업이다.
+4. 따라서 **두 문서화 체계가 일시적으로 공존한다**. 이 중복은 의도된 트레이드오프이며, 전환 기간에 문서 공백을 만들지 않기 위한 선택이다.
+
+**산출물**
+
+5. `GET /openapi.product.json` **런타임 endpoint**로 제공한다. 경로는 `springdoc.api-docs.path`로 지정한다.
+6. **swagger-ui는 비활성화**한다. 스펙 JSON만 노출한다.
+7. **Scalar UI 도입은 범위 밖**이다. `springdoc-openapi-starter-webmvc-scalar` 2.8.17이 존재하고 에셋을 WebJar로 로컬 서빙하는 것까지 확인했으나, 이번에는 넣지 않는다.
+8. 빌드 타임 JSON 파일 산출(`openapi-gradle-plugin`)도 **범위 밖**이다. 런타임 endpoint만 만든다.
+
+**구현 성격**
+
+9. `GlobalResponse.data`는 제네릭이 아닌 `Object` 타입이다. 따라서 응답 스키마는 **springdoc `OperationCustomizer`로 공통 형식 래핑을 적용**하고, 컨트롤러 메서드는 `data`에 들어갈 실제 타입만 힌트로 지정한다.
+   - **2026-07-26 수정**: "전역 자동 적용"은 성립하지 않는다. 77개 중 3개(`GET /api/v2/auth/apple/nonce`, `POST /api/v2/auth/apple`, `POST /api/v2/auth/kakao`)는 공통 형식을 거치지 않고 DTO를 그대로 내보낸다. 이들을 감싸면 문서가 실제 응답과 달라진다.
+   - 구분 근거는 **컨트롤러가 선언한 반환 타입**이다. `ResponseEntity<NonceResponse>`처럼 본문 타입을 구체적으로 적으면 감싸지 않고, `ResponseEntity<?>`와 `ResponseEntity<GlobalResponse>`는 감싼다. 예외 목록을 코드 밖에 두지 않으므로 코드와 문서가 어긋날 수 없다.
+10. 어노테이션은 런타임 동작에 영향을 주지 않으므로 **API 계약과 응답 본문은 변경되지 않는다.**
+   - **2026-07-26 수정**: 컨트롤러 시그니처는 **구체화할 수 있다**. `ResponseEntity<?>` → `ResponseEntity<GlobalResponse>`는 제네릭 소거로 바이트코드와 응답이 동일하므로 API 계약을 바꾸지 않는다. `GlobalResponse.ok()` 3종의 반환 타입을 좁혔고 호출부 77곳이 그대로 컴파일되는 것을 확인했다. 가정의 의도(계약 보존)는 유지된다.
+11. 문서 어노테이션은 **컨트롤러 밖으로 격리**한다. 수백 줄짜리 `@Operation` 블록이 컨트롤러 본문에 들어가지 않도록 메타 어노테이션으로 묶는다(profanity-api에서 검증된 패턴).
+12. 문서 텍스트는 **한국어**로 쓴다.
+13. 문서 텍스트는 **Scalar UI 화면에 그대로 노출될 것을 전제로 자연어 문장으로 쓴다.** 식별자를 그대로 옮기지 않는다. 태그는 도메인 이름, summary는 행위를 서술하는 문장, description은 조건·제약·부수효과를 설명하는 완결된 문장으로 쓴다.
+14. **에러 응답(4xx/5xx) 문서화는 범위 밖**이다. 정상 응답(2xx) 스키마만 다룬다.
+15. `openapi.product.json`은 **무인증 접근을 허용**한다. `SecurityPolicy` fallback이 `REQUIRED_AUTH`이므로 PUBLIC 라우트를 명시해야 한다.
+
+### Success Criteria
+
+생성된 `openapi.product.json`을 기준으로 검증한다.
+
+1. **컨트롤러 클래스명이 태그로 남은 operation이 0건**이다. 스펙에 노출되는 태그 25개 전부 한국어 도메인 태그를 갖는다. (`review-controller` 같은 fallback 소멸)
+2. **77개 operation 전부가 `summary`를 갖는다.** 누락 0건. (paths 69개 / operations 77개 — 2026-07-26 실측)
+3. **`summary`가 메서드 식별자와 동일한 operation이 0건**이다. (`createReview`가 아니라 `리뷰를 작성한다` 형태)
+4. **응답 스키마가 빈 `{"type":"object"}`인 operation이 0건**이다. 공통 형식을 쓰는 엔드포인트는 `data`가 실제 DTO를 `$ref`로 가리키고, 공통 형식을 쓰지 않는 3개 엔드포인트는 응답 본문 자체가 DTO를 가리킨다. (2026-07-26 수정 — 가정 9 참조)
+5. `GET /openapi.product.json`이 **무인증 호출에 200을 반환**하고 `info.title`이 지정값과 일치한다.
+6. `/swagger-ui/**`가 **200을 반환하지 않는다.**
+7. **기존 테스트가 전부 통과한다.** `unit_test`, `integration_test`, `check_rule_test`, 그리고 기존 문서 파이프라인(`restDocsTest`, `asciidoctor`)까지 포함한다. 운영 동작과 기존 문서 체계가 손상되지 않았음을 증명한다.
+8. RestDocs 자산의 **삭제 예정 표시가 존재**하고 그 위치가 이 문서에 기록된다.
+
+### Impact Scope
+
+**모듈**
+- `bottlenote-product-api` — 주 대상. 의존성, 설정, 컨트롤러 어노테이션, `OperationCustomizer`
+- `bottlenote-mono` — `GlobalResponse`가 여기 있다. 전역 커스터마이저 방식이면 수정이 불필요할 수 있으나, DTO에 `@Schema`를 붙이는 범위에 따라 접촉 가능
+- `gradle/libs.versions.toml` — springdoc 버전 카탈로그 등록
+
+**변경 없음**
+- 스키마 마이그레이션 불필요 (엔티티 변경 없음, Flyway 무관)
+- cross-domain 결합 변화 없음 (Facade 신설 불필요)
+- 이벤트 발행·수신 변화 없음
+- 캐시 정책 변화 없음
+- 외부 API 계약 변화 없음
+
+**주의 지점**
+- **레이어 표준 5와 충돌 가능**: profanity-api는 문서 어노테이션을 `app.openapi` 한 곳에 모았으나, 이 프로젝트는 "코드는 자기 도메인 패키지에만 둔다"가 표준이다. 배치 위치를 `app.bottlenote.{domain}.openapi`로 할지 별도 패키지로 할지 `/plan`에서 결정해야 한다.
+- **ArchUnit 룰**: `ControllerLayerRules`가 컨트롤러 명명·패키지를 검증한다. 어노테이션 타입은 컨트롤러가 아니라 직접 충돌하지 않지만, 신규 패키지 도입 시 `DataTransferObjectRules` 등과의 충돌 여부를 확인해야 한다.
+- **테스트 계층**: endpoint 노출·무인증 접근·swagger-ui 차단은 통합 테스트로 검증한다. 태그·summary 누락 여부는 생성된 JSON을 검사하는 방식이 필요하다.
+
+## Execution Mode
+
+- mode: **delegated**
+- scope: **plan, implement**
+  - 사용자 선언은 "implement"였다. Tasks 없이는 구현이 불가능하므로 전제인 `plan`을 포함해 해석했다.
+  - `test`, `verify`, `commit`, `push`, `pr`은 scope 밖이다. 구현이 끝나면 정지하고 보고한다.
+  - 단, 구현 중 컴파일 확인과 변경 영향 범위의 기존 테스트 실행은 `implement`의 일부로 수행한다. 검증 없이 완료를 주장하지 않는다는 프로젝트 지침 때문이다.
+- stop-conditions:
+  1. 가정 붕괴 — 이 문서의 Assumptions를 깨는 발견 시 즉시 정지하고 재개봉 프로토콜을 따른다.
+  2. 검증 3회 연속 실패.
+  3. scope 밖 행동이 필요해진 시점 (커밋, 푸시, PR 생성, admin-api 착수 등).
+
+## Tasks
+
+분해 기준은 **도메인**이다. "모든 컨트롤러에 태그 붙이기 → 모든 컨트롤러에 summary 붙이기"는 수평 분해이므로 쓰지 않는다. 도메인 하나마다 태그·summary·description·응답 스키마를 한꺼번에 완결한다.
+
+Task 1-3은 기반이다. 이것들이 없으면 어떤 도메인도 문서화를 완결할 수 없으므로 의존성 경계로서 앞세운다.
+
+대상 컨트롤러 26개의 도메인 분포: alcohols 5, user 4, support 4(block/business/help/report), review 3, curation 2, external 2(앱 정보·알림), rating·picks·like·history·banner·파일 업로드 각 1.
+
+### Task 1: springdoc 도입과 스펙 endpoint 노출
+- Acceptance:
+  - `GET /openapi.product.json`이 무인증 호출에 200과 OpenAPI 3.1 문서를 반환한다
+  - `info.title`이 지정한 한국어 서비스명과 일치한다
+  - `/swagger-ui/**`가 200을 반환하지 않는다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiDocs*"`
+- Files (advisory): `gradle/libs.versions.toml`, `bottlenote-product-api/build.gradle`, `src/main/resources/application.yml`, `src/test/resources/application-test.yml`, `app/global/security/SecurityPolicyConfig.java`, `app/global/config/OpenApiConfig.java`, 신규 통합 테스트 1개
+- Depends: 없음
+- Size: M (7파일)
+- Status: [x] done
+
+### Task 2: GlobalResponse 응답 스키마 전역 래핑
+- Acceptance:
+  - 임의의 2xx 응답 스키마가 `success`/`code`/`data`/`errors`/`meta` 구조로 나타난다
+  - `data`가 빈 `{"type":"object"}`가 아니라 실제 DTO를 `$ref`로 가리킨다
+  - 컨트롤러 시그니처는 변경되지 않는다
+- Verification: 위 통합 테스트에 응답 스키마 검증 추가 후 동일 명령
+- Files (advisory): 신규 `OperationCustomizer` 1개, `OpenApiConfig.java` 등록
+- Depends: 1
+- Size: S (2파일)
+- Status: [x] done
+- 검증 시점 조정: Acceptance 2번(`data`가 실제 DTO를 `$ref`로 가리킴)은 엔드포인트가 타입 힌트를 준 뒤에야 관찰할 수 있다. 래핑 구조 자체는 이 Task에서 검증했고, `$ref` 연결은 첫 힌트가 붙는 Task 4에서 확인한다. 계약의 내용은 그대로다.
+
+### Task 3: 스펙 품질 전수 검증 테스트와 미적용 allowlist
+- Acceptance:
+  - 생성된 스펙을 읽어 ① 컨트롤러 클래스명이 태그로 남은 operation ② `summary` 누락 ③ `summary`가 메서드 식별자와 동일 ④ 빈 응답 스키마를 검출하는 테스트가 존재한다
+  - 아직 적용하지 않은 컨트롤러는 allowlist로 예외 처리되어 테스트가 통과한다
+  - allowlist에 26개 컨트롤러가 등재된 상태로 시작한다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): 신규 검증 테스트 1개, allowlist 상수
+- Depends: 1
+- Size: S (2파일)
+- Status: [x] done
+
+### Checkpoint: after Tasks 1-3
+- [x] 컴파일 통과
+- [x] `check_rule_test` 통과 (ArchUnit 룰이 신규 패키지를 거부하지 않음)
+- [x] 기존 `restDocsTest`, `asciidoctor` 통과 (가정 3 — 기존 문서 체계 무손상)
+
+### 확정된 문서화 패턴 (Task 4에서 결정 — Task 5 이후 이 형태를 반복한다)
+
+배치는 **도메인별 분산**으로 정했다. profanity-api는 `app.openapi` 한 곳에 모았으나, 이 프로젝트는 도메인 응집을 표준으로 삼고 ArchUnit으로 강제하므로 도메인 안에 둔다. 한 패키지에 모으면 그 패키지가 모든 도메인의 DTO를 import하게 되는 문제도 있다.
+
+1. 위치: `app.bottlenote.{domain}.controller.docs.{Controller이름}ApiDocs` (컨트롤러당 하나. `external`은 `app.external.{name}.presentation.docs`)
+2. 형태: `private` 생성자를 둔 `final` 클래스 안에 메타 어노테이션을 모은다
+   - `@ApiTag` — `@Target(TYPE)`, 한국어 도메인 태그와 설명
+   - endpoint별 `@interface` — `@Target(METHOD)`, `@Operation(summary, description, responses)`
+3. 컨트롤러에는 어노테이션 한 줄만 붙인다 (`@ReviewApiDocs.CreateReview`)
+4. 응답 `data` 타입은 서비스 메서드의 실제 반환 타입에서 가져온다. 목록은 `array = @ArraySchema(schema = @Schema(implementation = X.class))`
+5. `GlobalResponse.ok(Pair, params)`를 쓰는 엔드포인트는 실제 `data`가 `CollectionResponse<T>`(`{totalCount, items}`)다. 제네릭은 어노테이션으로 표현할 수 없으므로 같은 모양의 문서용 `record`를 ApiDocs 안에 `private`으로 선언해 가리킨다
+6. 문장은 화면에 노출되는 자연어로 쓴다. summary는 "~한다" 서술형, description은 조건·제약·`meta` 활용법을 설명한다
+
+### Task 4: 어노테이션 배치 패턴 확정과 review 도메인 적용
+- Acceptance:
+  - 문서 어노테이션이 컨트롤러 본문 밖에 격리되고, 배치 위치가 레이어 표준 5와 충돌하지 않음이 문서에 기록된다
+  - review 3개 컨트롤러가 한국어 도메인 태그를 갖는다
+  - 해당 endpoint의 summary가 식별자가 아닌 서술 문장이다
+  - allowlist에서 review 컨트롤러 3개가 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): review 문서 어노테이션 1개, `ReviewController.java`, `ReviewExploreController.java`, `ReviewReplyController.java`
+- Depends: 1, 2, 3
+- Size: S (4파일)
+- Status: [x] done
+
+### Task 5: alcohols 도메인 적용
+- Acceptance: alcohols 5개 컨트롤러가 태그·summary·응답 스키마를 갖고 allowlist에서 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): alcohols 문서 어노테이션, `AlcoholExploreController`, `AlcoholPopularQueryController`, `AlcoholQueryController`, `AlcoholReferenceController`, `TastingTagController`
+- Depends: 4
+- Size: M (6파일)
+- Status: [x] done
+
+### Checkpoint: after Tasks 4-5
+- [x] 패턴이 두 도메인에서 반복 적용 가능함이 확인됨
+- [x] `check_rule_test` 통과
+
+### Task 5A: 응답 본문 타입 전면 선언과 와일드카드 금지 규칙
+사용자 결정으로 범위에 추가됐다(2026-07-26). 가정 9 수정의 후속이다 — 반환 타입이 문서 판단의 근거가 되었으므로, 선언을 빠뜨릴 수 있는 여지 자체를 없앤다.
+
+- Acceptance:
+  - 모든 `@RestController` public 메서드가 `ResponseEntity`의 본문 타입을 구체적으로 선언한다 (`ResponseEntity<?>` 0건)
+  - ArchUnit 규칙이 와일드카드 반환을 검출해 실패시킨다
+  - 규칙이 공허하지 않음을 확인한다 (일부러 위반을 만들어 실패를 관찰)
+  - 런타임 동작과 기존 테스트에 영향이 없다
+- Verification: `./gradlew :bottlenote-product-api:check_rule_test --rerun-tasks`, `integration_test --tests "*OpenApi*"`, `restDocsTest asciidoctor`
+- Files (advisory): 컨트롤러 다수(65개 메서드), `app/rule/api/ControllerLayerRules.java`, `GlobalResponse.java`
+- Depends: 4
+- Size: M (변경 파일 다수이나 기계적 치환)
+- Status: [x] done
+
+### Task 6: user 도메인 적용
+- Acceptance: user 4개 컨트롤러(인증·팔로우·기본 정보·마이페이지)가 태그·summary·응답 스키마를 갖고 allowlist에서 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): user 문서 어노테이션, `AuthV2Controller`, `FollowController`, `UserBasicController`, `UserMyPageController`
+- Depends: 4
+- Size: M (5파일)
+- Status: [x] done
+
+### Task 7: support 도메인 적용 — 차단, 신고
+- Acceptance: `BlockController`, `ReportCommandController`가 태그·summary·응답 스키마를 갖고 allowlist에서 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): block/report 문서 어노테이션, 컨트롤러 2개
+- Depends: 4
+- Size: S (4파일)
+- Status: [x] done
+
+### Task 8: support 도메인 적용 — 비즈니스 지원, 문의
+- Acceptance: `BusinessSupportController`, `HelpCommandController`가 태그·summary·응답 스키마를 갖고 allowlist에서 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): business/help 문서 어노테이션, 컨트롤러 2개
+- Depends: 4
+- Size: S (4파일)
+- Status: [x] done
+
+### Checkpoint: after Tasks 6-8
+- [x] `unit_test`, `integration_test`, `check_rule_test` 통과
+- [x] allowlist 잔여 항목이 예상과 일치 (9건)
+
+### Task 9: curation, rating 도메인 적용
+- Acceptance: curation 2개와 `RatingController`가 태그·summary·응답 스키마를 갖고 allowlist에서 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): curation·rating 문서 어노테이션, `ProductCurationSpecController`, `ProductSpecBasedCurationController`, `RatingController`
+- Depends: 4
+- Size: M (5파일)
+- Status: [x] done
+
+### Task 10: picks, like, history 도메인 적용
+- Acceptance: `PicksCommandController`, `LikesCommandController`, `UserHistoryController`가 태그·summary·응답 스키마를 갖고 allowlist에서 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): picks·like·history 문서 어노테이션, 컨트롤러 3개
+- Depends: 4
+- Size: M (6파일)
+- Status: [x] done
+
+### Checkpoint: after Tasks 9-10
+- [x] `integration_test` 통과
+- [x] 남은 대상이 banner, 파일 업로드, external 2개뿐임을 확인
+
+### Task 11: banner, 파일 업로드, external 도메인 적용
+- Acceptance: `BannerQueryController`, `ImageUploadController`, `AppInfoController`, `NotificationController`가 태그·summary·응답 스키마를 갖고 allowlist에서 제거된다
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"` 통과
+- Files (advisory): banner·file·external 문서 어노테이션, 컨트롤러 4개
+- Depends: 4
+- Size: M (7파일)
+- Status: [x] done
+
+### Task 12: allowlist 소진 확인과 RestDocs 삭제 예정 표시
+- Acceptance:
+  - allowlist가 비고, 예외 없이 전수 검증이 통과한다 (성공 기준 1-4 자동 증명)
+  - RestDocs·Antora 자산에 삭제 예정 표시가 존재하고 그 위치가 이 문서에 기록된다
+  - 기존 `restDocsTest`, `asciidoctor`가 여전히 통과한다 (가정 3)
+- Verification: `./gradlew :bottlenote-product-api:integration_test --tests "*OpenApiSpec*"`, `./gradlew restDocsTest asciidoctor`
+- Files (advisory): allowlist 제거, 삭제 예정 표시 위치(build.gradle 주석 또는 docs 패키지 안내 문서), 이 plan 문서
+- Depends: 5, 6, 7, 8, 9, 10, 11
+- Size: S (4파일)
+- Status: [x] done
+
+## Progress Log
+
+- 2026-07-26 define 작성. main 기준으로 `restdocs-api-spec` 파일럿 발견, springdoc 전면 전환으로 방향 확정.
+- 2026-07-26 Task 9·10·11·12 완료. 큐레이션 2개·별점 3건, 찜하기·좋아요·활동 기록 4건, 배너·이미지 업로드·서버 정보 3건을 문서화해 **allowlist를 비웠다**. `Map`을 반환하는 서버 정보 엔드포인트는 실제 담기는 키를 문서용 record로 표현했다. 전수 검증이 예외 없이 통과해 성공 기준 1-4가 자동 증명됐다 — 실측 결과 fallback 태그 0건, summary 누락 0건, 빈 응답 스키마 0건, 한국어 태그 25종.
+  Task 12의 삭제 예정 표시는 네 곳에 남겼다: ① `bottlenote-product-api/src/test/java/app/docs/DEPRECATED.md`(대체 수단과 함께 삭제될 자산 목록) ② `bottlenote-product-api/build.gradle`의 `asciidoctor` 태스크 주석 ③ 루트 `build.gradle`의 `restDocsTest` 태스크 주석 ④ `product-api.adoc` 상단 주석. 최종 검증으로 `integration_test`(OpenAPI), `check_rule_test`, `unit_test`, `restDocsTest`, `asciidoctor`, `build` 전부 통과했다(성공 기준 7·8 충족).
+- 2026-07-26 Task 6·7·8 완료 및 Checkpoint(6-8) 통과. user 4개(인증·팔로우·회원 정보·마이페이지) 17건, support 차단 8건·신고 2건, 비즈니스 문의 5건·문의 5건을 문서화했다. 두 가지 실수를 잡았다 — ① allowlist 마지막 항목을 지울 때 닫는 괄호까지 삭제해 문법이 깨졌고 spotless가 즉시 잡아줬다 ② `GetAppleNonce`에 스키마 없는 빈 `@Content`를 지정해 springdoc이 추론한 `NonceResponse`를 덮어써, 반환 타입 기반 예외 처리가 무력화됐다. 스키마를 명시해 해결했다. 후자는 "감싸지 않는 응답"도 스키마를 명시해야 한다는 교훈이다. allowlist 잔여 9건.
+- 2026-07-26 Task 5A 완료. 컨트롤러 65개 메서드의 반환 타입을 `ResponseEntity<GlobalResponse>`로 구체화하고(컴파일 통과, import 보강 불필요), `ControllerLayerRules`에 와일드카드 반환을 금지하는 ArchUnit 규칙을 추가했다. 규칙을 처음 `noMethods().should(...)`로 썼을 때 판정이 반전되어 위반을 잡지 못했고, `methods().should(...)` positive 형태로 고쳐 해결했다. 규칙이 공허하지 않음을 확인하려고 `RatingController` 한 곳을 일부러 와일드카드로 되돌려 실패를 관찰한 뒤 복구했다. 이 과정에서 `check_rule_test`가 Gradle `UP-TO-DATE`로 스킵되는 것을 발견했다 — 루트 `test` 블록의 `outputs.upToDateWhen { false }`가 커스텀 Test 태스크에는 없기 때문이다. 규칙 검증 시 `--rerun-tasks`가 필요하다. `integration_test`, `restDocsTest`, `asciidoctor` 모두 통과.
+- 2026-07-26 가정 붕괴 발견과 해결 (Task 6 진행 중 정지 → 방향 수정 후 재개). `AuthV2Controller`의 3개 엔드포인트가 공통 형식 없이 DTO를 그대로 반환하는 것을 발견해 stop-condition 1번으로 정지했다. 사용자 제안에 따라 예외 목록 대신 **반환 타입 선언**을 구분 근거로 삼는 방식을 택했다. `GlobalResponse.ok()` 반환 타입을 좁히고(호출부 77곳 무영향 확인), Apple·카카오 로그인 2건에 실제 본문 타입을 선언했다. customizer는 `ResolvableType`으로 반환 타입을 읽어 감싸기를 건너뛴다. 검증 결과 3건은 DTO를 직접 가리키고 나머지는 공통 형식을 유지한다. 이 발견으로 `OpenApiDocsIntegrationTest`의 "모든 200 응답이 공통 형식"이라는 단정이 거짓이 되어, 공통 형식 대상과 예외 3건을 각각 검사하도록 고쳤다(검사가 약해진 것이 아니라 예외가 고정되어 오히려 강해졌다). Task 2에서 `NonceResponse` `$ref` 연결을 성공 증거로 보고했던 것은 오판이었고 정정했다.
+- 2026-07-26 Task 5 완료 및 Checkpoint(4-5) 통과. alcohols 5개 컨트롤러(조회·탐색·인기·기준 정보·테이스팅 태그) 13개 엔드포인트를 문서화했다. 진행 중 `AlcoholPopularQueryController`가 서비스의 `List<PopularItem>`을 컨트롤러에서 `PopularsOfWeekResponse`로 감싸는 것을 발견해, 서비스 반환 타입이 아니라 컨트롤러가 실제로 내보내는 타입을 기준으로 문서를 고쳤다. 4개 엔드포인트 중 봄 추천만 배열, 나머지 3개는 `{totalCount, alcohols}` 형태다. 큐레이션 조회 2건은 `CursorResponse<T>`가 그대로 data에 담기므로 문서용 record로 표현했다. allowlist 잔여 17건.
+- 2026-07-26 Task 4 완료. 배치 위치를 도메인별 분산(`{domain}.controller.docs.*ApiDocs`)으로 확정하고 review 3개 컨트롤러 12개 엔드포인트에 적용했다. 확정된 패턴은 위 "확정된 문서화 패턴" 절에 적었다. 탐색 엔드포인트는 `GlobalResponse.ok(Pair, params)` 경유로 실제 `data`가 `CollectionResponse<T>`임을 코드에서 확인해(추측하지 않고) 문서용 record로 표현했다. 생성 결과를 눈으로 확인해 태그 3종(리뷰·리뷰 댓글·리뷰 탐색), 요약 12건, `data` 실타입 연결 12건을 확인했다. allowlist 잔여 22건.
+- 2026-07-26 Task 3 완료 및 Checkpoint(1-3) 통과. `OpenApiSpecQualityTest`가 태그·요약·요약과 메서드명 중복·빈 응답 스키마 네 가지를 전수 검사하고, 미문서화 컨트롤러 25개는 `PENDING_TAGS`로 예외 처리한다. 목록에 이미 문서화된 태그가 남으면 실패하는 검사도 넣어 목록이 낡지 않게 했다. 검증기가 공허하지 않음을 확인하려고 `review-controller`를 목록에서 임시로 빼 보았고 검사 3건이 예상대로 실패했다(복구 완료). 스펙 조회 로직은 `OpenApiSpecTestSupport`로 분리했다. `check_rule_test`와 기존 `restDocsTest`·`asciidoctor`도 통과해 가정 3(기존 체계 공존)을 확인했다.
+- 2026-07-26 Task 2 보완. 실태 조사에서 `PUT /api/v1/picks`와 `GET /api/v1/banners`가 `ResponseEntity<GlobalResponse>`를 반환해 공통 형식이 `data` 안에 중첩되는 결함을 발견했다. customizer가 `GlobalResponse` 참조를 힌트로 취급하지 않도록 고쳤고 중첩 0건을 확인했다. 같은 조사에서 `GET /api/v2/auth/apple/nonce`가 `NonceResponse`를 `$ref`로 가리키는 것을 확인해 Task 2 Acceptance 2번도 증명됐다.
+- 2026-07-26 실태 수치 정정. 스펙 실측 결과 paths 69개, operations 77개, 태그 25개다. define에 적은 71 paths는 이전 브랜치 기준이었다. 태그가 25개인 이유는 `NotificationController`가 본문 없는 빈 클래스여서 노출 엔드포인트가 없기 때문이다 — 문서화 대상이 아니므로 Task 11에서 제외한다. 성공 기준의 숫자를 실측값으로 바꿨다(가정 자체는 유지).
+- 2026-07-26 Task 2 완료. `GlobalResponseSchemaCustomizer`(`OperationCustomizer`)로 2xx 응답을 공통 형식으로 감싼다. 컨트롤러가 `ResponseEntity<?>`를 반환해 반환 타입을 알 수 없으므로, 엔드포인트가 표준 `@ApiResponse`로 `data` 타입만 알려주면 customizer가 그것을 `data` 자리로 옮기고 success·code·errors·meta를 덧붙이는 구조로 만들었다. 이미 감싼 응답을 다시 감싸지 않도록 방어했고, 타입 정보가 없는 빈 object는 힌트로 취급하지 않는다. 통합 테스트 4건 통과 — 스펙의 모든 200 응답이 공통 5개 필드를 갖는다.
+- 2026-07-26 Task 1 완료. springdoc 2.8.17을 카탈로그와 product-api에 추가하고, `springdoc.api-docs.path`를 `/openapi.product.json`으로 지정했다. swagger-ui는 설정으로 껐다. `SecurityPolicy` fallback이 `REQUIRED_AUTH`이므로 스펙 경로를 PUBLIC으로 명시했다. `OpenApiConfig`에 한국어 제목·설명과 액세스 토큰 인증 스키마를 정의했다. 통합 테스트 3건(무인증 200·OpenAPI 3.1 형식·swagger-ui 차단) 통과.


### PR DESCRIPTION
## 배경

현재 API 문서는 RestDocs 테스트 41개 → asciidoc 92개 → Antora 사이트 세 단계를 사람이 손으로 동기화하는 구조입니다. 산출물이 HTML이라 기계가 읽을 수 없어 클라이언트 코드 생성이나 API 테스트 도구를 붙일 수 없습니다.

springdoc OpenAPI 어노테이션 방식으로 옮겨 `GET /openapi.product.json` 으로 OpenAPI 3.1 스펙을 제공합니다.

참고로 이 저장소에는 `restdocs-api-spec` 플러그인과 파일럿 테스트 1개가 이미 있었습니다. 그 경로는 엔드포인트마다 문서화 테스트를 유지해야 하고 Mockito 의존(레이어 표준 10 위반)이라 확장을 포기하고 런타임 어노테이션으로 통일했습니다.

## 변경 사항

**스펙 생성 기반**
- `springdoc-openapi-starter-webmvc-ui` 2.8.17 추가 (2.8.x가 Spring Boot 3.x 지원 라인)
- `GET /openapi.product.json` 노출, swagger-ui는 비활성
- `GlobalResponseSchemaCustomizer` — 응답을 공통 형식으로 감쌈

**문서 어노테이션**
- 26개 컨트롤러 77개 엔드포인트에 한국어 태그·요약·설명 부여
- 설명은 컨트롤러 밖 `{도메인}.controller.docs.*ApiDocs` 에 격리. 컨트롤러에는 어노테이션 한 줄만
- 문장은 추후 Scalar UI 화면에 노출될 것을 전제로 자연어로 작성

**응답 타입 명시**
- 컨트롤러 65개 메서드의 `ResponseEntity<?>` 를 실제 본문 타입으로 선언
- ArchUnit 규칙으로 와일드카드 반환 금지

**검증**
- `OpenApiSpecQualityTest` — 태그·요약·응답 스키마 누락을 전수 검사

## 설계 판단 두 가지

**응답 스키마 표현** — `GlobalResponse.data` 가 `Object` 라서 제네릭으로 표현할 수 없습니다. 엔드포인트가 `data` 에 담길 타입만 알려주고 customizer가 공통 필드를 덧붙이는 구조로, 공통 형식을 엔드포인트마다 반복하지 않습니다.

**공통 형식 예외 판별** — 3개 엔드포인트(애플 nonce·애플 로그인·카카오 로그인)는 공통 형식 없이 DTO를 그대로 내보냅니다. 이를 감싸면 문서가 거짓이 되므로, **컨트롤러가 선언한 반환 타입**을 근거로 감싸기를 건너뜁니다. 예외 목록을 코드 밖에 두지 않아 코드와 문서가 어긋날 수 없습니다.

## 검증

로컬에서 확인한 스펙 실측치입니다.

| 항목 | 결과 |
|---|---|
| 컨트롤러 클래스명 태그 | 0건 (한국어 태그 25종) |
| 요약 누락 | 0건 / 77 operations |
| 빈 응답 스키마 | 0건 |
| 스펙 무인증 조회 | 200 |
| swagger-ui | 차단 확인 |

`unit_test`, `check_rule_test`, `restDocsTest`, `asciidoctor`, `build` 통과. 전체 통합 테스트는 이 PR의 CI에서 검증합니다.

## 제외 범위

- **admin-api** — product에서 패턴을 확정한 뒤 후속 작업
- **기존 RestDocs 자산 제거** — 전환 기간에 문서 공백을 만들지 않기 위해 삭제 예정 표시만 남기고 유지. 두 체계 모두 CI를 통과해야 합니다
- **Scalar UI 도입** — `springdoc-openapi-starter-webmvc-scalar` 로 가능한 것은 확인했으나 이번 범위 밖
- **에러 응답(4xx/5xx) 문서화** — 정상 응답만 다룸
- **빌드 타임 JSON 산출** — 런타임 endpoint만

API 계약과 응답 본문은 변경되지 않습니다. 반환 타입 구체화는 제네릭 소거로 런타임 동작이 동일합니다.

## 알려진 기존 문제

`check_rule_test` 가 Gradle `UP-TO-DATE` 로 스킵됩니다. 루트 `test` 블록의 `outputs.upToDateWhen { false }` 가 커스텀 Test 태스크에 적용되지 않기 때문입니다. 이 PR에서 고치지 않았고, 로컬 검증 시 `--rerun-tasks` 가 필요합니다.

계획과 진행 기록: `plan/openapi-annotation-docs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)