### PR TITLE
fix: OpenAPI 스펙 경로를 ingress 라우팅 범위 안으로 이동

### DIFF
--- a/bottlenote-product-api/build.gradle
+++ b/bottlenote-product-api/build.gradle
@@ -104,7 +104,7 @@ tasks.named('processResources') {
 tasks.register("prepareKotlinBuildScriptModel") {}
 
 // [삭제 예정] Spring REST Docs 설정
-// API 문서는 springdoc OpenAPI(GET /openapi.product.json)로 대체됐다.
+// API 문서는 springdoc OpenAPI(GET /api/v1/openapi.product.json)로 대체됐다.
 // 전환 기간 동안만 유지하며 새 엔드포인트를 이 경로로 문서화하지 않는다.
 // 상세: src/test/java/app/docs/DEPRECATED.md
 asciidoctor {

--- a/bottlenote-product-api/src/docs/asciidoc/product-api.adoc
+++ b/bottlenote-product-api/src/docs/asciidoc/product-api.adoc
@@ -1,4 +1,4 @@
-// [삭제 예정] 이 문서는 springdoc OpenAPI(GET /openapi.product.json)로 대체됐습니다.
+// [삭제 예정] 이 문서는 springdoc OpenAPI(GET /api/v1/openapi.product.json)로 대체됐습니다.
 // 새 엔드포인트를 이 문서에 추가하지 마세요. 상세: ../../test/java/app/docs/DEPRECATED.md
 
 ifndef::snippets[]

--- a/bottlenote-product-api/src/main/resources/application.yml
+++ b/bottlenote-product-api/src/main/resources/application.yml
@@ -63,9 +63,10 @@ bottlenote:
       enabled: false
 
 # OpenAPI 문서 (스펙 JSON만 노출하고 swagger-ui는 사용하지 않는다)
+# ingress가 /api/v*/** 만 앱으로 넘기므로 스펙 경로도 그 아래에 둔다
 springdoc:
   api-docs:
-    path: /openapi.product.json
+    path: /api/v1/openapi.product.json
   swagger-ui:
     enabled: false
   # 응답은 모두 JSON이므로 @Content마다 미디어 타입을 적지 않는다

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -26,7 +26,7 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
   @Test
   @DisplayName("인증 없이 스펙 문서를 조회할 수 있다")
   void 인증_없이_스펙_문서를_조회할_수_있다() {
-    assertThat(mockMvcTester.get().uri(SPEC_PATH))
+    assertThat(mockMvcTester.get().uri(specPath))
         .hasStatusOk()
         .bodyJson()
         .extractingPath("$.info.title")
@@ -36,7 +36,7 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
   @Test
   @DisplayName("스펙 문서는 OpenAPI 3.1 형식이다")
   void 스펙_문서는_OpenAPI_3_1_형식이다() {
-    assertThat(mockMvcTester.get().uri(SPEC_PATH))
+    assertThat(mockMvcTester.get().uri(specPath))
         .hasStatusOk()
         .bodyJson()
         .extractingPath("$.openapi")

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiSpecTestSupport.java
@@ -10,14 +10,17 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.springframework.beans.factory.annotation.Value;
 
 /** 생성된 OpenAPI 스펙을 읽어 검사하는 테스트들의 공통 기반. */
 abstract class OpenApiSpecTestSupport extends IntegrationTestSupport {
 
-  protected static final String SPEC_PATH = "/openapi.product.json";
+  // 스펙 경로의 SSOT는 springdoc.api-docs.path 프로퍼티다
+  @Value("${springdoc.api-docs.path}")
+  protected String specPath;
 
   protected JsonNode fetchSpec() {
-    var result = mockMvcTester.get().uri(SPEC_PATH).exchange();
+    var result = mockMvcTester.get().uri(specPath).exchange();
     try {
       return mapper.readTree(result.getResponse().getContentAsString(UTF_8));
     } catch (IOException e) {

--- a/bottlenote-product-api/src/test/java/app/docs/DEPRECATED.md
+++ b/bottlenote-product-api/src/test/java/app/docs/DEPRECATED.md
@@ -6,7 +6,7 @@
 
 API 문서는 springdoc OpenAPI 어노테이션으로 생성합니다.
 
-- 스펙: `GET /openapi.product.json` (앱 실행 중 조회)
+- 스펙: `GET /api/v1/openapi.product.json` (앱 실행 중 조회)
 - 문서 작성 위치: `app.bottlenote.{도메인}.controller.docs.{컨트롤러}ApiDocs`
 - 품질 검증: `OpenApiSpecQualityTest` — 태그·요약·응답 스키마 누락을 전수 검사합니다
 

--- a/bottlenote-product-api/src/test/resources/application-test.yml
+++ b/bottlenote-product-api/src/test/resources/application-test.yml
@@ -57,7 +57,7 @@ app:
 # OpenAPI 문서 (운영 설정과 같은 경로를 유지해 스펙을 그대로 검증한다)
 springdoc:
   api-docs:
-    path: /openapi.product.json
+    path: /api/v1/openapi.product.json
   swagger-ui:
     enabled: false
   default-produces-media-type: application/json


### PR DESCRIPTION
## 배경

`GET /openapi.product.json` 스펙 엔드포인트가 개발 환경에서 403으로 접근 불가였다. 원인은 앱 코드가 아니라 ingress가 `/api/v*/**`, `/actuator/**` 외의 루트 경로를 앱으로 넘기지 않는 것이었다 (`/error` 등 앱에서 공개한 경로도 403 반환 확인).

## 변경

- 스펙 경로를 `/openapi.product.json` → `/api/v1/openapi.product.json`으로 변경 (`springdoc.api-docs.path`, application.yml·application-test.yml)
- `OpenApiSpecTestSupport`의 하드코딩된 `SPEC_PATH` 상수를 제거하고 `@Value(${springdoc.api-docs.path})` 주입으로 교체해 경로 SSOT를 프로퍼티 하나로 통일
- build.gradle, product-api.adoc, DEPRECATED.md의 경로 표기 갱신

`SecurityPolicyConfig`는 이미 `@Value`로 프로퍼티를 읽으므로 수정 없이 새 경로를 PUBLIC으로 인식한다.

## 검증

- OpenAPI 통합 테스트 13개 전부 통과 (OpenApiDocsIntegrationTest, OpenApiSecurityRequirementTest, OpenApiSpecQualityTest, 0 failures)
- spotlessCheck 통과

## 배포 후 확인

개발 환경 배포 후 `https://api.development.bottle-note.com/api/v1/openapi.product.json` 무인증 200 확인 필요