### PR TITLE
feat: 마케팅 선택 동의와 만료 상태 추가

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/constant/AgreementAction.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/constant/AgreementAction.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 public enum AgreementAction {
   AGREE("약관에 동의함"),
-  REVOKE("약관 동의를 철회함");
+  REVOKE("약관 동의를 철회함"),
+  EXPIRED("약관 동의가 만료됨");
 
   private final String description;
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/constant/AgreementType.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/constant/AgreementType.java
@@ -5,12 +5,15 @@ import lombok.Getter;
 /** 사용자가 동의할 수 있는 약관 유형을 나타낸다. */
 @Getter
 public enum AgreementType {
-  TERMS_OF_SERVICE("서비스 이용약관"),
-  PRIVACY_COLLECTION_USE("개인정보 수집 및 이용 동의");
+  TERMS_OF_SERVICE("서비스 이용약관", true),
+  PRIVACY_COLLECTION_USE("개인정보 수집 및 이용 동의", true),
+  MARKETING("마케팅 정보 수신 동의", false);
 
   private final String description;
+  private final boolean required;
 
-  AgreementType(String description) {
+  AgreementType(String description, boolean required) {
     this.description = description;
+    this.required = required;
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/exception/AgreementExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/exception/AgreementExceptionCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum AgreementExceptionCode implements ExceptionCode {
   INVALID_AGREEMENT_TYPE(HttpStatus.BAD_REQUEST, "알 수 없는 동의 유형입니다."),
+  UNSUPPORTED_AGREEMENT_ACTION(HttpStatus.BAD_REQUEST, "요청할 수 없는 동의 상태입니다."),
   AGREEMENT_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "동의 문서 원문은 비어 있을 수 없습니다.");
 
   private final HttpStatus httpStatus;

--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/service/AgreementEvaluator.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/service/AgreementEvaluator.java
@@ -20,7 +20,7 @@ public class AgreementEvaluator {
   public AgreementEvaluation evaluate(Long userId) {
     List<Item> items =
         Arrays.stream(AgreementType.values()).map(type -> evaluate(userId, type)).toList();
-    boolean eligible = items.stream().allMatch(Item::agreed);
+    boolean eligible = items.stream().filter(Item::required).allMatch(Item::agreed);
     return new AgreementEvaluation(eligible, items);
   }
 
@@ -30,6 +30,6 @@ public class AgreementEvaluator {
             .findFirstByUserIdAndAgreementTypeOrderByIdDesc(userId, type)
             .filter(agreement -> agreement.getAction() == AgreementAction.AGREE)
             .isPresent();
-    return new Item(type, true, agreed);
+    return new Item(type, type.isRequired(), agreed);
   }
 }

--- a/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
@@ -71,6 +71,19 @@ class AgreementEvaluatorTest {
   }
 
   @Test
+  @DisplayName("동의 후 만료되면 철회와 동일하게 미동의로 판정한다")
+  void evaluate_whenLatestActionIsExpired_returnsNotEligible() {
+    save(AgreementType.TERMS_OF_SERVICE, AgreementAction.AGREE, RECORDED_AT.plusSeconds(10));
+    save(AgreementType.TERMS_OF_SERVICE, AgreementAction.EXPIRED, RECORDED_AT);
+    save(AgreementType.PRIVACY_COLLECTION_USE, AgreementAction.AGREE, RECORDED_AT);
+
+    AgreementEvaluation result = evaluator.evaluate(USER_ID);
+
+    assertThat(result.eligible()).isFalse();
+    assertThat(item(result, AgreementType.TERMS_OF_SERVICE).agreed()).isFalse();
+  }
+
+  @Test
   @DisplayName("철회 후 다시 동의하면 최신 동의 상태로 판정한다")
   void evaluate_whenLatestActionReturnsToAgree_returnsEligible() {
     save(AgreementType.TERMS_OF_SERVICE, AgreementAction.REVOKE, RECORDED_AT.plusSeconds(10));

--- a/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
@@ -40,7 +40,8 @@ class AgreementEvaluatorTest {
     assertThat(result.items())
         .containsExactly(
             new Item(AgreementType.TERMS_OF_SERVICE, true, false),
-            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false));
+            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false),
+            new Item(AgreementType.MARKETING, false, false));
   }
 
   @Test
@@ -52,7 +53,8 @@ class AgreementEvaluatorTest {
     AgreementEvaluation result = evaluator.evaluate(USER_ID);
 
     assertThat(result.eligible()).isTrue();
-    assertThat(result.items()).allMatch(Item::agreed);
+    assertThat(result.items()).filteredOn(Item::required).allMatch(Item::agreed);
+    assertThat(item(result, AgreementType.MARKETING).agreed()).isFalse();
   }
 
   @Test

--- a/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
@@ -45,8 +45,8 @@ class AgreementEvaluatorTest {
   }
 
   @Test
-  @DisplayName("두 유형의 최신 이력이 동의면 충족으로 판정한다")
-  void evaluate_whenLatestActionsAreAgree_returnsEligible() {
+  @DisplayName("필수 유형의 최신 이력이 동의면 선택 동의 없이도 충족으로 판정한다")
+  void evaluate_whenLatestRequiredActionsAreAgree_returnsEligible() {
     save(AgreementType.TERMS_OF_SERVICE, AgreementAction.AGREE, RECORDED_AT);
     save(AgreementType.PRIVACY_COLLECTION_USE, AgreementAction.AGREE, RECORDED_AT.minusYears(1));
 

--- a/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementServiceTest.java
@@ -57,7 +57,8 @@ class AgreementServiceTest {
     assertThat(result.items())
         .containsExactly(
             new Item(AgreementType.TERMS_OF_SERVICE, true, false),
-            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false));
+            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false),
+            new Item(AgreementType.MARKETING, false, false));
   }
 
   @Nested
@@ -110,7 +111,8 @@ class AgreementServiceTest {
               USER_AGENT);
 
       assertThat(result.eligible()).isTrue();
-      assertThat(result.items()).allMatch(Item::agreed);
+      assertThat(result.items()).filteredOn(Item::required).allMatch(Item::agreed);
+      assertThat(item(result, AgreementType.MARKETING).agreed()).isFalse();
       assertThat(result).isEqualTo(service.getStatus(USER_ID));
     }
 

--- a/bottlenote-product-api/src/main/java/app/bottlenote/agreement/dto/request/AgreementSubmitRequest.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/agreement/dto/request/AgreementSubmitRequest.java
@@ -25,7 +25,7 @@ public record AgreementSubmitRequest(
   /** 제출할 약관 동의 항목을 나타낸다. */
   @Schema(name = "AgreementSubmitItem", description = "제출할 동의 항목")
   public record Item(
-      @Schema(allowableValues = {"TERMS_OF_SERVICE", "PRIVACY_COLLECTION_USE"})
+      @Schema(allowableValues = {"TERMS_OF_SERVICE", "PRIVACY_COLLECTION_USE", "MARKETING"})
           @NotBlank(message = "AGREEMENT_TYPE_REQUIRED")
           String type,
       @NotNull(message = "AGREEMENT_ACTION_REQUIRED") AgreementAction action,

--- a/bottlenote-product-api/src/main/java/app/bottlenote/agreement/dto/request/AgreementSubmitRequest.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/agreement/dto/request/AgreementSubmitRequest.java
@@ -28,11 +28,18 @@ public record AgreementSubmitRequest(
       @Schema(allowableValues = {"TERMS_OF_SERVICE", "PRIVACY_COLLECTION_USE", "MARKETING"})
           @NotBlank(message = "AGREEMENT_TYPE_REQUIRED")
           String type,
-      @NotNull(message = "AGREEMENT_ACTION_REQUIRED") AgreementAction action,
+      @Schema(
+              description = "사용자 제출 가능 동작. EXPIRED는 서버가 기록하는 상태로 요청할 수 없다.",
+              allowableValues = {"AGREE", "REVOKE"})
+          @NotNull(message = "AGREEMENT_ACTION_REQUIRED")
+          AgreementAction action,
       @NotBlank(message = "AGREEMENT_CONTENT_EMPTY") String content,
       @NotNull(message = "AGREEMENT_INPUT_CONTEXT_REQUIRED") AgreementInputContext inputContext) {
 
     private AgreementSubmission toSubmission() {
+      if (action == AgreementAction.EXPIRED) {
+        throw new AgreementException(AgreementExceptionCode.UNSUPPORTED_AGREEMENT_ACTION);
+      }
       return new AgreementSubmission(agreementType(), action, content, inputContext);
     }
 

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package app.bottlenote.agreement.integration;
 
 import static app.bottlenote.agreement.constant.AgreementAction.AGREE;
+import static app.bottlenote.agreement.constant.AgreementAction.EXPIRED;
 import static app.bottlenote.agreement.constant.AgreementInputContext.INDIVIDUAL;
 import static app.bottlenote.agreement.constant.AgreementType.MARKETING;
 import static app.bottlenote.agreement.constant.AgreementType.PRIVACY_COLLECTION_USE;
@@ -159,6 +160,29 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
           .bodyJson()
           .extractingPath("$.errors[0].code")
           .isEqualTo(AgreementExceptionCode.INVALID_AGREEMENT_TYPE.name());
+    }
+
+    @Test
+    @DisplayName("만료 상태를 제출하면 저장하지 않고 400을 반환한다")
+    void submit_whenActionIsExpired_returnsBadRequestWithoutSaving() throws Exception {
+      User user = userTestFactory.persistUser();
+      TokenItem token = getToken(user);
+      AgreementSubmitRequest request =
+          new AgreementSubmitRequest(
+              List.of(new Item(TERMS_OF_SERVICE.name(), EXPIRED, "원문", INDIVIDUAL)));
+
+      MvcTestResult result = submit(token, request);
+
+      result.assertThat().hasStatus(HttpStatus.BAD_REQUEST);
+      result
+          .assertThat()
+          .bodyJson()
+          .extractingPath("$.errors[0].code")
+          .isEqualTo(AgreementExceptionCode.UNSUPPORTED_AGREEMENT_ACTION.name());
+      assertThat(
+              userAgreementRepository.findFirstByUserIdAndAgreementTypeOrderByIdDesc(
+                  user.getId(), TERMS_OF_SERVICE))
+          .isEmpty();
     }
 
     @Test

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package app.bottlenote.agreement.integration;
 
 import static app.bottlenote.agreement.constant.AgreementAction.AGREE;
 import static app.bottlenote.agreement.constant.AgreementInputContext.INDIVIDUAL;
+import static app.bottlenote.agreement.constant.AgreementType.MARKETING;
 import static app.bottlenote.agreement.constant.AgreementType.PRIVACY_COLLECTION_USE;
 import static app.bottlenote.agreement.constant.AgreementType.TERMS_OF_SERVICE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,9 +63,12 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       JsonNode data = responseData(result);
       assertThat(fieldNames(data)).containsExactlyInAnyOrder("eligible", "items");
       assertThat(data.path("eligible").booleanValue()).isFalse();
-      assertThat(data.path("items")).hasSize(2);
+      assertThat(data.path("items")).hasSize(3);
       assertThat(fieldNames(data.path("items").get(0)))
           .containsExactlyInAnyOrder("type", "required", "agreed");
+      JsonNode marketing = item(data, MARKETING.name());
+      assertThat(marketing.path("required").booleanValue()).isFalse();
+      assertThat(marketing.path("agreed").booleanValue()).isFalse();
     }
 
     @Test
@@ -106,7 +110,10 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       JsonNode data = responseData(result);
       assertThat(fieldNames(data)).containsExactlyInAnyOrder("eligible", "items");
       assertThat(data.path("eligible").booleanValue()).isTrue();
-      assertThat(data.path("items")).hasSize(2);
+      assertThat(data.path("items")).hasSize(3);
+      JsonNode marketing = item(data, MARKETING.name());
+      assertThat(marketing.path("required").booleanValue()).isFalse();
+      assertThat(marketing.path("agreed").booleanValue()).isTrue();
 
       UserAgreement terms = latest(user, TERMS_OF_SERVICE);
       assertThat(terms.getAction()).isEqualTo(AGREE);
@@ -114,6 +121,7 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       assertThat(terms.getInputContext()).isEqualTo(INDIVIDUAL);
       assertThat(terms.getClientIp()).isEqualTo("203.0.113.10");
       assertThat(terms.getUserAgent()).isEqualTo("BottleNote/2.0");
+      assertThat(latest(user, MARKETING).getAction()).isEqualTo(AGREE);
     }
 
     @Test
@@ -199,7 +207,8 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
     return new AgreementSubmitRequest(
         List.of(
             new Item(TERMS_OF_SERVICE.name(), AGREE, "이용약관 원문", INDIVIDUAL),
-            new Item(PRIVACY_COLLECTION_USE.name(), AGREE, "개인정보 수집 이용 원문", INDIVIDUAL)));
+            new Item(PRIVACY_COLLECTION_USE.name(), AGREE, "개인정보 수집 이용 원문", INDIVIDUAL),
+            new Item(MARKETING.name(), AGREE, "마케팅 정보 수신 동의 원문", INDIVIDUAL)));
   }
 
   private UserAgreement latest(User user, app.bottlenote.agreement.constant.AgreementType type) {
@@ -215,5 +224,12 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
   private Set<String> fieldNames(JsonNode node) {
     return StreamSupport.stream(((Iterable<String>) () -> node.fieldNames()).spliterator(), false)
         .collect(java.util.stream.Collectors.toSet());
+  }
+
+  private JsonNode item(JsonNode data, String type) {
+    return StreamSupport.stream(data.path("items").spliterator(), false)
+        .filter(item -> item.path("type").asText().equals(type))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -163,6 +163,8 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
         .containsExactlyInAnyOrder("type", "action", "content", "inputContext");
     assertThat(textValuesOf(requestItemSchema.path("required")))
         .containsExactlyInAnyOrder("type", "action", "content", "inputContext");
+    assertThat(textValuesOf(requestItemSchema.path("properties").path("type").path("enum")))
+        .containsExactly("TERMS_OF_SERVICE", "PRIVACY_COLLECTION_USE", "MARKETING");
   }
 
   private JsonNode resolveSchema(JsonNode spec, JsonNode schema) {

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -165,6 +165,8 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
         .containsExactlyInAnyOrder("type", "action", "content", "inputContext");
     assertThat(textValuesOf(requestItemSchema.path("properties").path("type").path("enum")))
         .containsExactly("TERMS_OF_SERVICE", "PRIVACY_COLLECTION_USE", "MARKETING");
+    assertThat(textValuesOf(requestItemSchema.path("properties").path("action").path("enum")))
+        .containsExactly("AGREE", "REVOKE");
   }
 
   private JsonNode resolveSchema(JsonNode spec, JsonNode schema) {

--- a/bottlenote-product-api/src/test/java/app/bottlenote/user/service/AuthServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/user/service/AuthServiceTest.java
@@ -251,6 +251,25 @@ class AuthServiceTest {
   }
 
   @Test
+  @DisplayName("필수 동의가 만료된 사용자가 로그인하면 동의 필요 힌트를 true로 반환한다")
+  void loginWithApple_whenRequiredAgreementIsExpired_returnsAgreementRequiredTrue() {
+    // given
+    saveAgreement(1L, AgreementType.TERMS_OF_SERVICE);
+    saveAgreement(1L, AgreementType.TERMS_OF_SERVICE, AgreementAction.EXPIRED);
+    saveAgreement(1L, AgreementType.PRIVACY_COLLECTION_USE);
+    AppleAuthService.AppleUserInfo appleUserInfo =
+        new AppleAuthService.AppleUserInfo("apple-expired", "expired@apple.com");
+    when(appleAuthService.validateAndGetUserInfo(anyString(), anyString()))
+        .thenReturn(appleUserInfo);
+
+    // when
+    AuthResponse result = authService.loginWithApple("valid-id-token", "valid-nonce");
+
+    // then
+    assertThat(result.agreementRequired()).isTrue();
+  }
+
+  @Test
   @DisplayName("애플 재로그인 시 isFirstLogin이 false를 반환한다")
   void test_Apple_ReLogin_ReturnsIsFirstLoginFalse() {
     // given
@@ -555,11 +574,15 @@ class AuthServiceTest {
   }
 
   private void saveAgreement(Long userId, AgreementType type) {
+    saveAgreement(userId, type, AgreementAction.AGREE);
+  }
+
+  private void saveAgreement(Long userId, AgreementType type, AgreementAction action) {
     agreementRepository.save(
         UserAgreement.create(
             userId,
             type,
-            AgreementAction.AGREE,
+            action,
             "document",
             LocalDateTime.of(2026, 8, 1, 0, 0),
             AgreementInputContext.INDIVIDUAL,

--- a/bottlenote-product-api/src/test/java/app/docs/agreement/RestAgreementControllerDocsTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/agreement/RestAgreementControllerDocsTest.java
@@ -2,6 +2,7 @@ package app.docs.agreement;
 
 import static app.bottlenote.agreement.constant.AgreementAction.AGREE;
 import static app.bottlenote.agreement.constant.AgreementInputContext.INDIVIDUAL;
+import static app.bottlenote.agreement.constant.AgreementType.MARKETING;
 import static app.bottlenote.agreement.constant.AgreementType.PRIVACY_COLLECTION_USE;
 import static app.bottlenote.agreement.constant.AgreementType.TERMS_OF_SERVICE;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -84,7 +85,8 @@ class RestAgreementControllerDocsTest extends AbstractRestDocs {
         new AgreementSubmitRequest(
             List.of(
                 new Item(TERMS_OF_SERVICE.name(), AGREE, "이용약관 원문", INDIVIDUAL),
-                new Item(PRIVACY_COLLECTION_USE.name(), AGREE, "개인정보 수집 이용 원문", INDIVIDUAL)));
+                new Item(PRIVACY_COLLECTION_USE.name(), AGREE, "개인정보 수집 이용 원문", INDIVIDUAL),
+                new Item(MARKETING.name(), AGREE, "마케팅 정보 수신 동의 원문", INDIVIDUAL)));
     mockMvc
         .perform(
             post("/api/v2/agreements")
@@ -98,7 +100,10 @@ class RestAgreementControllerDocsTest extends AbstractRestDocs {
                 "agreements/submit",
                 requestFields(
                     fieldWithPath("agreements").type(ARRAY).description("제출할 동의 항목"),
-                    fieldWithPath("agreements[].type").type(STRING).description("동의 유형"),
+                    fieldWithPath("agreements[].type")
+                        .type(STRING)
+                        .description(
+                            "동의 유형: TERMS_OF_SERVICE, PRIVACY_COLLECTION_USE 또는 MARKETING"),
                     fieldWithPath("agreements[].action")
                         .type(STRING)
                         .description("동의 의사표시: AGREE 또는 REVOKE"),

--- a/bottlenote-product-api/src/test/java/app/docs/agreement/RestAgreementControllerDocsTest.java
+++ b/bottlenote-product-api/src/test/java/app/docs/agreement/RestAgreementControllerDocsTest.java
@@ -106,7 +106,7 @@ class RestAgreementControllerDocsTest extends AbstractRestDocs {
                             "동의 유형: TERMS_OF_SERVICE, PRIVACY_COLLECTION_USE 또는 MARKETING"),
                     fieldWithPath("agreements[].action")
                         .type(STRING)
-                        .description("동의 의사표시: AGREE 또는 REVOKE"),
+                        .description("사용자 제출 가능 동작: AGREE 또는 REVOKE. EXPIRED는 서버 전용 상태로 제출할 수 없음"),
                     fieldWithPath("agreements[].content")
                         .type(STRING)
                         .description("사용자에게 표시한 문서 원문 스냅샷"),

--- a/plan/agreement-expired-action.md
+++ b/plan/agreement-expired-action.md
@@ -1,0 +1,51 @@
+# Plan: 동의 만료 액션
+
+## Overview
+
+`AgreementAction`에 서버가 기록할 수 있는 만료 상태 `EXPIRED`를 추가한다. 클라이언트 제출 API는 `EXPIRED`를 허용하지 않고 400 오류를 반환하며, 최신 이력이 `EXPIRED`이면 로그인 힌트와 상태 조회에서 `REVOKE`와 동일하게 미동의로 판정한다.
+
+### Assumptions
+
+- `EXPIRED`를 생성하는 배치나 운영 절차는 이번 범위에 포함하지 않는다.
+- 상태 조회 응답은 기존 `agreed` boolean 계약을 유지하고 최신 action 필드를 새로 노출하지 않는다.
+- action 컬럼은 문자열 enum을 저장할 수 있어 스키마 마이그레이션이 필요하지 않다.
+- 로컬에서는 전체 컴파일과 단위 테스트만 실행하고, 통합·문서·규칙·최종 빌드는 main 대상 PR CI로 검증한다.
+
+### Success Criteria
+
+- `AgreementAction.EXPIRED`가 존재한다.
+- 제출 요청에 `EXPIRED`가 포함되면 `UNSUPPORTED_AGREEMENT_ACTION` 코드와 함께 400을 반환하고 저장하지 않는다.
+- 최신 필수 동의 이력이 `EXPIRED`이면 `eligible=false`, 해당 항목은 `agreed=false`다.
+- OpenAPI와 RestDocs가 요청 가능한 action을 `AGREE`, `REVOKE`로 문서화하고 `EXPIRED`가 서버 상태임을 설명한다.
+
+### Impact Scope
+
+- `bottlenote-mono`: enum, 예외 코드, 동의 판정 회귀 테스트
+- `bottlenote-product-api`: 요청 경계 검증, API 통합 테스트, OpenAPI 및 RestDocs 계약
+- DB 스키마, 상태 응답 필드, 만료 생성 주기는 제외
+
+## Execution Mode
+
+- mode: delegated
+- scope: plan, implement, test, verify, commit, push, pr
+- local-verify: 전체 Java/Kotlin 컴파일, 전체 단위 테스트
+- ci-verify: main 대상 기존 PR의 통합 테스트, 문서 테스트, 규칙 테스트, 최종 빌드
+- stop-conditions: 가정 붕괴, verify 3회 반복 실패, scope 밖 행동 필요
+
+## Tasks
+
+### Task 1: 만료 액션 계약 추가
+- Acceptance:
+  - `EXPIRED`는 저장 가능한 도메인 action이지만 사용자 제출 API에서는 400으로 거부된다.
+  - 최신 `EXPIRED` 이력은 `REVOKE`와 동일하게 미동의 및 힌트 필요 상태로 판정된다.
+  - 요청 가능 action과 서버 전용 `EXPIRED`의 구분이 API 문서와 계약 테스트에 반영된다.
+- Verification: 전체 Java/Kotlin 컴파일, 전체 단위 테스트, PR CI
+- Files (advisory): agreement enum, request DTO, exception code, evaluator/controller/docs/OpenAPI tests
+- Depends: 없음
+- Size: M
+- Status: [x] done
+
+## Progress Log
+
+- 2026-08-02: Opus 5 오케스트레이션 검토 결과, enum 추가만으로는 POST가 `EXPIRED`를 저장하므로 요청 경계 차단이 필요함을 확인했다. 기존 evaluator는 `AGREE`만 유효로 보아 운영 로직 변경 없이 회귀 테스트로 요구사항을 고정한다.
+- 2026-08-02: `EXPIRED` enum과 요청 거부 오류를 추가하고, evaluator·로그인 힌트·API 저장 방지·OpenAPI·RestDocs 계약 테스트를 반영했다. 전체 Java/Kotlin 컴파일과 단위 테스트 555개가 통과했다.

--- a/plan/complete/marketing-agreement.md
+++ b/plan/complete/marketing-agreement.md
@@ -1,5 +1,8 @@
 # Plan: 마케팅 선택 동의 추가
 
+Status: Completed
+Completion Date: 2026-08-02
+
 ## Overview
 
 기존 사용자 동의 도메인에 마케팅 정보 수신 동의를 선택 항목으로 추가한다. 동의 상태 응답은 각 유형의 필수 여부와 현재 동의 여부를 함께 제공하고, 전체 동의 자격과 로그인 동의 필요 힌트는 필수 항목만 기준으로 판정한다.
@@ -65,3 +68,4 @@
 - 2026-08-02: plan 완료. 선택 동의 판정 경로와 API 계약의 수직 슬라이스 2개로 분해했으며 Task 2는 Task 1에 의존한다.
 - 2026-08-02: Task 1 완료. 동의 유형에 필수 여부를 추가하고 마케팅을 선택 유형으로 정의했다. Evaluator는 필수 항목만 전체 자격에 반영하며 상태 항목에는 유형별 필수 여부를 노출한다. 관련 compile과 evaluator/service/auth focused unit test가 통과했다.
 - 2026-08-02: Task 2 완료. 제출 API와 OpenAPI 허용값에 MARKETING을 추가하고 상태 응답에서 선택 여부와 최신 동의 상태를 검증하도록 API·문서 계약 테스트를 갱신했다. product-api main/test compile과 전체 unit test가 통과했으며 integration·RestDocs/OpenAPI 실행은 계약대로 PR CI에 위임한다.
+- 2026-08-02: 로컬 최종 검증 완료. 전체 Java/Kotlin main·test compile과 unit test 553개가 실패·오류·스킵 없이 통과했다. self-review는 Critical 0건, Important 0건, Nit 1건이었으며 테스트 설명을 현재 선택 동의 규칙에 맞게 수정해 해소했다. rule·product/admin integration·최종 build는 main 대상 PR CI에서 확인한다.

--- a/plan/marketing-agreement.md
+++ b/plan/marketing-agreement.md
@@ -57,10 +57,11 @@
 - Files (advisory): `AgreementSubmitRequest`, 동의 Controller 통합 테스트, RestDocs/OpenAPI 계약 테스트
 - Depends: Task 1
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ## Progress Log
 
 - 2026-08-02: define 승인. 마케팅을 선택 동의로 추가하고 필수 동의만 전체 자격과 로그인 힌트에 반영하기로 확정했다. 로컬 검증은 compile과 unit test로 제한하며, rule·integration·최종 build는 main 대상 PR CI에서 확인한다.
 - 2026-08-02: plan 완료. 선택 동의 판정 경로와 API 계약의 수직 슬라이스 2개로 분해했으며 Task 2는 Task 1에 의존한다.
 - 2026-08-02: Task 1 완료. 동의 유형에 필수 여부를 추가하고 마케팅을 선택 유형으로 정의했다. Evaluator는 필수 항목만 전체 자격에 반영하며 상태 항목에는 유형별 필수 여부를 노출한다. 관련 compile과 evaluator/service/auth focused unit test가 통과했다.
+- 2026-08-02: Task 2 완료. 제출 API와 OpenAPI 허용값에 MARKETING을 추가하고 상태 응답에서 선택 여부와 최신 동의 상태를 검증하도록 API·문서 계약 테스트를 갱신했다. product-api main/test compile과 전체 unit test가 통과했으며 integration·RestDocs/OpenAPI 실행은 계약대로 PR CI에 위임한다.

--- a/plan/marketing-agreement.md
+++ b/plan/marketing-agreement.md
@@ -1,0 +1,66 @@
+# Plan: 마케팅 선택 동의 추가
+
+## Overview
+
+기존 사용자 동의 도메인에 마케팅 정보 수신 동의를 선택 항목으로 추가한다. 동의 상태 응답은 각 유형의 필수 여부와 현재 동의 여부를 함께 제공하고, 전체 동의 자격과 로그인 동의 필요 힌트는 필수 항목만 기준으로 판정한다.
+
+### Assumptions
+
+1. 대상은 product-api의 기존 사용자 동의 조회·제출 및 로그인 힌트 흐름이다.
+2. 새 동의 유형의 식별자는 `MARKETING`, 설명은 `마케팅 정보 수신 동의`, 필수 여부는 `false`다.
+3. `TERMS_OF_SERVICE`, `PRIVACY_COLLECTION_USE`의 필수 여부는 `true`다.
+4. 마케팅 동의와 철회는 기존 append-only 동의 이력과 기존 제출 API를 사용한다.
+5. 상태 API는 마케팅 항목도 `required=false`와 최신 `agreed` 상태를 포함해 반환한다.
+6. 전체 `eligible`과 로그인 `agreementRequired`는 필수 동의 유형만 기준으로 계산한다.
+7. 실제 마케팅 메시지 발송과 채널별 수신 설정은 범위에서 제외한다.
+8. 동의 유형은 문자열 컬럼에 저장되므로 DB 스키마 마이그레이션은 필요하지 않다.
+
+### Success Criteria
+
+1. 동의 제출 API가 `MARKETING`의 `AGREE`와 `REVOKE`를 기존 방식으로 기록한다.
+2. 상태 API가 `MARKETING` 항목에 `required=false`와 최신 동의 상태를 반환한다.
+3. 마케팅 미동의 상태에서도 기존 필수 동의 두 유형이 모두 동의면 `eligible=true`다.
+4. 마케팅 미동의 상태에서도 기존 필수 동의 두 유형이 모두 동의면 로그인 응답의 `agreementRequired=false`다.
+5. 기존 필수 동의 중 하나라도 미동의면 마케팅 상태와 관계없이 `eligible=false`, `agreementRequired=true`다.
+6. OpenAPI 문서가 `MARKETING`을 제출 가능한 동의 유형으로 노출한다.
+7. 로컬 Java/Kotlin compile과 전체 unit test가 통과한다.
+8. main 대상 PR의 CI에서 rule, product/admin integration, 최종 build를 포함한 전체 파이프라인이 통과한다.
+
+### Impact Scope
+
+- `bottlenote-mono`: 동의 유형의 필수 여부와 동의 자격 판정
+- `bottlenote-product-api`: 동의 제출 API의 OpenAPI 계약과 상태 응답 회귀
+- 테스트: 동의 평가·서비스·로그인 힌트 단위 테스트 및 API 문서 계약
+- DB migration, admin-api 기능, batch, 실제 마케팅 발송 로직은 영향 범위에서 제외
+
+## Execution Mode
+
+- mode: delegated
+- scope: plan, implement, test, verify, commit, push, pr
+- local-verify: Java/Kotlin compile, unit test only
+- ci-verify: main 대상 PR의 `ci_pipeline.yml` 완료 확인
+- stop-conditions: 가정 붕괴, verify 3회 실패, scope 밖 행동
+
+## Tasks
+
+### Task 1: 선택 동의 판정 경로
+- Acceptance: `MARKETING`은 `required=false`로 평가되고 최신 동의 상태는 항목에 노출되지만, 필수 유형이 모두 동의면 마케팅 상태와 무관하게 `eligible=true`, 로그인 `agreementRequired=false`가 된다.
+- Verification: 전체 Java/Kotlin compile, `./gradlew unit_test`
+- Files (advisory): `AgreementType`, `AgreementEvaluator`, evaluator/service/auth 단위 테스트
+- Depends: 없음
+- Size: M
+- Status: [x] done
+
+### Task 2: 마케팅 동의 API 계약
+- Acceptance: 기존 제출 API가 `MARKETING`을 허용하고 OpenAPI에 해당 값을 노출하며, 상태 응답은 마케팅 항목의 `required=false`와 최신 `agreed` 값을 반환한다.
+- Verification: 로컬 compile·unit test, main 대상 PR CI의 product integration·RestDocs/OpenAPI 결과
+- Files (advisory): `AgreementSubmitRequest`, 동의 Controller 통합 테스트, RestDocs/OpenAPI 계약 테스트
+- Depends: Task 1
+- Size: M
+- Status: [ ] not done
+
+## Progress Log
+
+- 2026-08-02: define 승인. 마케팅을 선택 동의로 추가하고 필수 동의만 전체 자격과 로그인 힌트에 반영하기로 확정했다. 로컬 검증은 compile과 unit test로 제한하며, rule·integration·최종 build는 main 대상 PR CI에서 확인한다.
+- 2026-08-02: plan 완료. 선택 동의 판정 경로와 API 계약의 수직 슬라이스 2개로 분해했으며 Task 2는 Task 1에 의존한다.
+- 2026-08-02: Task 1 완료. 동의 유형에 필수 여부를 추가하고 마케팅을 선택 유형으로 정의했다. Evaluator는 필수 항목만 전체 자격에 반영하며 상태 항목에는 유형별 필수 여부를 노출한다. 관련 compile과 evaluator/service/auth focused unit test가 통과했다.


### PR DESCRIPTION
## 변경 사항

- 사용자 동의 유형에 선택 항목인 `MARKETING`을 추가했습니다.
- 유형별 `required` 값을 상태 응답에 반영하고, 필수 항목만 `eligible` 및 `agreementRequired` 계산에 사용합니다.
- `AgreementAction.EXPIRED`를 추가하고, 최신 만료 이력을 철회와 동일하게 미동의로 판정합니다.
- 제출 API의 `EXPIRED` 요청은 `UNSUPPORTED_AGREEMENT_ACTION` 400 응답으로 거부하고 저장하지 않습니다.
- 상태 조회, 제출, 로그인 힌트, RestDocs/OpenAPI 계약 테스트를 갱신했습니다.

## 배경

마케팅 수신 동의는 기존 약관 동의와 동일한 append-only 이력으로 관리하되 필수 동의 충족 여부에는 영향을 주지 않습니다. 만료 상태는 서버가 기록할 수 있지만 클라이언트가 임의로 제출할 수 없어야 합니다.

## 영향

- 기존 필수 동의 두 항목의 판정은 유지됩니다.
- 마케팅 미동의 사용자는 필수 동의를 모두 충족하면 `agreementRequired=false`입니다.
- 필수 동의의 최신 이력이 `EXPIRED`이면 `agreementRequired=true`입니다.
- 상태 조회 응답 필드와 DB 스키마는 변경하지 않습니다.
- 만료 상태를 생성하는 배치·운영 절차와 실제 마케팅 발송은 포함하지 않습니다.

## 검증

- 전체 Java/Kotlin main 및 test compile 통과
- unit test 555개 통과, 실패 0, 오류 0, 스킵 0
- 로컬 integration test는 실행하지 않았으며 main 대상 PR CI에서 rule, product/admin integration, 문서 및 최종 build를 확인합니다.

Related to bottle-note/workspace#311
