### PR TITLE
docs: 이슈 SSOT인 workspace 레포 참조 규칙 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,10 @@ gh workflow run deploy_batch.yml -f environment=production -f version=1.2.3
 gh workflow run deploy_development_applications.yml
 ```
 
+## 이슈 관리
+
+이슈의 SSOT는 [bottle-note/workspace](https://github.com/bottle-note/workspace) 레포지토리다. 이슈는 이 레포가 아니라 workspace에 등록하고, 작업 시작 전 관련 이슈를 먼저 확인한다. PR 본문에는 `bottle-note/workspace#N` 형식으로 관련 이슈를 링크한다.
+
 ## Skills (Development Workflow)
 
 Use these skills to follow the structured development lifecycle:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ gh workflow run deploy_batch.yml -f environment=production -f version=1.2.3
 gh workflow run deploy_development_applications.yml
 ```
 
+## 이슈 관리
+
+이슈의 SSOT는 [bottle-note/workspace](https://github.com/bottle-note/workspace) 레포지토리다. 이슈는 이 레포가 아니라 workspace에 등록하고, 작업 시작 전 관련 이슈를 먼저 확인한다. PR 본문에는 `bottle-note/workspace#N` 형식으로 관련 이슈를 링크한다.
+
 ## Skills (Development Workflow)
 
 Use these skills to follow the structured development lifecycle:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@
 
 ---
 
+## 이슈 관리
+
+기능 요청, 버그 리포트, 작업 항목 등 모든 이슈는 [bottle-note/workspace](https://github.com/bottle-note/workspace) 레포지토리에서 관리합니다. <br/>
+이슈의 SSOT는 workspace이며, PR 작성 시 본문에 `bottle-note/workspace#N` 형식으로 관련 이슈를 링크해 주세요.
+
+---
+
 보틀노트는 위스키 애호가들이 모여 서로의 의견을 공유하고 <br/>
 더욱 즐겁고 유익한 시음 경험을 할 수 있도록 도와줍니다.
 


### PR DESCRIPTION
## 배경

이슈를 `bottle-note/workspace` 레포에서 관리하는 규칙이 지라 대용 SSOT 관행으로 존재했지만, 어느 문서에도 명시돼 있지 않았다 (api-server·frontend·admin-dashboard README, AGENTS/CLAUDE 지침, CONTRIBUTING 모두 언급 없음 확인).

## 변경

- `README.md`: 아키텍처 섹션 뒤에 이슈 관리 안내 추가 (PR 본문에 `bottle-note/workspace#N` 링크 규칙 포함)
- `AGENTS.md` / `CLAUDE.md`: Skills 섹션 앞에 동일한 이슈 관리 섹션 추가 (미러 규칙에 따라 두 파일 본문 동일, diff로 허용된 4종 차이만 존재함을 확인)