### PR TITLE
feat: Admin OpenAPI 전환 및 레거시 문서 제거

### DIFF
--- a/bottlenote-admin-api/build.gradle.kts
+++ b/bottlenote-admin-api/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 
+	// OpenAPI
+	implementation(libs.springdoc.openapi.starter.webmvc.ui)
+
 	// Security
 	implementation(libs.spring.boot.starter.security)
 	implementation(libs.spring.security.test)

--- a/bottlenote-admin-api/build.gradle.kts
+++ b/bottlenote-admin-api/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
 	testImplementation(libs.spring.boot.starter.data.jpa)
 	testImplementation(libs.mysql.connector.j)
 
+	// Test - Architecture rules
+	testImplementation(libs.archunit)
+
 	// Test - Spring REST Docs
 	add("asciidoctorExt", libs.spring.restdocs.asciidoctor)
 	testImplementation(libs.spring.restdocs.mockmvc)

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.presentation
 import app.bottlenote.alcohols.dto.request.AdminAlcoholSearchRequest
 import app.bottlenote.alcohols.dto.request.AdminAlcoholUpsertRequest
 import app.bottlenote.alcohols.dto.request.AlcoholLookupRequest
+import app.bottlenote.alcohols.presentation.docs.AdminAlcoholsApiDocs
 import app.bottlenote.alcohols.service.AdminAlcoholCommandService
 import app.bottlenote.alcohols.service.AlcoholLookupService
 import app.bottlenote.alcohols.service.AlcoholQueryService
@@ -14,15 +15,17 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/alcohols")
+@AdminAlcoholsApiDocs.ApiTag
 class AdminAlcoholsController(
 	private val alcoholQueryService: AlcoholQueryService,
 	private val adminAlcoholCommandService: AdminAlcoholCommandService,
 	private val alcoholLookupService: AlcoholLookupService
 ) {
+	@AdminAlcoholsApiDocs.GetAlcoholLookups
 	@GetMapping("/lookup")
 	fun getAlcoholLookups(
 		@ModelAttribute @Valid request: AlcoholLookupRequest
-	): ResponseEntity<*> {
+	): ResponseEntity<GlobalResponse> {
 		val response = alcoholLookupService.lookup(request)
 		return GlobalResponse.ok(
 			response.items(),
@@ -32,32 +35,39 @@ class AdminAlcoholsController(
 		)
 	}
 
+	@AdminAlcoholsApiDocs.SearchAlcohols
 	@GetMapping
 	fun searchAlcohols(
 		@ModelAttribute request: AdminAlcoholSearchRequest
 	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(alcoholQueryService.searchAdminAlcohols(request))
 
+	@AdminAlcoholsApiDocs.GetAlcoholDetail
 	@GetMapping("/{alcoholId}")
 	fun getAlcoholDetail(
 		@PathVariable alcoholId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(alcoholQueryService.findAdminAlcoholDetailById(alcoholId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(alcoholQueryService.findAdminAlcoholDetailById(alcoholId))
 
+	@AdminAlcoholsApiDocs.GetCategoryReference
 	@GetMapping("/categories/reference")
-	fun getCategoryReference(): ResponseEntity<*> = GlobalResponse.ok(alcoholQueryService.findAllCategoryReferenceMap())
+	fun getCategoryReference(): ResponseEntity<GlobalResponse> =
+		GlobalResponse.ok(alcoholQueryService.findAllCategoryReferenceMap())
 
+	@AdminAlcoholsApiDocs.CreateAlcohol
 	@PostMapping
 	fun createAlcohol(
 		@RequestBody @Valid request: AdminAlcoholUpsertRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminAlcoholCommandService.createAlcohol(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminAlcoholCommandService.createAlcohol(request))
 
+	@AdminAlcoholsApiDocs.UpdateAlcohol
 	@PutMapping("/{alcoholId}")
 	fun updateAlcohol(
 		@PathVariable alcoholId: Long,
 		@RequestBody @Valid request: AdminAlcoholUpsertRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminAlcoholCommandService.updateAlcohol(alcoholId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminAlcoholCommandService.updateAlcohol(alcoholId, request))
 
+	@AdminAlcoholsApiDocs.DeleteAlcohol
 	@DeleteMapping("/{alcoholId}")
 	fun deleteAlcohol(
 		@PathVariable alcoholId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminAlcoholCommandService.deleteAlcohol(alcoholId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminAlcoholCommandService.deleteAlcohol(alcoholId))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
@@ -49,8 +49,7 @@ class AdminAlcoholsController(
 
 	@AdminAlcoholsApiDocs.GetCategoryReference
 	@GetMapping("/categories/reference")
-	fun getCategoryReference(): ResponseEntity<GlobalResponse> =
-		GlobalResponse.ok(alcoholQueryService.findAllCategoryReferenceMap())
+	fun getCategoryReference(): ResponseEntity<GlobalResponse> = GlobalResponse.ok(alcoholQueryService.findAllCategoryReferenceMap())
 
 	@AdminAlcoholsApiDocs.CreateAlcohol
 	@PostMapping

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminCurationController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminCurationController.kt
@@ -58,8 +58,7 @@ class AdminCurationController(
 	fun updateDisplayOrder(
 		@PathVariable curationId: Long,
 		@RequestBody @Valid request: AdminCurationDisplayOrderRequest
-	): ResponseEntity<GlobalResponse> =
-		GlobalResponse.ok(adminCurationService.updateDisplayOrder(curationId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.updateDisplayOrder(curationId, request))
 
 	@AdminCurationApiDocs.ReorderCurations
 	@PatchMapping("/bulk/reorder")

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminCurationController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminCurationController.kt
@@ -1,6 +1,7 @@
 package app.bottlenote.alcohols.presentation
 
 import app.bottlenote.alcohols.dto.request.*
+import app.bottlenote.alcohols.presentation.docs.AdminCurationApiDocs
 import app.bottlenote.alcohols.service.AdminCurationService
 import app.bottlenote.global.data.response.GlobalResponse
 import app.bottlenote.global.dto.request.AdminBulkReorderRequest
@@ -10,61 +11,73 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/curations")
+@AdminCurationApiDocs.ApiTag
 class AdminCurationController(
 	private val adminCurationService: AdminCurationService
 ) {
+	@AdminCurationApiDocs.GetAllCurations
 	@GetMapping
 	fun list(
 		@ModelAttribute request: AdminCurationSearchRequest
 	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(adminCurationService.search(request))
 
+	@AdminCurationApiDocs.GetCurationDetail
 	@GetMapping("/{curationId}")
 	fun detail(
 		@PathVariable curationId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.getDetail(curationId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.getDetail(curationId))
 
+	@AdminCurationApiDocs.CreateCuration
 	@PostMapping
 	fun create(
 		@RequestBody @Valid request: AdminCurationCreateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.create(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.create(request))
 
+	@AdminCurationApiDocs.UpdateCuration
 	@PutMapping("/{curationId}")
 	fun update(
 		@PathVariable curationId: Long,
 		@RequestBody @Valid request: AdminCurationUpdateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.update(curationId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.update(curationId, request))
 
+	@AdminCurationApiDocs.DeleteCuration
 	@DeleteMapping("/{curationId}")
 	fun delete(
 		@PathVariable curationId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.delete(curationId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.delete(curationId))
 
+	@AdminCurationApiDocs.UpdateCurationStatus
 	@PatchMapping("/{curationId}/status")
 	fun updateStatus(
 		@PathVariable curationId: Long,
 		@RequestBody @Valid request: AdminCurationStatusRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.updateStatus(curationId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.updateStatus(curationId, request))
 
+	@AdminCurationApiDocs.UpdateCurationDisplayOrder
 	@PatchMapping("/{curationId}/display-order")
 	fun updateDisplayOrder(
 		@PathVariable curationId: Long,
 		@RequestBody @Valid request: AdminCurationDisplayOrderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.updateDisplayOrder(curationId, request))
+	): ResponseEntity<GlobalResponse> =
+		GlobalResponse.ok(adminCurationService.updateDisplayOrder(curationId, request))
 
+	@AdminCurationApiDocs.ReorderCurations
 	@PatchMapping("/bulk/reorder")
 	fun reorder(
 		@RequestBody @Valid request: AdminBulkReorderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.reorder(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.reorder(request))
 
+	@AdminCurationApiDocs.AddAlcoholsToCuration
 	@PostMapping("/{curationId}/alcohols")
 	fun addAlcohols(
 		@PathVariable curationId: Long,
 		@RequestBody @Valid request: AdminCurationAlcoholRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.addAlcohols(curationId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.addAlcohols(curationId, request))
 
+	@AdminCurationApiDocs.RemoveAlcoholFromCuration
 	@DeleteMapping("/{curationId}/alcohols/{alcoholId}")
 	fun removeAlcohol(
 		@PathVariable curationId: Long,
 		@PathVariable alcoholId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminCurationService.removeAlcohol(curationId, alcoholId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminCurationService.removeAlcohol(curationId, alcoholId))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminDistilleryController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminDistilleryController.kt
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.presentation
 import app.bottlenote.alcohols.dto.request.AdminDistillerySortOrderRequest
 import app.bottlenote.alcohols.dto.request.AdminDistilleryUpsertRequest
 import app.bottlenote.alcohols.dto.request.AdminReferenceSearchRequest
+import app.bottlenote.alcohols.presentation.docs.AdminDistilleryApiDocs
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.alcohols.service.DistilleryService
 import app.bottlenote.global.data.response.GlobalResponse
@@ -22,44 +23,52 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/distilleries")
+@AdminDistilleryApiDocs.ApiTag
 class AdminDistilleryController(
 	private val alcoholReferenceService: AlcoholReferenceService,
 	private val distilleryService: DistilleryService
 ) {
+	@AdminDistilleryApiDocs.GetAllDistilleries
 	@GetMapping
 	fun getAllDistilleries(
 		@ModelAttribute request: AdminReferenceSearchRequest
-	): ResponseEntity<*> = ResponseEntity.ok(alcoholReferenceService.findAllDistilleries(request))
+	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(alcoholReferenceService.findAllDistilleries(request))
 
+	@AdminDistilleryApiDocs.GetDistilleryDetail
 	@GetMapping("/{distilleryId}")
 	fun getDistilleryDetail(
 		@PathVariable distilleryId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.getDetail(distilleryId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(distilleryService.getDetail(distilleryId))
 
+	@AdminDistilleryApiDocs.CreateDistillery
 	@PostMapping
 	fun createDistillery(
 		@RequestBody @Valid request: AdminDistilleryUpsertRequest
-	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.create(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(distilleryService.create(request))
 
+	@AdminDistilleryApiDocs.UpdateDistillery
 	@PutMapping("/{distilleryId}")
 	fun updateDistillery(
 		@PathVariable distilleryId: Long,
 		@RequestBody @Valid request: AdminDistilleryUpsertRequest
-	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.update(distilleryId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(distilleryService.update(distilleryId, request))
 
+	@AdminDistilleryApiDocs.DeleteDistillery
 	@DeleteMapping("/{distilleryId}")
 	fun deleteDistillery(
 		@PathVariable distilleryId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.delete(distilleryId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(distilleryService.delete(distilleryId))
 
+	@AdminDistilleryApiDocs.UpdateDistillerySortOrder
 	@PatchMapping("/{distilleryId}/sort-order")
 	fun updateSortOrder(
 		@PathVariable distilleryId: Long,
 		@RequestBody @Valid request: AdminDistillerySortOrderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.updateSortOrder(distilleryId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(distilleryService.updateSortOrder(distilleryId, request))
 
+	@AdminDistilleryApiDocs.ReorderDistilleries
 	@PatchMapping("/bulk/reorder")
 	fun reorder(
 		@RequestBody @Valid request: AdminBulkReorderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(distilleryService.reorder(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(distilleryService.reorder(request))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminRegionController.kt
@@ -4,6 +4,7 @@ import app.bottlenote.alcohols.dto.request.AdminReferenceSearchRequest
 import app.bottlenote.alcohols.dto.request.AdminRegionCreateRequest
 import app.bottlenote.alcohols.dto.request.AdminRegionSortOrderRequest
 import app.bottlenote.alcohols.dto.request.AdminRegionUpdateRequest
+import app.bottlenote.alcohols.presentation.docs.AdminRegionApiDocs
 import app.bottlenote.alcohols.service.AdminRegionService
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.global.data.response.GlobalResponse
@@ -23,50 +24,59 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/regions")
+@AdminRegionApiDocs.ApiTag
 class AdminRegionController(
 	private val alcoholReferenceService: AlcoholReferenceService,
 	private val adminRegionService: AdminRegionService
 ) {
+	@AdminRegionApiDocs.GetAllRegions
 	@GetMapping
 	fun getAllRegions(
 		@ModelAttribute request: AdminReferenceSearchRequest
-	): ResponseEntity<*> = ResponseEntity.ok(alcoholReferenceService.findAllRegionsForAdmin(request))
+	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(alcoholReferenceService.findAllRegionsForAdmin(request))
 
+	@AdminRegionApiDocs.GetRegionDetail
 	@GetMapping("/{regionId}")
 	fun detail(
 		@PathVariable regionId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.getDetail(regionId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminRegionService.getDetail(regionId))
 
+	@AdminRegionApiDocs.CreateRegion
 	@PostMapping
 	fun create(
 		@RequestBody @Valid request: AdminRegionCreateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.create(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminRegionService.create(request))
 
+	@AdminRegionApiDocs.UpdateRegion
 	@PutMapping("/{regionId}")
 	fun update(
 		@PathVariable regionId: Long,
 		@RequestBody @Valid request: AdminRegionUpdateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.update(regionId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminRegionService.update(regionId, request))
 
+	@AdminRegionApiDocs.DeleteRegion
 	@DeleteMapping("/{regionId}")
 	fun delete(
 		@PathVariable regionId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.delete(regionId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminRegionService.delete(regionId))
 
+	@AdminRegionApiDocs.UpdateRegionSortOrder
 	@PatchMapping("/{regionId}/sort-order")
 	fun updateSortOrder(
 		@PathVariable regionId: Long,
 		@RequestBody @Valid request: AdminRegionSortOrderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.updateSortOrder(regionId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminRegionService.updateSortOrder(regionId, request))
 
+	@AdminRegionApiDocs.ReorderRegions
 	@PatchMapping("/bulk/reorder")
 	fun reorder(
 		@RequestBody @Valid request: AdminBulkReorderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.reorder(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminRegionService.reorder(request))
 
+	@AdminRegionApiDocs.ReorderRegionChildren
 	@PatchMapping("/{parentId}/children/bulk/reorder")
 	fun reorderChildren(
 		@PathVariable parentId: Long,
 		@RequestBody @Valid request: AdminBulkReorderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminRegionService.reorderChildren(parentId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminRegionService.reorderChildren(parentId, request))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminTastingTagController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminTastingTagController.kt
@@ -3,6 +3,7 @@ package app.bottlenote.alcohols.presentation
 import app.bottlenote.alcohols.dto.request.AdminReferenceSearchRequest
 import app.bottlenote.alcohols.dto.request.AdminTastingTagAlcoholRequest
 import app.bottlenote.alcohols.dto.request.AdminTastingTagUpsertRequest
+import app.bottlenote.alcohols.presentation.docs.AdminTastingTagApiDocs
 import app.bottlenote.alcohols.service.AlcoholReferenceService
 import app.bottlenote.alcohols.service.TastingTagService
 import app.bottlenote.global.data.response.GlobalResponse
@@ -12,45 +13,53 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/tasting-tags")
+@AdminTastingTagApiDocs.ApiTag
 class AdminTastingTagController(
 	private val alcoholReferenceService: AlcoholReferenceService,
 	private val tastingTagService: TastingTagService
 ) {
+	@AdminTastingTagApiDocs.GetAllTastingTags
 	@GetMapping
 	fun getAllTastingTags(
 		@ModelAttribute request: AdminReferenceSearchRequest
-	): ResponseEntity<*> = ResponseEntity.ok(alcoholReferenceService.findAllTastingTags(request))
+	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(alcoholReferenceService.findAllTastingTags(request))
 
+	@AdminTastingTagApiDocs.GetTastingTagDetail
 	@GetMapping("/{tagId}")
 	fun getTagDetail(
 		@PathVariable tagId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(tastingTagService.getTagDetail(tagId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(tastingTagService.getTagDetail(tagId))
 
+	@AdminTastingTagApiDocs.CreateTastingTag
 	@PostMapping
 	fun createTag(
 		@RequestBody @Valid request: AdminTastingTagUpsertRequest
-	): ResponseEntity<*> = GlobalResponse.ok(tastingTagService.createTag(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(tastingTagService.createTag(request))
 
+	@AdminTastingTagApiDocs.UpdateTastingTag
 	@PutMapping("/{tagId}")
 	fun updateTag(
 		@PathVariable tagId: Long,
 		@RequestBody @Valid request: AdminTastingTagUpsertRequest
-	): ResponseEntity<*> = GlobalResponse.ok(tastingTagService.updateTag(tagId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(tastingTagService.updateTag(tagId, request))
 
+	@AdminTastingTagApiDocs.DeleteTastingTag
 	@DeleteMapping("/{tagId}")
 	fun deleteTag(
 		@PathVariable tagId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(tastingTagService.deleteTag(tagId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(tastingTagService.deleteTag(tagId))
 
+	@AdminTastingTagApiDocs.AddAlcoholsToTastingTag
 	@PostMapping("/{tagId}/alcohols")
 	fun addAlcoholsToTag(
 		@PathVariable tagId: Long,
 		@RequestBody @Valid request: AdminTastingTagAlcoholRequest
-	): ResponseEntity<*> = GlobalResponse.ok(tastingTagService.addAlcoholsToTag(tagId, request.alcoholIds()))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(tastingTagService.addAlcoholsToTag(tagId, request.alcoholIds()))
 
+	@AdminTastingTagApiDocs.RemoveAlcoholsFromTastingTag
 	@DeleteMapping("/{tagId}/alcohols")
 	fun removeAlcoholsFromTag(
 		@PathVariable tagId: Long,
 		@RequestBody @Valid request: AdminTastingTagAlcoholRequest
-	): ResponseEntity<*> = GlobalResponse.ok(tastingTagService.removeAlcoholsFromTag(tagId, request.alcoholIds()))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(tastingTagService.removeAlcoholsFromTag(tagId, request.alcoholIds()))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminAlcoholsApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminAlcoholsApiDocs.kt
@@ -1,0 +1,157 @@
+package app.bottlenote.alcohols.presentation.docs
+
+import app.bottlenote.alcohols.dto.response.AdminAlcoholDetailResponse
+import app.bottlenote.alcohols.dto.response.AdminAlcoholItem
+import app.bottlenote.alcohols.dto.response.AlcoholLookupItem
+import app.bottlenote.alcohols.dto.response.CategoryPairItem
+import app.bottlenote.global.dto.response.AdminResultResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 위스키 기본 정보 엔드포인트의 문서 설명. */
+object AdminAlcoholsApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "위스키", description = "위스키 기본 정보를 등록·수정·삭제하고 목록·상세·룩업·카테고리 기준 정보를 조회한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "위스키 룩업 목록을 조회한다",
+		description = """
+			검색어, 카테고리, 지역, 증류소, 커서로 위스키 룩업 목록을 커서 방식으로 조회합니다.
+
+			다른 화면에서 위스키를 빠르게 선택할 때 쓰는 경량 목록이며, Redis 스냅샷을 우선 사용하고 비어 있으면 DB로 폴백합니다.
+			다음 페이지 정보는 meta.pageable에, 요청 파라미터는 meta.searchParameters에 담깁니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "위스키 룩업 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AlcoholLookupItem::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAlcoholLookups
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "위스키 목록을 검색한다",
+		description = "검색어, 카테고리, 지역, 정렬 기준·방향, 페이지 번호·크기, 삭제 데이터 포함 여부로 위스키 목록을 페이지 단위로 조회합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "위스키 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AdminAlcoholItem::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class SearchAlcohols
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "위스키 상세 정보를 조회한다",
+		description = "위스키 ID로 단일 위스키의 상세 정보를 조회합니다. 지역·증류소·테이스팅 태그 정보와 평점·리뷰·픽 집계를 함께 반환합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "위스키 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminAlcoholDetailResponse::class))]
+			)
+		]
+	)
+	annotation class GetAlcoholDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "카테고리 기준 정보를 조회한다",
+		description = """
+			등록·수정 폼에서 카테고리를 고를 때 쓰는 기준 정보입니다.
+
+			카테고리 그룹(AlcoholCategoryGroup) 이름을 키로, 그 그룹에 속한 한글/영문 카테고리 쌍(CategoryPairItem) 배열을 값으로 갖는 객체를 반환합니다.
+			데이터가 없는 그룹도 빈 배열로 포함되며, 그룹 순서는 enum 선언 순서로 고정됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "카테고리 그룹별 카테고리 쌍 목록",
+				content = [
+					Content(schema = Schema(implementation = AlcoholCategoryReferenceSchema::class))
+				]
+			)
+		]
+	)
+	annotation class GetCategoryReference
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "위스키를 등록한다",
+		description = "새 위스키를 등록합니다. 이름, 도수, 타입, 카테고리, 지역, 증류소 등 기본 정보를 입력하며, tastingTagIds로 테이스팅 태그를 함께 연결할 수 있습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class CreateAlcohol
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "위스키 정보를 수정한다",
+		description = "기존 위스키의 기본 정보를 수정합니다. 이미 삭제된 위스키는 수정할 수 없습니다. tastingTagIds를 보내면 기존 연결을 모두 교체합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "수정 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateAlcohol
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "위스키를 삭제한다",
+		description = "위스키를 삭제합니다. 이미 삭제된 위스키이거나 리뷰·평점이 하나라도 있으면 삭제할 수 없습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "삭제 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class DeleteAlcohol
+}
+
+@Schema(name = "AlcoholCategoryReference", description = "카테고리 그룹별 한글·영문 카테고리 쌍 목록")
+internal data class AlcoholCategoryReferenceSchema(
+	val SINGLE_MALT: List<CategoryPairItem>,
+	val BLEND: List<CategoryPairItem>,
+	val BLENDED_MALT: List<CategoryPairItem>,
+	val BOURBON: List<CategoryPairItem>,
+	val RYE: List<CategoryPairItem>,
+	val OTHER: List<CategoryPairItem>
+)

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminCurationApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminCurationApiDocs.kt
@@ -1,0 +1,182 @@
+package app.bottlenote.alcohols.presentation.docs
+
+import app.bottlenote.alcohols.dto.response.AdminCurationDetailResponse
+import app.bottlenote.alcohols.dto.response.AdminCurationListResponse
+import app.bottlenote.global.dto.response.AdminResultResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 큐레이션 엔드포인트의 문서 설명. */
+object AdminCurationApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "큐레이션", description = "위스키를 묶어 노출하는 큐레이션을 등록·수정·삭제하고 정렬 순서와 포함 위스키를 관리한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션 목록을 조회한다",
+		description = """
+			검색어, 활성화 상태, 페이지 번호·크기로 큐레이션 목록을 페이지 단위로 조회합니다.
+
+			isActive를 비우면 활성/비활성 여부와 관계없이 전체 큐레이션을 반환합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "큐레이션 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AdminCurationListResponse::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAllCurations
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션 상세 정보를 조회한다",
+		description = "큐레이션 ID로 단일 큐레이션의 상세 정보를 조회합니다. 포함된 위스키 목록을 함께 반환합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "큐레이션 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminCurationDetailResponse::class))]
+			)
+		]
+	)
+	annotation class GetCurationDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션을 등록한다",
+		description = "새 큐레이션을 등록합니다. 이름이 이미 등록된 큐레이션과 중복되면 실패합니다. alcoholIds로 포함할 위스키를 함께 지정할 수 있습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class CreateCuration
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션 정보를 수정한다",
+		description = "기존 큐레이션의 이름, 설명, 커버 이미지, 노출 순서, 활성화 상태, 포함 위스키 목록을 한 번에 수정합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "수정 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateCuration
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션을 삭제한다",
+		description = "큐레이션을 삭제합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "삭제 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class DeleteCuration
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션 활성화 상태를 변경한다",
+		description = "큐레이션의 활성/비활성 상태만 변경합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "활성화 상태 변경 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateCurationStatus
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션 노출 순서를 변경한다",
+		description = "단일 큐레이션의 노출 순서 값을 변경합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "노출 순서 변경 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateCurationDisplayOrder
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션 목록을 일괄 재정렬한다",
+		description = """
+			큐레이션 ID 목록을 원하는 순서대로 보내면 그 순서대로 노출 순서를 다시 매깁니다.
+
+			목록에 포함되지 않은 나머지 큐레이션은 기존 순서를 유지한 채 뒤로 이어 붙습니다. ID가 중복되면 실패합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "재정렬 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class ReorderCurations
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션에 위스키를 추가한다",
+		description = "위스키 ID 목록을 받아 해당 큐레이션에 일괄로 추가합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "추가 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class AddAlcoholsToCuration
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션에서 위스키를 제거한다",
+		description = "큐레이션에 포함된 위스키 하나를 제거합니다. 포함되지 않은 위스키 ID를 보내면 실패합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "제거 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class RemoveAlcoholFromCuration
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminDistilleryApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminDistilleryApiDocs.kt
@@ -1,0 +1,140 @@
+package app.bottlenote.alcohols.presentation.docs
+
+import app.bottlenote.alcohols.dto.response.AdminDistilleryItem
+import app.bottlenote.global.dto.response.AdminResultResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 증류소 기준 정보 엔드포인트의 문서 설명. */
+object AdminDistilleryApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "증류소", description = "위스키 증류소 기준 정보를 등록·수정·삭제하고 정렬 순서를 관리한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "증류소 목록을 조회한다",
+		description = """
+			검색어, 정렬 방향, 페이지 번호·크기로 증류소 목록을 페이지 단위로 조회합니다.
+
+			keyword를 비우면 전체 증류소를 반환하며, sortOrder를 지정하지 않으면 오름차순(ASC)이 기본값입니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "증류소 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AdminDistilleryItem::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAllDistilleries
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "증류소 상세 정보를 조회한다",
+		description = "증류소 ID로 단일 증류소의 상세 정보를 조회합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "증류소 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminDistilleryItem::class))]
+			)
+		]
+	)
+	annotation class GetDistilleryDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "증류소를 등록한다",
+		description = """
+			새 증류소를 등록합니다.
+
+			한글/영문 이름이 이미 등록된 증류소와 중복되면 실패합니다. 정렬 순서를 지정하지 않으면 맨 뒤에 배치됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class CreateDistillery
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "증류소 정보를 수정한다",
+		description = "기존 증류소의 이름, 이미지, 정렬 순서를 수정합니다. 이름을 변경하면 다른 증류소와의 중복 여부를 다시 검사합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "수정 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateDistillery
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "증류소를 삭제한다",
+		description = "증류소를 삭제합니다. 해당 증류소로 등록된 위스키가 하나라도 있으면 삭제할 수 없습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "삭제 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class DeleteDistillery
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "증류소 정렬 순서를 변경한다",
+		description = "단일 증류소의 정렬 순서 값을 변경합니다. 기존에 같은 순서 이상을 쓰던 증류소들은 뒤로 한 칸씩 밀립니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "정렬 순서 변경 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateDistillerySortOrder
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "증류소 목록을 일괄 재정렬한다",
+		description = """
+			증류소 ID 목록을 원하는 순서대로 보내면 그 순서대로 정렬 순서를 다시 매깁니다.
+
+			목록에 포함되지 않은 나머지 증류소는 기존 순서를 유지한 채 뒤로 이어 붙습니다. ID가 중복되면 실패합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "재정렬 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class ReorderDistilleries
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminRegionApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminRegionApiDocs.kt
@@ -1,0 +1,156 @@
+package app.bottlenote.alcohols.presentation.docs
+
+import app.bottlenote.alcohols.dto.response.AdminRegionDetailResponse
+import app.bottlenote.alcohols.dto.response.AdminRegionItem
+import app.bottlenote.global.dto.response.AdminResultResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 지역 기준 정보 엔드포인트의 문서 설명. */
+object AdminRegionApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "지역", description = "위스키 생산 지역 기준 정보를 등록·수정·삭제하고 정렬 순서를 관리한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "지역 목록을 조회한다",
+		description = """
+			검색어, 정렬 방향, 페이지 번호·크기로 지역 목록을 페이지 단위로 조회합니다.
+
+			keyword를 비우면 전체 지역을 반환하며, 부모/자식 지역이 모두 같은 목록에 평면적으로 포함됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "지역 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AdminRegionItem::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAllRegions
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "지역 상세 정보를 조회한다",
+		description = "지역 ID로 단일 지역의 상세 정보를 조회합니다. 부모 지역 정보, 자식 지역 존재 여부, 연결된 위스키 수를 함께 반환합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "지역 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminRegionDetailResponse::class))]
+			)
+		]
+	)
+	annotation class GetRegionDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "지역을 등록한다",
+		description = """
+			새 지역을 등록합니다.
+
+			한글/영문 이름이 중복되면 실패합니다. parentId를 지정하면 해당 지역의 하위 지역으로 등록되며, 깊이는 최대 2단계(부모-자식)까지만 허용됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class CreateRegion
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "지역 정보를 수정한다",
+		description = "기존 지역의 이름, 대륙, 설명, 이미지, 상위 지역, 정렬 순서를 수정합니다. 자기 자신을 부모로 지정하거나 순환 참조가 발생하면 실패합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "수정 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateRegion
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "지역을 삭제한다",
+		description = "지역을 삭제합니다. 하위 지역이 있거나 해당 지역으로 등록된 위스키가 있으면 삭제할 수 없습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "삭제 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class DeleteRegion
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "지역 정렬 순서를 변경한다",
+		description = "단일 지역의 정렬 순서 값을 변경합니다. 기존에 같은 순서 이상을 쓰던 지역들은 뒤로 한 칸씩 밀립니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "정렬 순서 변경 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateRegionSortOrder
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "최상위 지역 목록을 일괄 재정렬한다",
+		description = """
+			지역 ID 목록을 원하는 순서대로 보내면 그 순서대로 정렬 순서를 다시 매깁니다.
+
+			목록에 포함되지 않은 나머지 지역은 기존 순서를 유지한 채 뒤로 이어 붙습니다. ID가 중복되면 실패합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "재정렬 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class ReorderRegions
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "특정 지역의 하위 지역 목록을 일괄 재정렬한다",
+		description = "부모 지역 ID로 범위를 한정해, 그 하위 지역들만 요청한 순서대로 정렬 순서를 다시 매깁니다. 부모 지역이 없으면 실패합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "재정렬 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class ReorderRegionChildren
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminTastingTagApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminTastingTagApiDocs.kt
@@ -1,0 +1,141 @@
+package app.bottlenote.alcohols.presentation.docs
+
+import app.bottlenote.alcohols.dto.response.AdminTastingTagDetailResponse
+import app.bottlenote.alcohols.dto.response.TastingTagNodeItem
+import app.bottlenote.global.dto.response.AdminResultResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 테이스팅 태그 기준 정보 엔드포인트의 문서 설명. */
+object AdminTastingTagApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "테이스팅 태그", description = "위스키 맛·향 테이스팅 태그를 등록·수정·삭제하고 위스키와의 연결을 관리한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "테이스팅 태그 목록을 조회한다",
+		description = """
+			검색어, 정렬 방향, 페이지 번호·크기로 테이스팅 태그 목록을 페이지 단위로 조회합니다.
+
+			keyword를 비우면 전체 태그를 반환하며, 목록 항목의 parent/children 필드는 채우지 않습니다(상세 조회에서만 트리 구조를 반환합니다).
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "테이스팅 태그 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = TastingTagNodeItem::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAllTastingTags
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "테이스팅 태그 상세 정보를 조회한다",
+		description = """
+			태그 ID로 단일 태그의 상세 정보를 조회합니다.
+
+			부모 태그 체인과 자식 태그 트리를 마트료시카 구조(parent.parent... / children[].children[]...)로 함께 반환하며, 이 태그가 연결된 위스키 목록도 포함합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "테이스팅 태그 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminTastingTagDetailResponse::class))]
+			)
+		]
+	)
+	annotation class GetTastingTagDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "테이스팅 태그를 등록한다",
+		description = """
+			새 테이스팅 태그를 등록합니다.
+
+			한글 이름이 이미 등록된 태그와 중복되면 실패합니다. parentId를 지정하면 하위 태그로 등록되며, 깊이는 최대 3단계까지만 허용됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class CreateTastingTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "테이스팅 태그 정보를 수정한다",
+		description = "기존 태그의 이름, 아이콘, 설명, 상위 태그를 수정합니다. 상위 태그를 바꾸면 다시 깊이 제한을 검사합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "수정 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateTastingTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "테이스팅 태그를 삭제한다",
+		description = "태그를 삭제합니다. 하위 태그가 있거나 연결된 위스키가 하나라도 있으면 삭제할 수 없습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "삭제 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class DeleteTastingTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "테이스팅 태그에 위스키를 연결한다",
+		description = "위스키 ID 목록을 받아 해당 태그에 일괄로 연결합니다. 존재하지 않는 위스키 ID가 포함되면 실패합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "연결 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class AddAlcoholsToTastingTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "테이스팅 태그에서 위스키 연결을 해제한다",
+		description = "위스키 ID 목록을 받아 해당 태그와의 연결을 일괄로 해제합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "연결 해제 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class RemoveAlcoholsFromTastingTag
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/auth/presentation/AuthController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/auth/presentation/AuthController.kt
@@ -1,6 +1,7 @@
 package app.bottlenote.auth.presentation
 
 import app.bottlenote.auth.config.RootAdminProperties
+import app.bottlenote.auth.presentation.docs.AuthApiDocs
 import app.bottlenote.global.annotation.SecurityPolicy
 import app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC
 import app.bottlenote.global.data.response.GlobalResponse
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/auth")
+@AuthApiDocs.ApiTag
 class AuthController(
 	private val authService: AdminAuthService,
 	private val rootAdminProperties: RootAdminProperties,
@@ -40,37 +42,42 @@ class AuthController(
 		}
 	}
 
+	@AuthApiDocs.Login
 	@SecurityPolicy(auth = PUBLIC)
 	@PostMapping("/login")
-	fun login(@RequestBody request: LoginRequest): ResponseEntity<*> {
+	fun login(@RequestBody request: LoginRequest): ResponseEntity<GlobalResponse> {
 		val tokenItem: TokenItem = authService.login(request.email, request.password)
 		return GlobalResponse.ok(tokenItem)
 	}
 
+	@AuthApiDocs.Refresh
 	@SecurityPolicy(auth = PUBLIC)
 	@PostMapping("/refresh")
-	fun refresh(@RequestBody request: RefreshRequest): ResponseEntity<*> {
+	fun refresh(@RequestBody request: RefreshRequest): ResponseEntity<GlobalResponse> {
 		val tokenItem: TokenItem = authService.refresh(request.refreshToken)
 		return GlobalResponse.ok(tokenItem)
 	}
 
+	@AuthApiDocs.LoginWithAgent
 	@SecurityPolicy(auth = PUBLIC)
 	@PostMapping("/agent")
-	fun loginWithAgent(@RequestBody @Valid request: AgentLoginRequest): ResponseEntity<*> {
+	fun loginWithAgent(@RequestBody @Valid request: AgentLoginRequest): ResponseEntity<GlobalResponse> {
 		val tokenItem: TokenItem = authService.loginWithAgent(request.agentKey())
 		return GlobalResponse.ok(tokenItem)
 	}
 
+	@AuthApiDocs.Signup
 	@PostMapping("/signup")
-	fun signup(@RequestBody @Valid request: AdminSignupRequest): ResponseEntity<*> {
+	fun signup(@RequestBody @Valid request: AdminSignupRequest): ResponseEntity<GlobalResponse> {
 		val requesterId = SecurityContextUtil.getAdminUserIdByContext()
 			.orElseThrow { UserException(UserExceptionCode.REQUIRED_USER_ID) }
 		val response = authService.signup(requesterId, request)
 		return GlobalResponse.ok(response)
 	}
 
+	@AuthApiDocs.Withdraw
 	@DeleteMapping("/withdraw")
-	fun withdraw(): ResponseEntity<*> {
+	fun withdraw(): ResponseEntity<GlobalResponse> {
 		val adminId = SecurityContextUtil.getAdminUserIdByContext()
 			.orElseThrow { UserException(UserExceptionCode.REQUIRED_USER_ID) }
 		authService.withdraw(adminId)

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/auth/presentation/docs/AuthApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/auth/presentation/docs/AuthApiDocs.kt
@@ -1,0 +1,103 @@
+package app.bottlenote.auth.presentation.docs
+
+import app.bottlenote.user.dto.response.AdminSignupResponse
+import app.bottlenote.user.dto.response.TokenItem
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 관리자 로그인과 계정 등록·탈퇴 엔드포인트의 문서 설명. */
+object AuthApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "인증", description = "관리자 로그인, 토큰 재발급, 관리자 계정 등록·탈퇴를 처리한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "이메일과 비밀번호로 로그인한다",
+		description = "등록된 관리자 이메일과 비밀번호로 로그인해 액세스 토큰과 리프레시 토큰을 발급받습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "발급된 토큰",
+				content = [Content(schema = Schema(implementation = TokenItem::class))]
+			)
+		]
+	)
+	annotation class Login
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "리프레시 토큰으로 액세스 토큰을 재발급한다",
+		description = "액세스 토큰이 만료됐을 때 리프레시 토큰으로 새 액세스 토큰과 리프레시 토큰을 다시 발급받습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "재발급된 토큰",
+				content = [Content(schema = Schema(implementation = TokenItem::class))]
+			)
+		]
+	)
+	annotation class Refresh
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "에이전트 키로 로그인한다",
+		description = "발급받은 에이전트 키로 매핑된 관리자 계정에 로그인해 액세스 토큰과 리프레시 토큰을 발급받습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "발급된 토큰",
+				content = [Content(schema = Schema(implementation = TokenItem::class))]
+			)
+		]
+	)
+	annotation class LoginWithAgent
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "관리자 계정을 등록한다",
+		description = """
+			이메일, 비밀번호, 이름, 역할로 새 관리자 계정을 등록합니다.
+
+			등록은 이미 로그인한 관리자만 요청할 수 있습니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록된 관리자 계정 정보",
+				content = [Content(schema = Schema(implementation = AdminSignupResponse::class))]
+			)
+		]
+	)
+	annotation class Signup
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "관리자 계정을 탈퇴한다",
+		description = "요청자 본인의 관리자 계정을 탈퇴 처리합니다. 탈퇴 후에는 해당 계정으로 다시 로그인할 수 없습니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "탈퇴 처리 결과 메시지",
+				content = [Content(schema = Schema(implementation = AdminWithdrawResponseSchema::class))]
+			)
+		]
+	)
+	annotation class Withdraw
+}
+
+@Schema(name = "AdminWithdrawResponse", description = "관리자 탈퇴 처리 결과")
+internal data class AdminWithdrawResponseSchema(
+	@field:Schema(example = "탈퇴 처리되었습니다.")
+	val message: String
+)

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/banner/presentation/AdminBannerController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/banner/presentation/AdminBannerController.kt
@@ -1,6 +1,7 @@
 package app.bottlenote.banner.presentation
 
 import app.bottlenote.banner.dto.request.*
+import app.bottlenote.banner.presentation.docs.AdminBannerApiDocs
 import app.bottlenote.banner.service.AdminBannerService
 import app.bottlenote.global.data.response.GlobalResponse
 import app.bottlenote.global.dto.request.AdminBulkReorderRequest
@@ -10,49 +11,58 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/banners")
+@AdminBannerApiDocs.ApiTag
 class AdminBannerController(
 	private val adminBannerService: AdminBannerService
 ) {
+	@AdminBannerApiDocs.GetAllBanners
 	@GetMapping
 	fun list(
 		@ModelAttribute request: AdminBannerSearchRequest
 	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(adminBannerService.search(request))
 
+	@AdminBannerApiDocs.GetBannerDetail
 	@GetMapping("/{bannerId}")
 	fun detail(
 		@PathVariable bannerId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.getDetail(bannerId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminBannerService.getDetail(bannerId))
 
+	@AdminBannerApiDocs.CreateBanner
 	@PostMapping
 	fun create(
 		@RequestBody @Valid request: AdminBannerCreateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.create(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminBannerService.create(request))
 
+	@AdminBannerApiDocs.UpdateBanner
 	@PutMapping("/{bannerId}")
 	fun update(
 		@PathVariable bannerId: Long,
 		@RequestBody @Valid request: AdminBannerUpdateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.update(bannerId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminBannerService.update(bannerId, request))
 
+	@AdminBannerApiDocs.DeleteBanner
 	@DeleteMapping("/{bannerId}")
 	fun delete(
 		@PathVariable bannerId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.delete(bannerId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminBannerService.delete(bannerId))
 
+	@AdminBannerApiDocs.UpdateBannerStatus
 	@PatchMapping("/{bannerId}/status")
 	fun updateStatus(
 		@PathVariable bannerId: Long,
 		@RequestBody @Valid request: AdminBannerStatusRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.updateStatus(bannerId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminBannerService.updateStatus(bannerId, request))
 
+	@AdminBannerApiDocs.UpdateBannerSortOrder
 	@PatchMapping("/{bannerId}/sort-order")
 	fun updateSortOrder(
 		@PathVariable bannerId: Long,
 		@RequestBody @Valid request: AdminBannerSortOrderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.updateSortOrder(bannerId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminBannerService.updateSortOrder(bannerId, request))
 
+	@AdminBannerApiDocs.ReorderBanners
 	@PatchMapping("/bulk/reorder")
 	fun reorder(
 		@RequestBody @Valid request: AdminBulkReorderRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminBannerService.reorder(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminBannerService.reorder(request))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/banner/presentation/docs/AdminBannerApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/banner/presentation/docs/AdminBannerApiDocs.kt
@@ -1,0 +1,164 @@
+package app.bottlenote.banner.presentation.docs
+
+import app.bottlenote.banner.dto.response.AdminBannerDetailResponse
+import app.bottlenote.banner.dto.response.AdminBannerListResponse
+import app.bottlenote.global.dto.response.AdminResultResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 배너 엔드포인트의 문서 설명. */
+object AdminBannerApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "배너", description = "앱에 노출되는 배너를 등록·수정·삭제하고 노출 상태와 정렬 순서를 관리한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너 목록을 조회한다",
+		description = """
+			검색어, 활성 여부, 배너 타입, 페이지 번호·크기로 배너 목록을 페이지 단위로 조회합니다.
+
+			keyword를 비우면 전체 배너를 반환합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "배너 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AdminBannerListResponse::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAllBanners
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너 상세 정보를 조회한다",
+		description = "배너 ID로 단일 배너의 상세 정보를 조회합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "배너 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminBannerDetailResponse::class))]
+			)
+		]
+	)
+	annotation class GetBannerDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너를 등록한다",
+		description = """
+			새 배너를 등록합니다.
+
+			이름이 이미 등록된 배너와 중복되면 실패합니다. isExternalUrl이 true이면 targetUrl이 반드시 있어야 하며,
+			startDate가 endDate보다 늦으면 실패합니다. endDate가 이미 지난 시점이면 등록과 동시에 비활성 상태가 됩니다.
+			정렬 순서를 지정하면 기존에 같은 순서 이상을 쓰던 배너들은 뒤로 한 칸씩 밀립니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class CreateBanner
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너 정보를 수정한다",
+		description = """
+			기존 배너의 문구, 이미지, 노출 기간, 정렬 순서, 활성 여부를 수정합니다.
+
+			isExternalUrl이 true이면 targetUrl이 반드시 있어야 하며, startDate가 endDate보다 늦으면 실패합니다.
+			endDate가 이미 지난 시점이면 요청한 isActive 값과 무관하게 비활성 상태로 저장됩니다.
+			정렬 순서를 변경하면 기존에 같은 순서 이상을 쓰던 배너들은 뒤로 한 칸씩 밀립니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "수정 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateBanner
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너를 삭제한다",
+		description = "배너를 삭제합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "삭제 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class DeleteBanner
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너 활성 상태를 변경한다",
+		description = "단일 배너의 활성/비활성 상태만 변경합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "상태 변경 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateBannerStatus
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너 정렬 순서를 변경한다",
+		description = "단일 배너의 정렬 순서 값을 변경합니다. 기존에 같은 순서 이상을 쓰던 배너들은 뒤로 한 칸씩 밀립니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "정렬 순서 변경 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateBannerSortOrder
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "배너 목록을 일괄 재정렬한다",
+		description = """
+			배너 ID 목록을 원하는 순서대로 보내면 그 순서대로 정렬 순서를 다시 매깁니다.
+
+			목록에 포함되지 않은 나머지 배너는 기존 순서를 유지한 채 뒤로 이어 붙습니다. ID가 중복되면 실패합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "재정렬 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class ReorderBanners
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/common/file/presentation/AdminImageUploadController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/common/file/presentation/AdminImageUploadController.kt
@@ -1,6 +1,7 @@
 package app.bottlenote.common.file.presentation
 
 import app.bottlenote.common.file.dto.request.ImageUploadRequest
+import app.bottlenote.common.file.presentation.docs.AdminImageUploadApiDocs
 import app.bottlenote.common.file.service.ImageUploadService
 import app.bottlenote.global.data.response.GlobalResponse
 import app.bottlenote.global.security.SecurityContextUtil
@@ -14,13 +15,15 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/s3")
+@AdminImageUploadApiDocs.ApiTag
 class AdminImageUploadController(
 	private val imageUploadService: ImageUploadService
 ) {
+	@AdminImageUploadApiDocs.GetPreSignUrl
 	@GetMapping("/presign-url")
 	fun getPreSignUrl(
 		@ModelAttribute request: ImageUploadRequest
-	): ResponseEntity<*> {
+	): ResponseEntity<GlobalResponse> {
 		val adminId =
 			SecurityContextUtil
 				.getAdminUserIdByContext()

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/common/file/presentation/docs/AdminImageUploadApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/common/file/presentation/docs/AdminImageUploadApiDocs.kt
@@ -1,0 +1,38 @@
+package app.bottlenote.common.file.presentation.docs
+
+import app.bottlenote.common.file.dto.response.ImageUploadResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 이미지 업로드 엔드포인트의 문서 설명. */
+object AdminImageUploadApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "이미지 업로드", description = "S3에 직접 업로드할 수 있는 presigned URL을 발급한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "이미지 업로드용 presigned URL을 발급한다",
+		description = """
+			rootPath 하위에 uploadSize 개수만큼 S3 업로드용 presigned URL을 발급합니다.
+
+			uploadSize를 지정하지 않으면 1장, contentType을 지정하지 않으면 image/jpeg가 기본값입니다.
+			발급된 URL은 유효 기간(expiryTime, 분 단위) 동안만 PUT 업로드에 사용할 수 있으며,
+			요청 시점에 관리자 계정으로 업로드 이력이 함께 기록됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "발급된 presigned URL 목록",
+				content = [Content(schema = Schema(implementation = ImageUploadResponse::class))]
+			)
+		]
+	)
+	annotation class GetPreSignUrl
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/AdminCurationSpecController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/AdminCurationSpecController.kt
@@ -1,5 +1,6 @@
 package app.bottlenote.curation.presentation
 
+import app.bottlenote.curation.presentation.docs.AdminCurationSpecApiDocs
 import app.bottlenote.curation.service.CurationSpecQueryService
 import app.bottlenote.global.data.response.GlobalResponse
 import org.springframework.http.ResponseEntity
@@ -10,14 +11,17 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v2/curation-specs")
+@AdminCurationSpecApiDocs.ApiTag
 class AdminCurationSpecController(
 	private val curationSpecQueryService: CurationSpecQueryService
 ) {
+	@AdminCurationSpecApiDocs.GetAllCurationSpecs
 	@GetMapping
-	fun list(): ResponseEntity<*> = GlobalResponse.ok(curationSpecQueryService.listActiveSpecs())
+	fun list(): ResponseEntity<GlobalResponse> = GlobalResponse.ok(curationSpecQueryService.listActiveSpecs())
 
+	@AdminCurationSpecApiDocs.GetCurationSpecDetail
 	@GetMapping("/{specId}")
 	fun detail(
 		@PathVariable specId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(curationSpecQueryService.getSpecDetail(specId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(curationSpecQueryService.getSpecDetail(specId))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/AdminSpecBasedCurationController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/AdminSpecBasedCurationController.kt
@@ -3,6 +3,7 @@ package app.bottlenote.curation.presentation
 import app.bottlenote.curation.dto.request.CurationCreateRequest
 import app.bottlenote.curation.dto.request.CurationSearchRequest
 import app.bottlenote.curation.dto.request.CurationUpdateRequest
+import app.bottlenote.curation.presentation.docs.AdminSpecBasedCurationApiDocs
 import app.bottlenote.curation.service.AdminSpecBasedCurationService
 import app.bottlenote.global.data.response.GlobalResponse
 import jakarta.validation.Valid
@@ -18,32 +19,38 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v2/curations")
+@AdminSpecBasedCurationApiDocs.ApiTag
 class AdminSpecBasedCurationController(
 	private val adminSpecBasedCurationService: AdminSpecBasedCurationService
 ) {
+	@AdminSpecBasedCurationApiDocs.GetAllSpecBasedCurations
 	@GetMapping
 	fun list(
 		@ModelAttribute request: CurationSearchRequest
 	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(adminSpecBasedCurationService.search(request))
 
+	@AdminSpecBasedCurationApiDocs.GetSpecBasedCurationFeed
 	@GetMapping("/feed")
 	fun feed(
 		@ModelAttribute request: CurationSearchRequest
 	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(adminSpecBasedCurationService.searchFeed(request))
 
+	@AdminSpecBasedCurationApiDocs.GetSpecBasedCurationDetail
 	@GetMapping("/{curationId}")
 	fun detail(
 		@PathVariable curationId: Long
-	): ResponseEntity<*> = GlobalResponse.ok(adminSpecBasedCurationService.getDetail(curationId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminSpecBasedCurationService.getDetail(curationId))
 
+	@AdminSpecBasedCurationApiDocs.CreateSpecBasedCuration
 	@PostMapping
 	fun create(
 		@RequestBody @Valid request: CurationCreateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminSpecBasedCurationService.create(request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminSpecBasedCurationService.create(request))
 
+	@AdminSpecBasedCurationApiDocs.UpdateSpecBasedCuration
 	@PutMapping("/{curationId}")
 	fun update(
 		@PathVariable curationId: Long,
 		@RequestBody @Valid request: CurationUpdateRequest
-	): ResponseEntity<*> = GlobalResponse.ok(adminSpecBasedCurationService.update(curationId, request))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminSpecBasedCurationService.update(curationId, request))
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/docs/AdminCurationSpecApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/docs/AdminCurationSpecApiDocs.kt
@@ -1,0 +1,62 @@
+package app.bottlenote.curation.presentation.docs
+
+import app.bottlenote.curation.dto.response.CurationSpecListResponse
+import app.bottlenote.curation.dto.response.CurationSpecResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 큐레이션 스펙 엔드포인트의 문서 설명. */
+object AdminCurationSpecApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "큐레이션 스펙", description = "스펙 기반 큐레이션 작성에 쓰는 스펙(필드 정의)을 조회한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "활성화된 큐레이션 스펙 목록을 조회한다",
+		description = """
+			현재 활성화된 큐레이션 스펙 목록을 코드, 이름, 버전과 함께 조회합니다.
+
+			새 큐레이션을 등록할 때 어떤 스펙을 쓸지 고르는 데 사용합니다. 응답은 로컬 캐시(local_cache_curation_spec_list)로 캐싱됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "활성 큐레이션 스펙 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = CurationSpecListResponse::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAllCurationSpecs
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "큐레이션 스펙 상세 정보를 조회한다",
+		description = """
+			스펙 ID로 단일 스펙의 상세 정보를 조회합니다.
+
+			등록·수정 요청 payload가 따라야 하는 필드 정의는 requestSpec에, 피드 응답을 구체화할 때 쓰는 필드 정의는 responseSpec에 담깁니다.
+			스펙별로 로컬 캐시(local_cache_curation_spec_detail)로 캐싱됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "큐레이션 스펙 상세 정보",
+				content = [Content(schema = Schema(implementation = CurationSpecResponse::class))]
+			)
+		]
+	)
+	annotation class GetCurationSpecDetail
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/docs/AdminSpecBasedCurationApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/curation/presentation/docs/AdminSpecBasedCurationApiDocs.kt
@@ -1,0 +1,122 @@
+package app.bottlenote.curation.presentation.docs
+
+import app.bottlenote.curation.dto.response.AdminSpecBasedCurationDetailResponse
+import app.bottlenote.curation.dto.response.AdminSpecBasedCurationListResponse
+import app.bottlenote.curation.dto.response.CurationFeedItemResponse
+import app.bottlenote.global.dto.response.AdminResultResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 스펙 기반 큐레이션 엔드포인트의 문서 설명. */
+object AdminSpecBasedCurationApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "스펙 기반 큐레이션", description = "큐레이션 스펙을 기반으로 만든 큐레이션을 등록·수정하고 목록·피드·상세를 조회한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "스펙 기반 큐레이션 목록을 조회한다",
+		description = """
+			검색어, 스펙 코드, 활성화 상태, 페이지 번호·크기로 큐레이션 목록을 페이지 단위로 조회합니다.
+
+			code에 해당하는 스펙이 없으면 오류가 아니라 빈 목록을 200으로 반환합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "스펙 기반 큐레이션 목록",
+				content = [
+					Content(
+						array =
+						ArraySchema(schema = Schema(implementation = AdminSpecBasedCurationListResponse::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetAllSpecBasedCurations
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "스펙 기반 큐레이션 피드를 조회한다",
+		description = """
+			각 큐레이션을 스펙의 응답 정의(responseSpec)에 맞춰 완성된 피드 항목으로 구체화해 반환합니다.
+
+			size는 최대 10개로 제한되며, code에 해당하는 스펙이 없으면 오류가 아니라 빈 목록을 200으로 반환합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "스펙 기반 큐레이션 피드 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = CurationFeedItemResponse::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class GetSpecBasedCurationFeed
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "스펙 기반 큐레이션 상세 정보를 조회한다",
+		description = "큐레이션 ID로 단일 큐레이션의 상세 정보를 조회합니다. 사용한 스펙 정보와 등록 시 저장한 원본 payload를 함께 반환합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "스펙 기반 큐레이션 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminSpecBasedCurationDetailResponse::class))]
+			)
+		]
+	)
+	annotation class GetSpecBasedCurationDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "스펙 기반 큐레이션을 등록한다",
+		description = """
+			새 큐레이션을 등록합니다.
+
+			specId로 지정한 스펙의 requestSpec 정의에 맞춰 payload를 검증하며, 형식이 맞지 않으면 실패합니다.
+			노출 시작일이 종료일보다 늦거나, 활성화 상태로 등록하면서 노출 종료일이 이미 지난 경우에도 실패합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class CreateSpecBasedCuration
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "스펙 기반 큐레이션 정보를 수정한다",
+		description = """
+			기존 큐레이션의 스펙, 이름, 설명, 이미지, 노출 기간, 노출 순서, 활성화 상태, payload를 한 번에 수정합니다.
+
+			payload는 지정한 스펙의 requestSpec 정의로 다시 검증됩니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "수정 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminResultResponse::class))]
+			)
+		]
+	)
+	annotation class UpdateSpecBasedCuration
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/review/presentation/AdminReviewController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/review/presentation/AdminReviewController.kt
@@ -2,6 +2,7 @@ package app.bottlenote.review.presentation
 
 import app.bottlenote.global.data.response.GlobalResponse
 import app.bottlenote.review.dto.request.AdminReviewSearchRequest
+import app.bottlenote.review.presentation.docs.AdminReviewApiDocs
 import app.bottlenote.review.service.AdminReviewQueryService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -12,9 +13,11 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/reviews")
+@AdminReviewApiDocs.ApiTag
 class AdminReviewController(
 	private val adminReviewQueryService: AdminReviewQueryService
 ) {
+	@AdminReviewApiDocs.ListReviews
 	@GetMapping
 	fun list(
 		@Valid @ModelAttribute request: AdminReviewSearchRequest

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/review/presentation/docs/AdminReviewApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/review/presentation/docs/AdminReviewApiDocs.kt
@@ -1,0 +1,41 @@
+package app.bottlenote.review.presentation.docs
+
+import app.bottlenote.review.dto.response.AdminReviewListResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 리뷰 관리 엔드포인트의 문서 설명. */
+object AdminReviewApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "리뷰 관리", description = "작성된 리뷰 목록을 검색하고 조회한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "리뷰 목록을 조회한다",
+		description = """
+			위스키, 작성자, 활성·공개 상태, 검색어, 작성일 범위, 정렬 기준·방향, 페이지 번호·크기로 리뷰 목록을 페이지 단위로 조회합니다.
+
+			필터 값을 비우면 전체 리뷰를 대상으로 조회합니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "리뷰 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AdminReviewListResponse::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class ListReviews
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/AdminHelpController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/AdminHelpController.kt
@@ -4,6 +4,7 @@ import app.bottlenote.global.data.response.GlobalResponse
 import app.bottlenote.global.security.SecurityContextUtil
 import app.bottlenote.support.help.dto.request.AdminHelpAnswerRequest
 import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest
+import app.bottlenote.support.help.presentation.docs.AdminHelpApiDocs
 import app.bottlenote.support.help.service.AdminHelpService
 import app.bottlenote.user.exception.UserException
 import app.bottlenote.user.exception.UserExceptionCode
@@ -13,30 +14,34 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/helps")
+@AdminHelpApiDocs.ApiTag
 class AdminHelpController(
 	private val adminHelpService: AdminHelpService
 ) {
+	@AdminHelpApiDocs.GetHelpList
 	@GetMapping
 	fun getHelpList(
 		@ModelAttribute request: AdminHelpPageableRequest
-	): ResponseEntity<*> {
+	): ResponseEntity<GlobalResponse> {
 		val response = adminHelpService.getHelpList(request)
 		return GlobalResponse.ok(response)
 	}
 
+	@AdminHelpApiDocs.GetHelpDetail
 	@GetMapping("/{helpId}")
 	fun getHelpDetail(
 		@PathVariable helpId: Long
-	): ResponseEntity<*> {
+	): ResponseEntity<GlobalResponse> {
 		val response = adminHelpService.getHelpDetail(helpId)
 		return GlobalResponse.ok(response)
 	}
 
+	@AdminHelpApiDocs.AnswerHelp
 	@PostMapping("/{helpId}/answer")
 	fun answerHelp(
 		@PathVariable helpId: Long,
 		@RequestBody @Valid request: AdminHelpAnswerRequest
-	): ResponseEntity<*> {
+	): ResponseEntity<GlobalResponse> {
 		val adminId =
 			SecurityContextUtil
 				.getAdminUserIdByContext()

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/docs/AdminHelpApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/docs/AdminHelpApiDocs.kt
@@ -1,0 +1,77 @@
+package app.bottlenote.support.help.presentation.docs
+
+import app.bottlenote.global.service.cursor.CursorPageable
+import app.bottlenote.support.help.dto.response.AdminHelpAnswerResponse
+import app.bottlenote.support.help.dto.response.AdminHelpDetailResponse
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 문의(Help) 엔드포인트의 문서 설명. */
+object AdminHelpApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "문의", description = "사용자가 남긴 문의를 조회하고 답변을 등록한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "문의 목록을 조회한다",
+		description = """
+			처리 상태, 문의 유형, 커서, 페이지 크기로 문의 목록을 커서 방식으로 조회합니다.
+
+			cursor를 지정하지 않으면 0(처음)부터, pageSize를 지정하지 않으면 20건씩 조회합니다.
+			응답의 data.content는 전체 건수(totalCount)와 문의 항목 목록(helpList)을 담고,
+			data.cursorPageable은 현재 커서·다음 커서·페이지 크기·다음 페이지 존재 여부를 담습니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "문의 목록과 커서 페이징 정보",
+				content = [Content(schema = Schema(implementation = AdminHelpPageResponseSchema::class))]
+			)
+		]
+	)
+	annotation class GetHelpList
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "문의 상세 정보를 조회한다",
+		description = "문의 ID로 단일 문의의 상세 정보를 조회합니다. 첨부 이미지 목록과 기존 답변 내용을 함께 반환합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "문의 상세 정보",
+				content = [Content(schema = Schema(implementation = AdminHelpDetailResponse::class))]
+			)
+		]
+	)
+	annotation class GetHelpDetail
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "문의에 답변을 등록한다",
+		description = "문의에 답변 내용과 처리 상태를 등록합니다. 답변한 관리자 계정은 인증 컨텍스트에서 추출합니다.",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "답변 등록 처리 결과",
+				content = [Content(schema = Schema(implementation = AdminHelpAnswerResponse::class))]
+			)
+		]
+	)
+	annotation class AnswerHelp
+}
+
+@Schema(name = "AdminHelpPageResponse", description = "문의 목록과 커서 페이징 정보")
+internal data class AdminHelpPageResponseSchema(
+	val content: AdminHelpListResponse,
+	val cursorPageable: CursorPageable
+)

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/user/presentation/AdminUsersController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/user/presentation/AdminUsersController.kt
@@ -2,6 +2,7 @@ package app.bottlenote.user.presentation
 
 import app.bottlenote.global.data.response.GlobalResponse
 import app.bottlenote.user.dto.request.AdminUserSearchRequest
+import app.bottlenote.user.presentation.docs.AdminUsersApiDocs
 import app.bottlenote.user.service.AdminUserService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -11,9 +12,11 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/users")
+@AdminUsersApiDocs.ApiTag
 class AdminUsersController(
 	private val adminUserService: AdminUserService
 ) {
+	@AdminUsersApiDocs.ListUsers
 	@GetMapping
 	fun list(
 		@ModelAttribute request: AdminUserSearchRequest

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/user/presentation/docs/AdminUsersApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/user/presentation/docs/AdminUsersApiDocs.kt
@@ -1,0 +1,41 @@
+package app.bottlenote.user.presentation.docs
+
+import app.bottlenote.user.dto.response.AdminUserListResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+
+/** 회원 관리 엔드포인트의 문서 설명. */
+object AdminUsersApiDocs {
+
+	@Target(AnnotationTarget.CLASS)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Tag(name = "회원 관리", description = "가입한 회원 목록을 검색하고 조회한다")
+	annotation class ApiTag
+
+	@Target(AnnotationTarget.FUNCTION)
+	@Retention(AnnotationRetention.RUNTIME)
+	@Operation(
+		summary = "회원 목록을 조회한다",
+		description = """
+			검색어, 상태, 정렬 기준·방향, 페이지 번호·크기로 회원 목록을 페이지 단위로 조회합니다.
+
+			keyword를 비우면 전체 회원을 반환하며, 각 회원의 리뷰·별점·찜 수와 가입일·최종 로그인일을 함께 내려줍니다.
+			""",
+		responses = [
+			ApiResponse(
+				responseCode = "200",
+				description = "회원 목록",
+				content = [
+					Content(
+						array = ArraySchema(schema = Schema(implementation = AdminUserListResponse::class))
+					)
+				]
+			)
+		]
+	)
+	annotation class ListUsers
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/global/config/CommonErrorResponseCustomizer.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/config/CommonErrorResponseCustomizer.kt
@@ -1,0 +1,65 @@
+package app.global.config
+
+import app.bottlenote.global.annotation.SecurityPolicy.AuthType
+import app.bottlenote.global.exception.custom.code.ExceptionCode
+import app.bottlenote.global.exception.custom.code.ValidExceptionCode
+import app.bottlenote.global.security.jwt.JwtExceptionType
+import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector
+import app.global.security.SecurityPolicyConfig
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.responses.ApiResponses
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+
+// 어느 엔드포인트에서나 돌아올 수 있는 공통 오류 응답을 문서에 싣는다.
+// 대상은 전역 예외 처리기가 도메인과 무관하게 만들어내는 응답뿐이다. 도메인마다 다른 업무 규칙 위반은 각 엔드포인트가 직접 문서화한다.
+// 엔드포인트가 같은 상태 코드를 이미 설명해 두었다면 그 설명을 덮지 않는다.
+@Component
+class CommonErrorResponseCustomizer :
+	OperationCustomizer,
+	OpenApiCustomizer {
+
+	override fun customise(openApi: OpenAPI) {
+		if (openApi.components == null) {
+			openApi.components = Components()
+		}
+		ErrorResponseSchema.registerInto(openApi.components)
+	}
+
+	override fun customize(operation: Operation, handlerMethod: HandlerMethod): Operation {
+		val responses = operation.responses ?: return operation
+
+		describe(
+			responses,
+			BAD_REQUEST,
+			ValidExceptionCode.TYPE_MISMATCH,
+			"요청 값이 올바르지 않습니다. 필수값 누락, 타입 불일치, 본문 파싱 실패가 여기에 해당합니다."
+		)
+		if (requiresToken(handlerMethod)) {
+			describe(responses, UNAUTHORIZED, JwtExceptionType.MALFORMED_TOKEN, "액세스 토큰이 없거나 유효하지 않습니다.")
+			// 만료된 토큰만 유일하게 403이다. JwtExceptionType.EXPIRED_TOKEN 참고
+			describe(responses, FORBIDDEN, JwtExceptionType.EXPIRED_TOKEN, "액세스 토큰이 만료되었습니다.")
+		}
+		describe(responses, SERVER_ERROR, ValidExceptionCode.UNKNOWN_ERROR, "서버가 처리하지 못한 오류입니다.")
+
+		return operation
+	}
+
+	private fun describe(responses: ApiResponses, status: String, sample: ExceptionCode, description: String) {
+		responses.computeIfAbsent(status) { ErrorResponseSchema.response(sample, description) }
+	}
+
+	// 토큰을 요구하는 엔드포인트만 401을 낼 수 있다. 판정 근거는 실제 인증과 같은 @SecurityPolicy다.
+	private fun requiresToken(handlerMethod: HandlerMethod): Boolean = SecurityPolicyRouteCollector.resolveAuthType(handlerMethod, SecurityPolicyConfig.FALLBACK_AUTH_TYPE) != AuthType.PUBLIC
+
+	private companion object {
+		private const val BAD_REQUEST = "400"
+		private const val UNAUTHORIZED = "401"
+		private const val FORBIDDEN = "403"
+		private const val SERVER_ERROR = "500"
+	}
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/global/config/ErrorResponseSchema.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/config/ErrorResponseSchema.kt
@@ -1,0 +1,91 @@
+package app.global.config
+
+import app.bottlenote.global.exception.custom.code.ExceptionCode
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.BooleanSchema
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
+import io.swagger.v3.oas.models.responses.ApiResponse
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+
+// 오류가 실리는 자리의 스키마를 한곳에 모은다.
+// 성공 응답의 errors(빈 배열)와 실패 응답 본문이 같은 모양에서 갈라지므로 한곳에서 만들어야 서로 어긋나지 않는다.
+internal object ErrorResponseSchema {
+
+	private const val ITEM_NAME = "Error"
+	private const val ENVELOPE_NAME = "ErrorResponse"
+
+	private val ITEM_REF = Components.COMPONENTS_SCHEMAS_REF + ITEM_NAME
+	private val ENVELOPE_REF = Components.COMPONENTS_SCHEMAS_REF + ENVELOPE_NAME
+
+	// meta 자리의 예시. 값을 고정해 스펙을 만들 때마다 문서가 달라지지 않게 한다.
+	val EXAMPLE_META: Map<String, Any> = linkedMapOf(
+		"serverVersion" to "1.0.0",
+		"serverPathVersion" to "v1",
+		"serverEncoding" to "UTF-8",
+		"serverResponseTime" to "2026-01-01T00:00:00"
+	)
+
+	// 스펙 전체에서 한 번만 정의하고 각 응답은 참조만 한다.
+	fun registerInto(components: Components) {
+		components.addSchemas(ITEM_NAME, errorItem())
+		components.addSchemas(ENVELOPE_NAME, envelope())
+	}
+
+	// 실패 응답 하나. 본문 예시는 실제 예외 코드로 만들어 스펙과 실제 응답 모양이 어긋나지 않게 한다.
+	fun response(sample: ExceptionCode, description: String): ApiResponse = ApiResponse()
+		.description(description)
+		.content(
+			Content().addMediaType(
+				APPLICATION_JSON_VALUE,
+				MediaType()
+					.schema(Schema<Any>().`$ref`(ENVELOPE_REF))
+					.example(exampleBody(sample))
+			)
+		)
+
+	private fun exampleBody(sample: ExceptionCode): Map<String, Any> = linkedMapOf(
+		"success" to false,
+		"code" to sample.httpStatus.value(),
+		"data" to emptyList<Any>(),
+		"errors" to listOf(exampleItem(sample)),
+		"meta" to EXAMPLE_META
+	)
+
+	private fun exampleItem(sample: ExceptionCode): Map<String, Any> = linkedMapOf(
+		"code" to (sample as Enum<*>).name,
+		"status" to sample.httpStatus.name,
+		"message" to sample.message
+	)
+
+	// 오류가 담기는 배열.
+	fun errors(): Schema<*> = ArraySchema().items(Schema<Any>().`$ref`(ITEM_REF))
+
+	// 성공 응답에 실리는 errors. 항상 비어 있으므로 담길 항목의 모양(items)은 적지 않는다.
+	fun emptyErrors(): Schema<*> = ArraySchema().maxItems(0)
+
+	private fun errorItem(): Schema<*> = ObjectSchema()
+		.title("오류 항목")
+		.addProperty(
+			"code",
+			StringSchema().description("오류 코드. 클라이언트가 화면 분기에 쓰는 값이다").example("ALCOHOL_ID_REQUIRED")
+		)
+		.addProperty("status", StringSchema().description("HTTP 상태 이름").example("BAD_REQUEST"))
+		.addProperty("message", StringSchema().description("사람이 읽는 오류 설명").example("알코올 식별자는 필수입니다."))
+
+	private fun envelope(): Schema<*> = ObjectSchema()
+		.title("오류 응답")
+		.addProperty("success", BooleanSchema().description("요청 처리 성공 여부").example(false))
+		.addProperty("code", IntegerSchema().description("HTTP 상태 코드").example(400))
+		.addProperty(
+			"data",
+			ArraySchema().items(ObjectSchema()).maxItems(0).description("오류 응답에서는 항상 빈 배열이다")
+		)
+		.addProperty("errors", errors().description("발생한 오류 목록"))
+		.addProperty("meta", ObjectSchema().description("서버 버전, 응답 시각 등 부가 정보"))
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/global/config/GlobalResponseSchemaCustomizer.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/config/GlobalResponseSchemaCustomizer.kt
@@ -1,0 +1,101 @@
+package app.global.config
+
+import app.bottlenote.global.data.response.GlobalResponse
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.BooleanSchema
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.responses.ApiResponse
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.core.ResolvableType
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+
+// 성공 응답을 GlobalResponse 공통 형식으로 감싼다.
+// 각 엔드포인트는 data에 담길 타입만 표준 @ApiResponse로 알려주고, 이 클래스가 그 타입을 data 자리로 옮긴 뒤 공통 필드를 덧붙인다.
+// ResponseEntity의 본문 타입을 구체적으로 선언한 엔드포인트(공통 형식을 쓰지 않는 DTO 그대로 반환)는 감싸기를 건너뛴다.
+@Component
+class GlobalResponseSchemaCustomizer : OperationCustomizer {
+
+	override fun customize(operation: Operation, handlerMethod: HandlerMethod): Operation {
+		val responses = operation.responses ?: return operation
+		if (returnsBareDto(handlerMethod)) {
+			return operation
+		}
+		responses.forEach { (statusCode, response) -> wrapIfSuccess(statusCode, response) }
+		return operation
+	}
+
+	private fun returnsBareDto(handlerMethod: HandlerMethod): Boolean {
+		val returnType = ResolvableType.forMethodReturnType(handlerMethod.method)
+		if (!ResponseEntity::class.java.isAssignableFrom(returnType.toClass())) {
+			return false
+		}
+		val bodyType = returnType.getGeneric(0).resolve()
+		return bodyType != null &&
+			bodyType != Any::class.java &&
+			!GlobalResponse::class.java.isAssignableFrom(bodyType)
+	}
+
+	private fun wrapIfSuccess(statusCode: String, response: ApiResponse) {
+		if (!statusCode.startsWith(SUCCESS_STATUS_PREFIX)) {
+			return
+		}
+		val declared = declaredSchema(response)
+		if (declared != null && alreadyWrapped(declared)) {
+			return
+		}
+		val envelope = commonEnvelope(declared ?: ObjectSchema())
+		response.content = Content().addMediaType(APPLICATION_JSON_VALUE, MediaType().schema(envelope))
+	}
+
+	// 엔드포인트가 알려준 data 타입.
+	private fun declaredSchema(response: ApiResponse): Schema<*>? {
+		val content = response.content ?: return null
+		return content.values.map { it.schema }.firstOrNull { isMeaningful(it) }
+	}
+
+	// 타입 정보가 없는 빈 object와 공통 형식 자체는 힌트로 취급하지 않는다.
+	private fun isMeaningful(schema: Schema<*>?): Boolean = schema != null && !isEnvelopeItself(schema) && !isEmptyObject(schema)
+
+	private fun isEmptyObject(schema: Schema<*>): Boolean = OBJECT_TYPE == schema.type && schema.`get$ref`() == null && schema.properties.isNullOrEmpty()
+
+	private fun isEnvelopeItself(schema: Schema<*>): Boolean = ENVELOPE_SCHEMA_REF == schema.`get$ref`()
+
+	// 이미 공통 형식으로 적혀 있는지. isEnvelopeItself와 달리 참조가 아닌 펼쳐진 스키마를 본다.
+	private fun alreadyWrapped(schema: Schema<*>): Boolean = schema.properties?.containsKey(DATA) == true
+
+	private fun commonEnvelope(data: Schema<*>): Schema<*> = ObjectSchema()
+		.addProperty(SUCCESS, BooleanSchema().description("요청 처리 성공 여부").example(true))
+		.addProperty(CODE, IntegerSchema().description("HTTP 상태 코드").example(HTTP_OK))
+		.addProperty(DATA, data.description("요청 결과 값"))
+		.addProperty(ERRORS, ErrorResponseSchema.emptyErrors().description("오류 목록. 성공 시 비어 있다"))
+		.addProperty(
+			META,
+			ObjectSchema().description("서버 버전, 응답 시각, 페이징 정보 등 부가 정보").example(ErrorResponseSchema.EXAMPLE_META)
+		)
+
+	companion object {
+		private const val SUCCESS_STATUS_PREFIX = "2"
+		private const val OBJECT_TYPE = "object"
+
+		// 공통 형식의 code에 담기는 값. 성공 응답은 항상 200이다.
+		private const val HTTP_OK = 200
+
+		private const val SUCCESS = "success"
+		private const val CODE = "code"
+		private const val DATA = "data"
+		private const val ERRORS = "errors"
+		private const val META = "meta"
+
+		// ResponseEntity<GlobalResponse>는 추론되는 스키마가 공통 형식 그 자체이므로 data에 담길 타입이 아니다.
+		// 그대로 두면 공통 형식 안에 공통 형식이 중첩된다.
+		private val ENVELOPE_SCHEMA_REF = Components.COMPONENTS_SCHEMAS_REF + GlobalResponse::class.java.simpleName
+	}
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/global/config/OpenApiConfig.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/config/OpenApiConfig.kt
@@ -1,0 +1,43 @@
+package app.global.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+// 스펙 문서의 최상단 정보와 인증 방식을 정의한다. 개별 엔드포인트 설명은 각 도메인의 문서 어노테이션이 담당한다.
+@Configuration
+class OpenApiConfig {
+	@Bean
+	fun adminOpenApi(): OpenAPI = OpenAPI().info(adminApiInfo()).components(securityComponents())
+
+	private fun adminApiInfo(): Info = Info()
+		.title("보틀노트 Admin API")
+		.version("v1")
+		.description(
+			"""
+			보틀노트 어드민 콘솔이 사용하는 관리자 API입니다.
+
+			모든 응답은 success, code, data, errors, meta를 갖는 공통 형식으로 감싸여 있고, 실제 결과값은 data 안에 담깁니다.
+
+			인증이 필요한 엔드포인트는 로그인 후 발급받은 액세스 토큰을 Authorization 헤더에 "Bearer {토큰}" 형태로 담아 호출합니다.
+			""".trimIndent()
+		)
+
+	private fun securityComponents(): Components = Components()
+		.addSecuritySchemes(
+			BEARER_AUTH,
+			SecurityScheme()
+				.type(SecurityScheme.Type.HTTP)
+				.scheme("bearer")
+				.bearerFormat("JWT")
+				.description("로그인 응답으로 받은 액세스 토큰을 그대로 입력합니다.")
+		)
+
+	companion object {
+		// components 하위 키는 OpenAPI 규칙상 영문 식별자여야 한다.
+		const val BEARER_AUTH = "bearerAuth"
+	}
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/global/config/SecurityRequirementCustomizer.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/config/SecurityRequirementCustomizer.kt
@@ -1,0 +1,31 @@
+package app.global.config
+
+import app.bottlenote.global.annotation.SecurityPolicy.AuthType
+import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector
+import app.global.security.SecurityPolicyConfig
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+
+// 엔드포인트가 액세스 토큰을 요구하는지 문서에 표시한다.
+// 판정 근거는 실제 인증과 같은 @SecurityPolicy다. 문서에 따로 적지 않으므로 정책을 바꾸면 문서도 함께 바뀐다.
+@Component
+class SecurityRequirementCustomizer : OperationCustomizer {
+
+	override fun customize(operation: Operation, handlerMethod: HandlerMethod): Operation {
+		val auth = SecurityPolicyRouteCollector.resolveAuthType(handlerMethod, SecurityPolicyConfig.FALLBACK_AUTH_TYPE)
+
+		if (auth == AuthType.PUBLIC) {
+			return operation
+		}
+
+		operation.addSecurityItem(SecurityRequirement().addList(OpenApiConfig.BEARER_AUTH))
+		if (auth == AuthType.OPTIONAL_AUTH) {
+			// 토큰 없이 호출해도 동작한다는 사실을 빈 요구사항으로 함께 알린다
+			operation.addSecurityItem(SecurityRequirement())
+		}
+		return operation
+	}
+}

--- a/bottlenote-admin-api/src/main/kotlin/app/global/security/CorsProperties.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/security/CorsProperties.kt
@@ -4,5 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "app.cors")
 data class CorsProperties(
-	val allowedOrigins: List<String>
+	val allowedOrigins: List<String>,
+	val docsAllowedOrigins: List<String>
 )

--- a/bottlenote-admin-api/src/main/kotlin/app/global/security/SecurityConfig.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/security/SecurityConfig.kt
@@ -4,6 +4,7 @@ import app.bottlenote.global.security.constant.MaliciousPathPattern
 import app.bottlenote.global.security.jwt.AdminJwtAuthenticationFilter
 import app.bottlenote.global.security.jwt.AdminJwtAuthenticationManager
 import app.bottlenote.global.security.policy.SecurityPolicyRegistry
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -26,9 +27,9 @@ class SecurityConfig(
 	private val corsProperties: CorsProperties
 ) {
 	@Bean
-	fun filterChain(http: HttpSecurity): SecurityFilterChain = http
+	fun filterChain(http: HttpSecurity, corsConfigurationSource: CorsConfigurationSource): SecurityFilterChain = http
 		.csrf { it.disable() }
-		.cors { it.configurationSource(corsConfigurationSource()) }
+		.cors { it.configurationSource(corsConfigurationSource) }
 		.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
 		.formLogin { it.disable() }
 		.httpBasic { it.disable() }
@@ -49,8 +50,17 @@ class SecurityConfig(
 			UsernamePasswordAuthenticationFilter::class.java
 		).build()
 
+	// 문서 스펙 경로는 일반 API와 분리된 CORS 정책을 쓴다.
 	@Bean
-	fun corsConfigurationSource(): CorsConfigurationSource {
+	fun corsConfigurationSource(
+		@Value("\${springdoc.api-docs.path}") openApiSpecPath: String
+	): CorsConfigurationSource {
+		val docsConfiguration = CorsConfiguration()
+		docsConfiguration.allowedOrigins = corsProperties.docsAllowedOrigins
+		docsConfiguration.allowedMethods = listOf("GET", "OPTIONS")
+		docsConfiguration.allowedHeaders = listOf("Authorization", "Content-Type")
+		docsConfiguration.allowCredentials = false
+
 		val configuration = CorsConfiguration()
 		configuration.allowedOrigins = corsProperties.allowedOrigins
 		configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
@@ -58,6 +68,7 @@ class SecurityConfig(
 		configuration.allowCredentials = false
 
 		val source = UrlBasedCorsConfigurationSource()
+		source.registerCorsConfiguration(openApiSpecPath, docsConfiguration)
 		source.registerCorsConfiguration("/**", configuration)
 		return source
 	}

--- a/bottlenote-admin-api/src/main/kotlin/app/global/security/SecurityPolicyConfig.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/security/SecurityPolicyConfig.kt
@@ -6,6 +6,7 @@ import app.bottlenote.global.security.policy.SecurityPolicyRegistry
 import app.bottlenote.global.security.policy.SecurityPolicyRoute
 import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
@@ -14,13 +15,16 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 class SecurityPolicyConfig {
 	@Bean
 	fun securityPolicyRegistry(
-		@Qualifier("requestMappingHandlerMapping") handlerMapping: RequestMappingHandlerMapping
+		@Qualifier("requestMappingHandlerMapping") handlerMapping: RequestMappingHandlerMapping,
+		@Value("\${springdoc.api-docs.path}") specPath: String
 	): SecurityPolicyRegistry = SecurityPolicyRouteCollector.collect(
 		handlerMapping,
 		REQUIRED_AUTH,
 		listOf(
 			SecurityPolicyRoute.explicit(null, "/actuator/**", PUBLIC),
-			SecurityPolicyRoute.explicit(null, "/error", PUBLIC)
+			SecurityPolicyRoute.explicit(null, "/error", PUBLIC),
+			// API 스펙은 클라이언트 개발자가 인증 없이 받아갈 수 있어야 한다
+			SecurityPolicyRoute.explicit(null, specPath, PUBLIC)
 		)
 	)
 }

--- a/bottlenote-admin-api/src/main/kotlin/app/global/security/SecurityPolicyConfig.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/global/security/SecurityPolicyConfig.kt
@@ -13,13 +13,17 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 
 @Configuration
 class SecurityPolicyConfig {
+	companion object {
+		val FALLBACK_AUTH_TYPE = REQUIRED_AUTH
+	}
+
 	@Bean
 	fun securityPolicyRegistry(
 		@Qualifier("requestMappingHandlerMapping") handlerMapping: RequestMappingHandlerMapping,
 		@Value("\${springdoc.api-docs.path}") specPath: String
 	): SecurityPolicyRegistry = SecurityPolicyRouteCollector.collect(
 		handlerMapping,
-		REQUIRED_AUTH,
+		FALLBACK_AUTH_TYPE,
 		listOf(
 			SecurityPolicyRoute.explicit(null, "/actuator/**", PUBLIC),
 			SecurityPolicyRoute.explicit(null, "/error", PUBLIC),

--- a/bottlenote-admin-api/src/main/resources/application.yml
+++ b/bottlenote-admin-api/src/main/resources/application.yml
@@ -85,6 +85,14 @@ root:
     email: ${ROOT_ADMIN_EMAIL:email@email.com}
     password: ${ROOT_ADMIN_PASSWORD}
 
+# OpenAPI JSON은 context-path와 합쳐 /admin/api/v1/openapi.admin.json으로 노출한다
+springdoc:
+  api-docs:
+    path: /v1/openapi.admin.json
+  swagger-ui:
+    enabled: false
+  default-produces-media-type: application/json
+
 --- # default/local 프로파일 (동일 설정)
 spring:
   config:

--- a/bottlenote-admin-api/src/main/resources/application.yml
+++ b/bottlenote-admin-api/src/main/resources/application.yml
@@ -4,7 +4,8 @@ app: # 애플리케이션 및 배포 정보
   cors:
     allowed-origins:
       - http://localhost:5173
-    docs-allowed-origins: []
+    docs-allowed-origins:
+      - https://bottle-note.github.io
   info:
     server-name: ${SERVER_NAME:unknown}
     environment: ${SPRING_PROFILES_ACTIVE:local}

--- a/bottlenote-admin-api/src/main/resources/application.yml
+++ b/bottlenote-admin-api/src/main/resources/application.yml
@@ -4,6 +4,7 @@ app: # 애플리케이션 및 배포 정보
   cors:
     allowed-origins:
       - http://localhost:5173
+    docs-allowed-origins: []
   info:
     server-name: ${SERVER_NAME:unknown}
     environment: ${SPRING_PROFILES_ACTIVE:local}

--- a/bottlenote-admin-api/src/test/kotlin/app/global/security/SecurityConfigIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/global/security/SecurityConfigIntegrationTest.kt
@@ -80,6 +80,20 @@ class SecurityConfigIntegrationTest : IntegrationTestSupport() {
 	}
 
 	@Test
+	@DisplayName("GitHub Pages Origin의 문서 스펙 요청을 허용한다")
+	fun openApiSpecGitHubPagesOriginAllowed() {
+		val result = mockMvcTester
+			.get()
+			.uri(openApiSpecPath)
+			.header(HttpHeaders.ORIGIN, "https://bottle-note.github.io")
+			.exchange()
+
+		result.assertThat().hasStatusOk()
+		assertThat(result.response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+			.isEqualTo("https://bottle-note.github.io")
+	}
+
+	@Test
 	@DisplayName("문서 스펙 경로는 Origin이 없는 무인증 GET을 정상 허용한다")
 	fun openApiSpecNoOriginRequestAllowed() {
 		val result = mockMvcTester

--- a/bottlenote-admin-api/src/test/kotlin/app/global/security/SecurityConfigIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/global/security/SecurityConfigIntegrationTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.test.web.servlet.assertj.MvcTestResult
@@ -12,6 +13,9 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult
 @Tag("admin_integration")
 @DisplayName("[integration] Admin SecurityConfig CORS 테스트")
 class SecurityConfigIntegrationTest : IntegrationTestSupport() {
+	@Value("\${springdoc.api-docs.path}")
+	private lateinit var openApiSpecPath: String
+
 	@Test
 	@DisplayName("Admin Origin의 preflight 요청에 해당 Origin을 반환한다")
 	fun allowedAdminOriginPreflight() {
@@ -47,4 +51,42 @@ class SecurityConfigIntegrationTest : IntegrationTestSupport() {
 		.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
 		.header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "authorization,content-type")
 		.exchange()
+
+	@Test
+	@DisplayName("문서 스펙 경로는 일반 API에서 허용된 Origin이어도 403이고 permissive CORS 헤더를 반환하지 않는다")
+	fun openApiSpecOriginRequestRejected() {
+		val result = mockMvcTester
+			.get()
+			.uri(openApiSpecPath)
+			.header(HttpHeaders.ORIGIN, "https://admin.bottle-note.com")
+			.exchange()
+
+		result.assertThat().hasStatus(FORBIDDEN)
+		assertThat(result.response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull()
+	}
+
+	@Test
+	@DisplayName("문서 스펙 경로의 preflight 요청도 일반 API에서 허용된 Origin이어도 403으로 거부한다")
+	fun openApiSpecPreflightRejected() {
+		val result = mockMvcTester
+			.options()
+			.uri(openApiSpecPath)
+			.header(HttpHeaders.ORIGIN, "https://admin.bottle-note.com")
+			.header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
+			.exchange()
+
+		result.assertThat().hasStatus(FORBIDDEN)
+		assertThat(result.response.getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull()
+	}
+
+	@Test
+	@DisplayName("문서 스펙 경로는 Origin이 없는 무인증 GET을 정상 허용한다")
+	fun openApiSpecNoOriginRequestAllowed() {
+		val result = mockMvcTester
+			.get()
+			.uri(openApiSpecPath)
+			.exchange()
+
+		result.assertThat().hasStatusOk()
+	}
 }

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiDocsIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiDocsIntegrationTest.kt
@@ -1,0 +1,95 @@
+package app.integration.openapi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+@Tag("admin_integration")
+@DisplayName("[integration] Admin OpenAPI 스펙 문서 노출")
+class OpenApiDocsIntegrationTest : OpenApiSpecTestSupport() {
+
+	private val envelopeFields = listOf("success", "code", "data", "errors", "meta")
+
+	// Admin의 65 operation은 모두 GlobalResponse 공통 형식을 쓴다 (plan Assumption 6).
+	// product와 달리 공통 형식을 벗어나는 예외 엔드포인트가 없다.
+	private val expectedOperationCount = 65
+
+	@Test
+	@DisplayName("인증 없이 스펙 문서를 조회할 수 있다")
+	fun openApiSpecCanBeReadWithoutAuthentication() {
+		assertThat(mockMvcTester.get().uri(specPath))
+			.hasStatusOk()
+			.bodyJson()
+			.extractingPath("$.info.title")
+			.isEqualTo("보틀노트 Admin API")
+	}
+
+	@Test
+	@DisplayName("스펙 문서는 OpenAPI 3.1 형식이다")
+	fun openApiSpecUsesVersion31() {
+		assertThat(mockMvcTester.get().uri(specPath))
+			.hasStatusOk()
+			.bodyJson()
+			.extractingPath("$.openapi")
+			.asString()
+			.startsWith("3.1")
+	}
+
+	@Test
+	@DisplayName("swagger-ui는 비활성화되어 접근할 수 없다")
+	fun swaggerUiIsDisabled() {
+		val result = mockMvcTester.get().uri("/swagger-ui/index.html").exchange()
+
+		assertThat(result.response.status).isNotEqualTo(200)
+	}
+
+	@Test
+	@DisplayName("문서에는 65개 operation이 누락 없이 포함된다")
+	fun openApiSpecContains65Operations() {
+		val operations = operationsOf(fetchSpec())
+
+		assertThat(operations)
+			.withFailMessage(
+				"operation 수가 %d건입니다(기대: %d건):%n%s",
+				operations.size,
+				expectedOperationCount,
+				joined(operations.map { it.toString() })
+			)
+			.hasSize(expectedOperationCount)
+	}
+
+	@Test
+	@DisplayName("모든 엔드포인트의 성공 응답은 GlobalResponse 공통 형식이다")
+	fun everySuccessResponseUsesGlobalEnvelope() {
+		val operations = operationsOf(fetchSpec())
+
+		assertThat(operations).isNotEmpty()
+		assertThat(operations)
+			.allSatisfy { operation ->
+				assertThat(propertyNamesOf(operation.successSchema()))
+					.withFailMessage("%s 의 성공 응답이 공통 형식이 아닙니다", operation)
+					.containsExactlyInAnyOrderElementsOf(envelopeFields)
+			}
+	}
+
+	@Test
+	@DisplayName("공통 형식의 data는 이중으로 감싸지지 않는다")
+	fun globalEnvelopeIsNotNestedInData() {
+		val operations = operationsOf(fetchSpec())
+
+		val doublyWrapped =
+			operations
+				.filter { operation ->
+					val dataSchema = operation.successSchema().path("properties").path("data")
+					val dataProperties = propertyNamesOf(dataSchema)
+					dataSchema.path("\$ref").asText().endsWith("/GlobalResponse") ||
+						(dataProperties.isNotEmpty() && dataProperties.containsAll(envelopeFields))
+				}
+				.map { it.toString() }
+
+		assertThat(doublyWrapped)
+			.withFailMessage("공통 형식이 data 안에 중첩된 엔드포인트가 있습니다:%n%s", joined(doublyWrapped))
+			.isEmpty()
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSecurityRequirementTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSecurityRequirementTest.kt
@@ -1,0 +1,93 @@
+package app.integration.openapi
+
+import app.bottlenote.global.annotation.SecurityPolicy.AuthType
+import app.bottlenote.global.security.policy.SecurityPolicyRouteCollector
+import app.global.security.SecurityPolicyConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
+
+/** 문서에 표시된 인증 요구가 실제 보안 정책과 어긋나지 않는지 검사한다. */
+@Tag("admin_integration")
+@DisplayName("[integration] Admin OpenAPI 인증 요구 표시")
+class OpenApiSecurityRequirementTest : OpenApiSpecTestSupport() {
+
+	@Autowired
+	@Qualifier("requestMappingHandlerMapping")
+	private lateinit var handlerMapping: RequestMappingHandlerMapping
+
+	@Test
+	@DisplayName("문서의 토큰 요구는 실제 인증 정책과 일치한다")
+	fun documentedTokenRequirementsMatchPolicies() {
+		val policies = authTypesByEndpoint()
+		val operations = operationsOf(fetchSpec())
+
+		// 경로 매칭이 실패하면 아래 검사가 조용히 비어버리므로 먼저 고정한다
+		val unmatched = operations.map { it.endpoint() }.filter { endpoint -> !policies.containsKey(endpoint) }
+		assertThat(unmatched)
+			.withFailMessage("실제 정책을 찾지 못한 엔드포인트가 있습니다:%n%s", joined(unmatched))
+			.isEmpty()
+
+		val violations =
+			operations
+				.filter { operation -> requiresBearer(operation) != (policies[operation.endpoint()] != AuthType.PUBLIC) }
+				.map { operation -> "${operation.endpoint()} (정책 ${policies[operation.endpoint()]})" }
+
+		assertThat(violations)
+			.withFailMessage("문서의 토큰 요구가 실제 정책과 다릅니다:%n%s", joined(violations))
+			.isEmpty()
+	}
+
+	@Test
+	@DisplayName("토큰을 요구하는 엔드포인트가 문서에 실제로 존재한다")
+	fun authenticatedOperationsExist() {
+		val requiring = operationsOf(fetchSpec()).filter { operation -> requiresBearer(operation) }
+
+		assertThat(requiring)
+			.withFailMessage("토큰 요구가 하나도 실리지 않았습니다. 보안 스키마가 연결되지 않은 상태입니다")
+			.isNotEmpty()
+	}
+
+	@Test
+	@DisplayName("로그인·갱신·에이전트 로그인 3건만 인증 없이 호출 가능하다")
+	fun onlyLoginRefreshAndAgentLoginArePublic() {
+		val policies = authTypesByEndpoint()
+		val publicEndpoints = policies.filterValues { it == AuthType.PUBLIC }.keys
+
+		assertThat(publicEndpoints)
+			.withFailMessage("PUBLIC 엔드포인트가 기대한 3건과 다릅니다:%n%s", joined(publicEndpoints.toList()))
+			.isEqualTo(setOf("POST /auth/login", "POST /auth/refresh", "POST /auth/agent"))
+	}
+
+	/** 실제 보안 정책이 판정한 엔드포인트별 인증 방식. */
+	private fun authTypesByEndpoint(): Map<String, AuthType> {
+		val policies = mutableMapOf<String, AuthType>()
+		handlerMapping.handlerMethods.forEach { (mapping, handlerMethod) ->
+			val patterns = mapping.pathPatternsCondition ?: return@forEach
+			val auth = SecurityPolicyRouteCollector.resolveAuthType(handlerMethod, SecurityPolicyConfig.FALLBACK_AUTH_TYPE)
+			mapping.methodsCondition.methods.forEach { method ->
+				patterns.patterns.forEach { pattern ->
+					policies["${method.name} ${pattern.patternString}"] = auth
+				}
+			}
+		}
+		return policies
+	}
+
+	private fun requiresBearer(operation: SpecOperation): Boolean {
+		for (item in operation.security()) {
+			if (item.has(BEARER_AUTH)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	companion object {
+		private const val BEARER_AUTH = "bearerAuth"
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSecurityRequirementTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSecurityRequirementTest.kt
@@ -60,7 +60,7 @@ class OpenApiSecurityRequirementTest : OpenApiSpecTestSupport() {
 
 		assertThat(publicEndpoints)
 			.withFailMessage("PUBLIC 엔드포인트가 기대한 3건과 다릅니다:%n%s", joined(publicEndpoints.toList()))
-			.isEqualTo(setOf("POST /auth/login", "POST /auth/refresh", "POST /auth/agent"))
+			.isEqualTo(setOf("POST /v1/auth/login", "POST /v1/auth/refresh", "POST /v1/auth/agent"))
 	}
 
 	/** 실제 보안 정책이 판정한 엔드포인트별 인증 방식. */

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSpecQualityTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSpecQualityTest.kt
@@ -1,0 +1,76 @@
+package app.integration.openapi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+
+/** 스펙 문서의 품질을 전수 검사한다. 예외를 두지 않으므로 모든 엔드포인트가 검사 대상이다. */
+@Tag("admin_integration")
+@DisplayName("[integration] Admin OpenAPI 스펙 품질")
+class OpenApiSpecQualityTest : OpenApiSpecTestSupport() {
+
+	@Test
+	@DisplayName("엔드포인트의 태그는 클래스 이름이 아닌 도메인 이름이다")
+	fun tagsUseDomainNames() {
+		assertNoOperation(
+			"태그가 컨트롤러 클래스명으로 남아 있습니다. 도메인 이름을 지정하세요"
+		) { operation -> operation.tag().endsWith("-controller") }
+	}
+
+	@Test
+	@DisplayName("모든 엔드포인트는 요약 문장을 갖는다")
+	fun everyOperationHasSummary() {
+		assertNoOperation("요약(summary)이 없습니다") { operation -> operation.summary().isBlank() }
+	}
+
+	@Test
+	@DisplayName("요약은 메서드 이름을 그대로 옮긴 것이 아니다")
+	fun summariesAreNotMethodNames() {
+		assertNoOperation(
+			"요약이 메서드 이름과 같습니다. 사람이 읽는 문장으로 쓰세요"
+		) { operation -> operation.summary() == operation.operationId() }
+	}
+
+	@Test
+	@DisplayName("응답 data는 실제 타입을 가리킨다")
+	fun responseDataReferencesConcreteSchema() {
+		assertNoOperation("응답 data가 빈 object입니다. 담기는 타입을 알려주세요") { operation -> operation.hasEmptyDataSchema() }
+	}
+
+	@Test
+	@DisplayName("components 하위 이름은 OpenAPI가 허용하는 식별자 형식이다")
+	fun componentNamesUseAllowedIdentifiers() {
+		val components = fetchSpec().at("/components")
+		val violations =
+			components.properties().flatMap { group ->
+				childNamesOf(group.value)
+					.filter { name -> !COMPONENT_NAME_PATTERN.matcher(name).matches() }
+					.map { name -> "${group.key}.$name" }
+			}
+
+		assertThat(violations)
+			.withFailMessage(
+				"""
+				components 하위 이름이 OpenAPI 규칙(%s)을 위반합니다. @Schema(name=...)이나 보안 스키마 이름에는 영문 식별자를 쓰고 한국어는 title이나 description으로 옮기세요. 위반하면 Scalar 같은 문서 도구가 스펙을 거부합니다:
+				%s
+				""".trimIndent(),
+				COMPONENT_NAME_PATTERN.pattern(),
+				joined(violations)
+			)
+			.isEmpty()
+	}
+
+	/** 조건을 위반하는 엔드포인트가 하나도 없어야 한다. */
+	private fun assertNoOperation(reason: String, violating: (SpecOperation) -> Boolean) {
+		val violations = operationsOf(fetchSpec()).filter(violating).map { it.toString() }
+
+		assertThat(violations).withFailMessage("%s:%n%s", reason, joined(violations)).isEmpty()
+	}
+
+	companion object {
+		// OpenAPI가 components 하위 키에 허용하는 형식.
+		private val COMPONENT_NAME_PATTERN: Pattern = Pattern.compile("^[a-zA-Z0-9._-]+$")
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSpecTestSupport.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/openapi/OpenApiSpecTestSupport.kt
@@ -1,0 +1,76 @@
+package app.integration.openapi
+
+import app.IntegrationTestSupport
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.MissingNode
+import org.springframework.beans.factory.annotation.Value
+import java.nio.charset.StandardCharsets.UTF_8
+
+/** 생성된 Admin OpenAPI 스펙을 읽어 검사하는 테스트들의 공통 기반. */
+abstract class OpenApiSpecTestSupport : IntegrationTestSupport() {
+
+	// 스펙 경로의 SSOT는 springdoc.api-docs.path 프로퍼티다
+	@Value("\${springdoc.api-docs.path}")
+	protected lateinit var specPath: String
+
+	protected fun fetchSpec(): JsonNode {
+		val result = mockMvcTester.get().uri(specPath).exchange()
+		return mapper.readTree(result.response.getContentAsString(UTF_8))
+	}
+
+	/** 스펙의 모든 엔드포인트를 평탄하게 펼친다. */
+	protected fun operationsOf(spec: JsonNode): List<SpecOperation> = spec.at("/paths").properties().flatMap { path ->
+		path.value.properties().map { method -> SpecOperation(path.key, method.key, method.value) }
+	}
+
+	/** 위반 목록을 실패 메시지에 담을 형태로 잇는다. */
+	protected fun joined(violations: List<String>): String = violations.joinToString(System.lineSeparator())
+
+	/** 노드의 직접 자식 이름. */
+	protected fun childNamesOf(node: JsonNode): List<String> = node.properties().map { it.key }
+
+	/** 스키마 노드가 선언한 property 이름. */
+	protected fun propertyNamesOf(node: JsonNode): List<String> = childNamesOf(node.path("properties"))
+
+	/** 스펙에 실린 하나의 엔드포인트. */
+	protected data class SpecOperation(val path: String, val method: String, val definition: JsonNode) {
+
+		/** 200 응답 본문의 스키마. 공통 형식이면 그 형식, 아니면 DTO 참조. */
+		fun successSchema(): JsonNode {
+			val content = definition.at("/responses/200/content")
+			if (content.isMissingNode || content.isEmpty) {
+				return MissingNode.getInstance()
+			}
+			return content.properties().iterator().next().value.path("schema")
+		}
+
+		/** HTTP 메서드와 경로를 합친 식별자. */
+		fun endpoint(): String = "${method.uppercase()} $path"
+
+		/** 문서에 선언된 보안 요구사항. 선언이 없으면 missing 노드. */
+		fun security(): JsonNode = definition.path("security")
+
+		fun tag(): String {
+			val tags = definition.at("/tags")
+			return if (tags.isArray && !tags.isEmpty) tags.get(0).asText() else ""
+		}
+
+		fun summary(): String = definition.path("summary").asText("")
+
+		fun operationId(): String = definition.path("operationId").asText("")
+
+		/** 공통 형식의 data 자리에 담긴 스키마. */
+		private fun dataSchema(): JsonNode = successSchema().path("properties").path("data")
+
+		fun hasEmptyDataSchema(): Boolean {
+			val data = dataSchema()
+			return OBJECT_TYPE == data.path("type").asText() && !data.has("\$ref") && !data.has("properties")
+		}
+
+		override fun toString(): String = "${method.uppercase()} $path (${tag()})"
+
+		companion object {
+			private const val OBJECT_TYPE = "object"
+		}
+	}
+}

--- a/bottlenote-admin-api/src/test/kotlin/app/rule/api/ControllerLayerRules.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/rule/api/ControllerLayerRules.kt
@@ -1,0 +1,88 @@
+package app.rule.api
+
+import com.tngtech.archunit.base.DescribedPredicate
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.domain.JavaClasses
+import com.tngtech.archunit.core.domain.JavaMethod
+import com.tngtech.archunit.core.domain.JavaParameterizedType
+import com.tngtech.archunit.core.domain.JavaWildcardType
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ * 컨트롤러 응답 본문 타입 명시 규칙을 검증한다.
+ *
+ * bottlenote-product-api의 ControllerLayerRules#컨트롤러_응답_타입_명시_검증과 같은 declareResponseBodyType 조건을 재사용한다.
+ * app.bottlenote 패키지를 임포트하면 admin-api 테스트 런타임 클래스패스에 함께 올라오는 admin 자체 컨트롤러와
+ * mono의 공유 클래스가 모두 검사 대상이 된다.
+ */
+@Tag("rule")
+@DisplayName("Admin API 컨트롤러 응답 타입 규칙")
+class ControllerLayerRules {
+
+	private lateinit var importedClasses: JavaClasses
+
+	@BeforeEach
+	fun setup() {
+		importedClasses = ClassFileImporter().importPackages("app.bottlenote")
+	}
+
+	@Test
+	fun controllersDeclareResponseBodyTypes() {
+		val rule: ArchRule = methods()
+			.that()
+			.arePublic()
+			.and()
+			.areDeclaredInClassesThat(respondToClients())
+			.should(declareResponseBodyType())
+			.because("응답 본문 타입은 API 문서 생성의 근거이므로 ResponseEntity<?> 대신 실제 타입을 선언해야 합니다")
+
+		rule.check(importedClasses)
+	}
+
+	/** 클라이언트에게 응답 본문을 직접 내보내는 클래스. */
+	private fun respondToClients(): DescribedPredicate<JavaClass> = object : DescribedPredicate<JavaClass>("@RestController 또는 @RestControllerAdvice 로 선언된") {
+		override fun test(javaClass: JavaClass): Boolean = javaClass.isAnnotatedWith(RestController::class.java) ||
+			javaClass.isAnnotatedWith(RestControllerAdvice::class.java)
+	}
+
+	private fun declareResponseBodyType(): ArchCondition<JavaMethod> = object : ArchCondition<JavaMethod>("ResponseEntity의 본문 타입을 구체적으로 선언한다") {
+		override fun check(method: JavaMethod, events: ConditionEvents) {
+			if (!method.rawReturnType.isAssignableTo(ResponseEntity::class.java)) {
+				return
+			}
+			val returnType = method.returnType
+			if (returnType !is JavaParameterizedType) {
+				events.add(
+					SimpleConditionEvent.violated(
+						method,
+						"${method.fullName} 이(가) 타입 인자 없는 ResponseEntity 를 반환합니다. 본문 타입을 선언하세요"
+					)
+				)
+				return
+			}
+			val hasWildcard = returnType.actualTypeArguments.any { it is JavaWildcardType }
+			if (hasWildcard) {
+				events.add(
+					SimpleConditionEvent.violated(
+						method,
+						"${method.fullName} 이(가) ResponseEntity<?> 를 반환합니다. 실제 본문 타입을 선언하세요"
+					)
+				)
+			} else {
+				events.add(SimpleConditionEvent.satisfied(method, "응답 본문 타입을 선언했습니다"))
+			}
+		}
+	}
+}

--- a/bottlenote-admin-api/src/test/resources/application-test.yml
+++ b/bottlenote-admin-api/src/test/resources/application-test.yml
@@ -47,6 +47,7 @@ app:
   cors:
     allowed-origins:
       - https://admin.bottle-note.com
+    docs-allowed-origins: []
 
 # Spring Security
 security:

--- a/bottlenote-admin-api/src/test/resources/application-test.yml
+++ b/bottlenote-admin-api/src/test/resources/application-test.yml
@@ -47,7 +47,8 @@ app:
   cors:
     allowed-origins:
       - https://admin.bottle-note.com
-    docs-allowed-origins: []
+    docs-allowed-origins:
+      - https://bottle-note.github.io
 
 # Spring Security
 security:

--- a/bottlenote-admin-api/src/test/resources/application-test.yml
+++ b/bottlenote-admin-api/src/test/resources/application-test.yml
@@ -95,3 +95,11 @@ root:
   admin:
     email: email@email.com
     password: test-root-admin-password
+
+# OpenAPI 문서 (운영 설정과 같은 경로를 유지해 스펙을 그대로 검증한다)
+springdoc:
+  api-docs:
+    path: /v1/openapi.admin.json
+  swagger-ui:
+    enabled: false
+  default-produces-media-type: application/json

--- a/bottlenote-product-api/src/main/java/app/global/security/CorsProperties.java
+++ b/bottlenote-product-api/src/main/java/app/global/security/CorsProperties.java
@@ -4,4 +4,4 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "app.cors")
-public record CorsProperties(List<String> allowedOrigins) {}
+public record CorsProperties(List<String> allowedOrigins, List<String> docsAllowedOrigins) {}

--- a/bottlenote-product-api/src/main/java/app/global/security/SecurityConfig.java
+++ b/bottlenote-product-api/src/main/java/app/global/security/SecurityConfig.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -98,12 +99,14 @@ public class SecurityConfig {
    * 필터 체인 보안 설정
    *
    * @param http the http
+   * @param corsConfigurationSource the cors configuration source
    * @return the security filter chain
    * @throws Exception the exception
    */
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+  public SecurityFilterChain filterChain(
+      HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource))
         .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(SecurityConfig::statelessSessionConfig)
         .formLogin(AbstractHttpConfigurer::disable)
@@ -135,12 +138,24 @@ public class SecurityConfig {
   /**
    * Cors 구성 소스 빈 등록
    *
+   * <p>문서 스펙 경로는 일반 API와 분리된 CORS 정책을 쓴다. 초기 허용 origin은 비어 있어 Origin이 있는 요청은 403으로 거부되고, Origin이 없는
+   * 무인증 GET은 CORS 처리 대상이 아니므로 정상 통과한다.
+   *
+   * @param openApiSpecPath the open api spec path
    * @return the cors configuration source
    */
   @Bean
-  CorsConfigurationSource corsConfigurationSource() {
+  CorsConfigurationSource corsConfigurationSource(
+      @Value("${springdoc.api-docs.path}") String openApiSpecPath) {
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+    CorsConfiguration docsConfiguration = new CorsConfiguration();
+    docsConfiguration.setAllowedOrigins(corsProperties.docsAllowedOrigins());
+    docsConfiguration.setAllowedMethods(List.of("GET", "OPTIONS"));
+    docsConfiguration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+    docsConfiguration.setAllowCredentials(false);
+    source.registerCorsConfiguration(openApiSpecPath, docsConfiguration);
 
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOrigins(corsProperties.allowedOrigins());

--- a/bottlenote-product-api/src/main/resources/application.yml
+++ b/bottlenote-product-api/src/main/resources/application.yml
@@ -6,6 +6,7 @@ app: # 애플리케이션 및 배포 정보
     allowed-origins:
       - http://localhost:3000
       - http://localhost:5173
+    docs-allowed-origins: []
   info:
     server-name: ${SERVER_NAME:unknown}
     environment: ${SPRING_PROFILES_ACTIVE:local}

--- a/bottlenote-product-api/src/main/resources/application.yml
+++ b/bottlenote-product-api/src/main/resources/application.yml
@@ -6,7 +6,8 @@ app: # 애플리케이션 및 배포 정보
     allowed-origins:
       - http://localhost:3000
       - http://localhost:5173
-    docs-allowed-origins: []
+    docs-allowed-origins:
+      - https://bottle-note.github.io
   info:
     server-name: ${SERVER_NAME:unknown}
     environment: ${SPRING_PROFILES_ACTIVE:local}

--- a/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -41,6 +42,9 @@ class SecurityConfigIntegrationTest extends IntegrationTestSupport {
   private ListAppender<ILoggingEvent> logAppender;
   private Logger dispatcherLogger;
   @Autowired private SecurityPolicyRegistry securityPolicyRegistry;
+
+  @Value("${springdoc.api-docs.path}")
+  private String openApiSpecPath;
 
   @BeforeEach
   void setUpLogCapture() {
@@ -234,6 +238,43 @@ class SecurityConfigIntegrationTest extends IntegrationTestSupport {
 
     result.assertThat().hasStatus(FORBIDDEN);
     assertThat(result.getResponse().getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull();
+  }
+
+  @Test
+  @DisplayName("문서 스펙 경로는 일반 API에서 허용된 Origin이어도 403이고 permissive CORS 헤더를 반환하지 않는다")
+  void 문서_스펙_Origin_있는_요청_거부() {
+    var result =
+        mockMvcTester
+            .get()
+            .uri(openApiSpecPath)
+            .header(HttpHeaders.ORIGIN, "https://bottle-note.com")
+            .exchange();
+
+    result.assertThat().hasStatus(FORBIDDEN);
+    assertThat(result.getResponse().getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull();
+  }
+
+  @Test
+  @DisplayName("문서 스펙 경로의 preflight 요청도 일반 API에서 허용된 Origin이어도 403으로 거부한다")
+  void 문서_스펙_preflight_거부() {
+    var result =
+        mockMvcTester
+            .options()
+            .uri(openApiSpecPath)
+            .header(HttpHeaders.ORIGIN, "https://bottle-note.com")
+            .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET")
+            .exchange();
+
+    result.assertThat().hasStatus(FORBIDDEN);
+    assertThat(result.getResponse().getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull();
+  }
+
+  @Test
+  @DisplayName("문서 스펙 경로는 Origin이 없는 무인증 GET을 정상 허용한다")
+  void 문서_스펙_Origin_없는_요청_허용() {
+    var result = mockMvcTester.get().uri(openApiSpecPath).exchange();
+
+    result.assertThat().hasStatusOk();
   }
 
   private org.springframework.test.web.servlet.assertj.MvcTestResult preflight(String origin) {

--- a/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/global/security/SecurityConfigIntegrationTest.java
@@ -270,6 +270,21 @@ class SecurityConfigIntegrationTest extends IntegrationTestSupport {
   }
 
   @Test
+  @DisplayName("GitHub Pages Origin의 문서 스펙 요청을 허용한다")
+  void 문서_스펙_GitHub_Pages_Origin_허용() {
+    var result =
+        mockMvcTester
+            .get()
+            .uri(openApiSpecPath)
+            .header(HttpHeaders.ORIGIN, "https://bottle-note.github.io")
+            .exchange();
+
+    result.assertThat().hasStatusOk();
+    assertThat(result.getResponse().getHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+        .isEqualTo("https://bottle-note.github.io");
+  }
+
+  @Test
   @DisplayName("문서 스펙 경로는 Origin이 없는 무인증 GET을 정상 허용한다")
   void 문서_스펙_Origin_없는_요청_허용() {
     var result = mockMvcTester.get().uri(openApiSpecPath).exchange();

--- a/bottlenote-product-api/src/test/resources/application-test.yml
+++ b/bottlenote-product-api/src/test/resources/application-test.yml
@@ -53,6 +53,8 @@ app:
   cors:
     allowed-origins:
       - https://bottle-note.com
+    docs-allowed-origins:
+      - https://bottle-note.github.io
 
 # OpenAPI 문서 (운영 설정과 같은 경로를 유지해 스펙을 그대로 검증한다)
 springdoc:

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -185,11 +185,11 @@
 - Files (advisory): Admin OpenAPI 테스트 지원·품질·노출·보안 테스트 4개
 - Depends: 3, 4, 5, 6, 7, 8, 9
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Checkpoint: after Tasks 5-11
-- [ ] Admin `ResponseEntity<*>` 0건 및 65 operation 문서 코드 완성
-- [ ] compile, compileTest, unit, rule 검증 통과
+- [x] Admin `ResponseEntity<*>` 0건 및 65 operation 문서 코드 완성
+- [x] compile, compileTest, unit, rule 검증 통과
 - [ ] Draft PR push 후 Product/Admin 통합 테스트 CI 통과
 
 ### Task 12: Product RestDocs 테스트 자산 제거
@@ -292,3 +292,5 @@
 - 2026-08-02: Task 8 완료. Banner·ImageUpload·Help 12개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 9 완료. CurationSpec·SpecBasedCuration 7개 operation 문서를 실제 `/v2` 경로를 유지해 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 10 완료. Admin `ResponseEntity<*>` 0건을 재확인하고 raw·wildcard 반환 타입 회귀 규칙을 추가했으며 전체 `check_rule_test`가 통과했다.
+- 2026-08-02: Task 11 완료. Admin OpenAPI 65 operation·품질·envelope·보안 계약 통합 테스트 4개를 추가했고 `compileTestKotlin`과 `unit_test`가 통과했다. 통합 테스트 실행은 Draft PR CI로 이관했다.
+- 2026-08-02: 검증 중 Kotlin/AssertJ 제네릭 추론 실패를 PUBLIC endpoint Set 값 비교로 수정해 중단 지점에서 재개했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -84,7 +84,7 @@
 - Files (advisory): admin 전용 응답 schema customizer 3개
 - Depends: 1
 - Size: S
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 3: Product 문서 전용 CORS 정책
 - Acceptance:
@@ -284,3 +284,4 @@
 - 2026-08-02: 빈 문서 CORS set의 실제 동작을 cross-origin 403, Origin 없는 무인증 GET 200으로 정밀화했다.
 - 2026-08-02: Task 1 완료. Admin springdoc 의존성·OpenAPI 설정·PUBLIC 스펙 경로를 추가했고 `compileKotlin`, `compileTestKotlin`이 통과했다. 로컬 통합 테스트는 실행하지 않았다.
 - 2026-08-02: Task 3 완료. Product 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileJava`, `compileTestJava`, `unit_test`가 통과했으며 통합 테스트는 실행하지 않았다.
+- 2026-08-02: Task 2 완료. Admin 전용 성공 envelope·공통 오류·SecurityPolicy 기반 인증 customizer를 추가했고 `compileKotlin`이 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -152,7 +152,7 @@
 - Files (advisory): 컨트롤러 3개, 문서 어노테이션 3개
 - Depends: 2
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 9: 큐레이션 스펙 operation 문서화
 - Acceptance:
@@ -289,3 +289,4 @@
 - 2026-08-02: Task 5 완료. Distillery·Region·TastingTag 22개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 6 완료. Alcohols·AdminCuration 17개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 7 완료. Auth·Users·Review 7개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 PUBLIC 인증 정책 3건을 유지한 채 `compileKotlin`이 통과했다.
+- 2026-08-02: Task 8 완료. Banner·ImageUpload·Help 12개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -142,7 +142,7 @@
 - Files (advisory): 컨트롤러 3개, 문서 어노테이션 3개
 - Depends: 2
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 8: 배너·이미지·문의 operation 문서화
 - Acceptance:
@@ -288,3 +288,4 @@
 - 2026-08-02: Task 4 완료. Admin 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileTestKotlin`과 `unit_test`가 통과했다.
 - 2026-08-02: Task 5 완료. Distillery·Region·TastingTag 22개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 6 완료. Alcohols·AdminCuration 17개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
+- 2026-08-02: Task 7 완료. Auth·Users·Review 7개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 PUBLIC 인증 정책 3건을 유지한 채 `compileKotlin`이 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -121,7 +121,7 @@
 - Files (advisory): 컨트롤러 3개, 문서 어노테이션 3개
 - Depends: 2
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 6: 위스키 본체 operation 문서화
 - Acceptance:
@@ -286,3 +286,4 @@
 - 2026-08-02: Task 3 완료. Product 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileJava`, `compileTestJava`, `unit_test`가 통과했으며 통합 테스트는 실행하지 않았다.
 - 2026-08-02: Task 2 완료. Admin 전용 성공 envelope·공통 오류·SecurityPolicy 기반 인증 customizer를 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 4 완료. Admin 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileTestKotlin`과 `unit_test`가 통과했다.
+- 2026-08-02: Task 5 완료. Distillery·Region·TastingTag 22개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -95,7 +95,7 @@
 - Files (advisory): product CORS properties/config, main/test application 설정, CORS 통합 테스트
 - Depends: 없음
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 4: Admin 문서 전용 CORS 정책
 - Acceptance:
@@ -283,3 +283,4 @@
 - 2026-08-02: 공통 OpenAPI customizer를 mono로 이동하면 batch까지 영향이 확장되므로 admin-api 내부 구현으로 범위를 유지하기로 계획했다.
 - 2026-08-02: 빈 문서 CORS set의 실제 동작을 cross-origin 403, Origin 없는 무인증 GET 200으로 정밀화했다.
 - 2026-08-02: Task 1 완료. Admin springdoc 의존성·OpenAPI 설정·PUBLIC 스펙 경로를 추가했고 `compileKotlin`, `compileTestKotlin`이 통과했다. 로컬 통합 테스트는 실행하지 않았다.
+- 2026-08-02: Task 3 완료. Product 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileJava`, `compileTestJava`, `unit_test`가 통과했으며 통합 테스트는 실행하지 않았다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -163,7 +163,7 @@
 - Files (advisory): 컨트롤러 2개, 문서 어노테이션 2개
 - Depends: 2
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 10: Admin 응답 타입 회귀 규칙
 - Acceptance:
@@ -290,3 +290,4 @@
 - 2026-08-02: Task 6 완료. Alcohols·AdminCuration 17개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 7 완료. Auth·Users·Review 7개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 PUBLIC 인증 정책 3건을 유지한 채 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 8 완료. Banner·ImageUpload·Help 12개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
+- 2026-08-02: Task 9 완료. CurationSpec·SpecBasedCuration 7개 operation 문서를 실제 `/v2` 경로를 유지해 추가했고 `compileKotlin`이 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -174,7 +174,7 @@
 - Files (advisory): 기존 product rule 테스트 1개
 - Depends: 5, 6, 7, 8, 9
 - Size: S
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 11: Admin OpenAPI 품질 통합 테스트
 - Acceptance:
@@ -291,3 +291,4 @@
 - 2026-08-02: Task 7 완료. Auth·Users·Review 7개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 PUBLIC 인증 정책 3건을 유지한 채 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 8 완료. Banner·ImageUpload·Help 12개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 9 완료. CurationSpec·SpecBasedCuration 7개 operation 문서를 실제 `/v2` 경로를 유지해 추가했고 `compileKotlin`이 통과했다.
+- 2026-08-02: Task 10 완료. Admin `ResponseEntity<*>` 0건을 재확인하고 raw·wildcard 반환 타입 회귀 규칙을 추가했으며 전체 `check_rule_test`가 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -106,11 +106,11 @@
 - Files (advisory): admin CORS properties/config, main/test application 설정, CORS 통합 테스트
 - Depends: 1
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Checkpoint: after Tasks 1-4
-- [ ] Admin/Product 컴파일과 테스트 컴파일 통과
-- [ ] 로컬 통합 테스트 실행 0건
+- [x] Admin/Product 컴파일과 테스트 컴파일 통과
+- [x] 로컬 통합 테스트 실행 0건
 
 ### Task 5: 위스키 참조 operation 문서화
 - Acceptance:
@@ -285,3 +285,4 @@
 - 2026-08-02: Task 1 완료. Admin springdoc 의존성·OpenAPI 설정·PUBLIC 스펙 경로를 추가했고 `compileKotlin`, `compileTestKotlin`이 통과했다. 로컬 통합 테스트는 실행하지 않았다.
 - 2026-08-02: Task 3 완료. Product 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileJava`, `compileTestJava`, `unit_test`가 통과했으며 통합 테스트는 실행하지 않았다.
 - 2026-08-02: Task 2 완료. Admin 전용 성공 envelope·공통 오류·SecurityPolicy 기반 인증 customizer를 추가했고 `compileKotlin`이 통과했다.
+- 2026-08-02: Task 4 완료. Admin 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileTestKotlin`과 `unit_test`가 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -131,7 +131,7 @@
 - Files (advisory): 컨트롤러 2개, 문서 어노테이션 2개
 - Depends: 2
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Task 7: 인증·사용자·리뷰 operation 문서화
 - Acceptance:
@@ -287,3 +287,4 @@
 - 2026-08-02: Task 2 완료. Admin 전용 성공 envelope·공통 오류·SecurityPolicy 기반 인증 customizer를 추가했고 `compileKotlin`이 통과했다.
 - 2026-08-02: Task 4 완료. Admin 문서 경로를 빈 `docs-allowed-origins` CORS set으로 분리하고 CI 실행 대상 통합 테스트 3개를 추가했다. `compileTestKotlin`과 `unit_test`가 통과했다.
 - 2026-08-02: Task 5 완료. Distillery·Region·TastingTag 22개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.
+- 2026-08-02: Task 6 완료. Alcohols·AdminCuration 17개 operation 문서와 명시적 `GlobalResponse` 반환 타입을 추가했고 `compileKotlin`이 통과했다.

--- a/plan/admin-openapi-and-legacy-docs-removal.md
+++ b/plan/admin-openapi-and-legacy-docs-removal.md
@@ -1,0 +1,285 @@
+# Plan: Admin OpenAPI 전환과 레거시 문서 제거
+
+## Overview
+
+**무엇을**: admin-api의 13개 컨트롤러 65개 operation을 런타임 OpenAPI 3.1 문서로 제공하고, Product/Admin의 RestDocs·AsciiDoc·Antora 문서 체계를 제거한다. Product/Admin OpenAPI JSON은 인증 없이 공개하되 일반 API CORS와 분리된 문서 전용 CORS 정책을 사용한다.
+
+**왜**: product-api는 이미 springdoc 기반 문서를 제공하지만 admin-api는 RestDocs 기반 문서만 남아 있어 문서 생성 방식이 이원화되어 있다. 두 API를 OpenAPI로 통일하고 수동 동기화가 필요한 레거시 문서 파이프라인을 제거한다.
+
+### Assumptions
+
+1. Admin OpenAPI의 외부 계약은 `GET https://admin-api.development.bottle-note.com/admin/api/v1/openapi.admin.json`이다.
+2. Admin OpenAPI JSON은 JWT 등 인증 정보 없이 조회할 수 있는 PUBLIC 리소스다. Swagger UI는 제공하지 않는다.
+3. Product와 Admin OpenAPI JSON은 일반 API CORS 정책에서 분리된 문서 전용 CORS 정책 집합을 사용한다.
+4. 문서 전용 CORS 정책의 초기 허용 origin은 비어 있다. `Origin` 없는 무인증 GET은 정상 처리하지만, `Origin`이 있는 cross-origin 요청은 Spring CORS 처리 단계에서 403으로 거부하며 permissive CORS 헤더를 반환하지 않는다. 전체 origin 허용은 후속 보안 작업에서 별도로 결정한다.
+5. product-api의 기존 springdoc 문서와 품질 검증은 유지한다. admin-api에는 같은 수준의 OpenAPI 문서 계약을 추가한다.
+6. Admin의 65개 operation 모두 한국어 태그·summary·정상 응답 스키마를 가지며, 실제 런타임 성공 응답은 기존과 동일한 `GlobalResponse` 형식을 유지한다.
+7. Admin 컨트롤러의 `ResponseEntity<*>` 58건은 명시적인 본문 타입으로 바꾸되 직렬화 결과, HTTP 상태, 헤더 및 비즈니스 동작은 변경하지 않는다. 이미 명시적인 7건과 기존에 `GlobalResponse`를 반환하는 호출을 다시 감싸지 않는다.
+8. 에러 응답 문서는 product-api의 기존 전역 오류 응답 문서화 정책과 일관되게 제공하되, 런타임 예외 처리 계약은 변경하지 않는다.
+9. Admin OpenAPI가 기존 문서를 대체할 수 있음이 검증된 뒤 Product/Admin의 RestDocs 테스트, AsciiDoc 원본, Antora 사이트, 관련 빌드·CI·프로젝트 지침을 제거한다.
+10. DB 스키마, 도메인 로직, 인증 정책(OpenAPI JSON 공개 예외 제외), API 요청·응답의 런타임 계약은 변경하지 않는다.
+
+### Success Criteria
+
+1. Admin OpenAPI 외부 URL을 무인증으로 호출하면 HTTP 200과 OpenAPI 3.1 JSON을 반환한다.
+2. Admin 문서에는 현재 13개 컨트롤러의 65개 operation이 누락 없이 포함된다.
+3. Admin operation에서 fallback 컨트롤러 태그, summary 누락, 메서드명과 동일한 summary, 빈 정상 응답 스키마가 각각 0건이다.
+4. Admin의 정상 응답 문서가 실제 `GlobalResponse` envelope와 내부 data 타입을 표현하며, 런타임 응답을 이중으로 감싼 endpoint가 0건이다.
+5. Admin 운영 컨트롤러의 `ResponseEntity<*>` 선언이 0건이며 이를 회귀 검출하는 규칙이 존재한다.
+6. Admin Swagger UI 경로는 HTTP 200을 반환하지 않는다.
+7. Product/Admin OpenAPI JSON을 임의의 외부 `Origin`으로 호출하거나 preflight 요청했을 때 permissive CORS 응답 헤더가 반환되지 않는다. 일반 API의 기존 CORS 동작은 유지된다.
+8. Product OpenAPI JSON의 무인증 HTTP 200, OpenAPI 3.1, 기존 operation 문서 품질이 유지된다.
+9. 저장소의 활성 코드·테스트·빌드·CI에서 RestDocs, AsciiDoc, Antora 실행 및 참조가 0건이다. 보존 목적의 완료 plan 기록은 검사 대상에서 제외한다.
+10. 로컬에서는 컴파일, 단위 테스트, 아키텍처 규칙 및 정적 검증이 통과하고, 통합 테스트는 PR CI의 `integration_test`와 `admin_integration_test` 결과로 통과를 확인한다.
+
+### Impact Scope
+
+**영향 모듈**
+
+- `bottlenote-admin-api`: springdoc 문서 계약, 공개 보안 정책, 문서 전용 CORS 정책, 명시적 응답 타입, 문서 품질 검증
+- `bottlenote-product-api`: 기존 OpenAPI 유지, 문서 전용 CORS 정책 분리, 레거시 문서 자산 제거
+- `bottlenote-mono`: 공통 OpenAPI/응답 타입과 아키텍처 규칙의 재사용 가능성 검토
+- 루트 Gradle·version catalog·CI workflow·프로젝트 지침: 레거시 문서 파이프라인 참조 정리
+- `docs/`: Antora 기반 정적 문서 사이트 제거
+
+**변경 없음**
+
+- Flyway 마이그레이션 및 데이터베이스 스키마
+- 도메인 서비스, Facade, Repository 및 이벤트 계약
+- OpenAPI JSON 외 일반 API의 인증·인가 정책
+- 배포 인프라와 DNS/HTTPRoute
+
+## Execution Mode
+
+- mode: **delegated**
+- scope: **plan, implement, test, verify, commit, push, pr**
+- verification-exception:
+  - 로컬 통합 테스트는 실행하지 않는다.
+  - 통합 테스트는 push 후 PR의 CI에서 실행되는 결과만 확인한다.
+  - 로컬에서는 컴파일, 단위 테스트, 아키텍처 규칙 및 통합 테스트를 제외한 정적 검증을 수행한다.
+- stop-conditions:
+  1. 가정 붕괴 — Assumptions를 깨는 발견 시 즉시 정지하고 재개봉 프로토콜을 따른다.
+  2. 검증 반복 실패 — 허용된 로컬 검증 또는 CI 실패를 3회 시도 안에 해결하지 못하면 정지한다.
+  3. scope 밖 행동 — 선언된 범위 밖의 되돌리기 어려운 행동이 필요해지면 직전에 정지한다.
+
+## Tasks
+
+### Task 1: Admin springdoc 기반과 공개 스펙 경로
+- Acceptance:
+  - context-path와 스펙 경로의 조합이 외부 계약 `/admin/api/v1/openapi.admin.json`과 일치한다.
+  - 스펙 경로가 PUBLIC이고 Swagger UI는 비활성화된다.
+  - Admin OpenAPI 상단 정보와 bearer 인증 스키마가 정의된다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin :bottlenote-admin-api:compileTestKotlin`
+- Files (advisory): admin build, main/test application 설정, `OpenApiConfig`, `SecurityPolicyConfig`
+- Depends: 없음
+- Size: M
+- Status: [x] done
+
+### Task 2: Admin GlobalResponse와 공통 오류 스키마 문서화
+- Acceptance:
+  - 정상 응답 스키마가 `success/code/data/errors/meta` envelope를 사용한다.
+  - 이미 envelope인 응답이 이중으로 감싸지지 않는다.
+  - 오류 응답 문서가 product-api의 기존 전역 정책과 일치한다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin`
+- Files (advisory): admin 전용 응답 schema customizer 3개
+- Depends: 1
+- Size: S
+- Status: [ ] not done
+
+### Task 3: Product 문서 전용 CORS 정책
+- Acceptance:
+  - Product 스펙 경로는 일반 API와 분리된 빈 문서 CORS set에 매칭된다.
+  - `Origin`이 있는 문서 요청은 403이고 permissive CORS 헤더가 없다.
+  - 문서 외 API의 기존 whitelist CORS 동작은 유지된다.
+- Verification: product compile/test compile; 실행 검증은 PR CI `integration_test`
+- Files (advisory): product CORS properties/config, main/test application 설정, CORS 통합 테스트
+- Depends: 없음
+- Size: M
+- Status: [ ] not done
+
+### Task 4: Admin 문서 전용 CORS 정책
+- Acceptance:
+  - Admin 스펙 경로는 context-path를 제외한 실제 매칭 경로로 빈 문서 CORS set에 등록된다.
+  - `Origin`이 있는 문서 요청은 403이고 permissive CORS 헤더가 없다.
+  - 문서 외 API의 기존 whitelist CORS 동작은 유지된다.
+- Verification: admin compile/test compile; 실행 검증은 PR CI `admin_integration_test`
+- Files (advisory): admin CORS properties/config, main/test application 설정, CORS 통합 테스트
+- Depends: 1
+- Size: M
+- Status: [ ] not done
+
+### Checkpoint: after Tasks 1-4
+- [ ] Admin/Product 컴파일과 테스트 컴파일 통과
+- [ ] 로컬 통합 테스트 실행 0건
+
+### Task 5: 위스키 참조 operation 문서화
+- Acceptance:
+  - Distillery·Region·TastingTag 22개 operation이 한국어 태그·summary·실제 data 스키마를 갖는다.
+  - 세 컨트롤러의 반환 타입이 명시적 `GlobalResponse`이고 런타임 반환식은 유지된다.
+  - OpenAPI components 식별자에 허용되지 않는 이름이 없다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin`
+- Files (advisory): 컨트롤러 3개, 문서 어노테이션 3개
+- Depends: 2
+- Size: M
+- Status: [ ] not done
+
+### Task 6: 위스키 본체 operation 문서화
+- Acceptance:
+  - Alcohols·AdminCuration 17개 operation이 한국어 태그·summary·실제 data 스키마를 갖는다.
+  - 두 컨트롤러의 반환 타입이 명시적 `GlobalResponse`이고 런타임 반환식은 유지된다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin`
+- Files (advisory): 컨트롤러 2개, 문서 어노테이션 2개
+- Depends: 2
+- Size: M
+- Status: [ ] not done
+
+### Task 7: 인증·사용자·리뷰 operation 문서화
+- Acceptance:
+  - Auth·Users·Review 7개 operation이 태그·summary·data 스키마를 갖는다.
+  - 로그인·갱신·Agent 로그인 3건은 무인증, 나머지는 bearer 인증으로 문서화된다.
+  - 와일드카드 반환 타입만 명시적으로 바뀌고 인증·응답 동작은 유지된다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin`
+- Files (advisory): 컨트롤러 3개, 문서 어노테이션 3개
+- Depends: 2
+- Size: M
+- Status: [ ] not done
+
+### Task 8: 배너·이미지·문의 operation 문서화
+- Acceptance:
+  - Banner·ImageUpload·Help 12개 operation이 태그·summary·data 스키마를 갖는다.
+  - 와일드카드 반환 타입만 명시적으로 바뀌고 런타임 동작은 유지된다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin`
+- Files (advisory): 컨트롤러 3개, 문서 어노테이션 3개
+- Depends: 2
+- Size: M
+- Status: [ ] not done
+
+### Task 9: 큐레이션 스펙 operation 문서화
+- Acceptance:
+  - CurationSpec·SpecBasedCuration 7개 operation이 태그·summary·data 스키마를 갖는다.
+  - `/v1` 접두사가 없는 현재 두 컨트롤러의 실제 경로를 그대로 문서화한다.
+  - Admin 65개 operation 문서 작성이 완성된다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin`
+- Files (advisory): 컨트롤러 2개, 문서 어노테이션 2개
+- Depends: 2
+- Size: M
+- Status: [ ] not done
+
+### Task 10: Admin 응답 타입 회귀 규칙
+- Acceptance:
+  - Admin 운영 컨트롤러의 `ResponseEntity<*>`가 0건이다.
+  - 와일드카드를 다시 넣으면 실패하는 `rule` 테스트가 존재한다.
+  - 기존 아키텍처 규칙 전체가 통과한다.
+- Verification: `./gradlew check_rule_test`
+- Files (advisory): 기존 product rule 테스트 1개
+- Depends: 5, 6, 7, 8, 9
+- Size: S
+- Status: [ ] not done
+
+### Task 11: Admin OpenAPI 품질 통합 테스트
+- Acceptance:
+  - 65 operation, 태그·summary·스키마 품질과 envelope 비중첩을 검사한다.
+  - 무인증 스펙 200, OpenAPI 3.1, Swagger UI 비활성, 보안 요구사항을 검사한다.
+  - 모든 테스트가 CI 대상 `admin_integration` 태그를 사용한다.
+- Verification: 로컬 `compileTestKotlin`; 실행은 PR CI `admin_integration_test`
+- Files (advisory): Admin OpenAPI 테스트 지원·품질·노출·보안 테스트 4개
+- Depends: 3, 4, 5, 6, 7, 8, 9
+- Size: M
+- Status: [ ] not done
+
+### Checkpoint: after Tasks 5-11
+- [ ] Admin `ResponseEntity<*>` 0건 및 65 operation 문서 코드 완성
+- [ ] compile, compileTest, unit, rule 검증 통과
+- [ ] Draft PR push 후 Product/Admin 통합 테스트 CI 통과
+
+### Task 12: Product RestDocs 테스트 자산 제거
+- Acceptance:
+  - Product의 RestDocs 테스트·지원 클래스·스니펫 템플릿과 `restdocs` 태그가 0건이다.
+  - 일반 통합 테스트에 남은 RestDocs request builder import는 표준 MockMvc builder로 교체된다.
+  - Product 테스트 컴파일이 통과한다.
+- Verification: `./gradlew :bottlenote-product-api:compileTestJava unit_test`
+- Files (advisory): product docs 테스트 디렉터리, external docs, 템플릿, `UserMyPageControllerTest`
+- Depends: 없음
+- Size: M
+- Status: [ ] not done
+
+### Task 13: Product AsciiDoc와 Gradle 문서 설정 제거
+- Acceptance:
+  - Product AsciiDoc 원본과 build의 RestDocs/AsciiDoctor 설정이 0건이다.
+  - Product springdoc 의존성과 OpenAPI 구현은 유지된다.
+  - Product 모듈 빌드가 허용된 검증 범위에서 통과한다.
+- Verification: `./gradlew :bottlenote-product-api:build -x test -x asciidoctor`
+- Files (advisory): product `src/docs/asciidoc`, product build
+- Depends: 12
+- Size: M
+- Status: [ ] not done
+
+### Task 14: Admin RestDocs 테스트 자산 제거
+- Acceptance:
+  - Admin RestDocs 테스트와 `restdocs` 태그가 0건이다.
+  - Admin OpenAPI 대체 문서가 직전 Draft PR CI에서 통과한 상태다.
+  - Admin 테스트 컴파일이 통과한다.
+- Verification: `./gradlew :bottlenote-admin-api:compileTestKotlin`
+- Files (advisory): admin docs 테스트 디렉터리
+- Depends: 11 및 중간 CI checkpoint
+- Size: M
+- Status: [ ] not done
+
+### Task 15: Admin AsciiDoc와 CI 문서 파이프라인 절단
+- Acceptance:
+  - Admin AsciiDoc/build 문서 설정과 GitHub Pages workflow가 제거된다.
+  - 4개 CI·배포 workflow의 `-x asciidoctor`가 0건이다.
+  - AsciiDoctor 태스크가 모두 사라진 상태에서 `build -x test`가 성립한다.
+- Verification: `./gradlew build -x test`; workflow 정적 검색
+- Files (advisory): admin docs/build, GitHub Pages, CI·배포 workflow 4개
+- Depends: 13, 14
+- Size: M
+- Status: [ ] not done
+
+### Task 16: 루트 Gradle·version catalog 문서 설정 제거
+- Acceptance:
+  - `asciidoctor`, `restDocsTest`, `docs_test`, `verifyRestDocsIncludes` 태스크가 0건이다.
+  - version catalog의 RestDocs/AsciiDoctor 항목은 0건이고 springdoc 항목은 유지된다.
+  - 통합 테스트를 제외한 전체 build가 통과한다.
+- Verification: `./gradlew tasks --all`; `./gradlew build -x test --build-cache --parallel`
+- Files (advisory): root build, version catalog
+- Depends: 15
+- Size: S
+- Status: [ ] not done
+
+### Task 17: Antora 사이트와 RestDocs 테스트 태그 정책 제거
+- Acceptance:
+  - `docs/`와 활성 `.adoc` 파일이 0건이다.
+  - 허용 테스트 태그에서 `restdocs`가 제거된다.
+  - 전체 rule 테스트가 통과한다.
+- Verification: 정적 검색; `./gradlew check_rule_test`
+- Files (advisory): `docs/`, `TestTagRules`
+- Depends: 12, 14, 15, 16
+- Size: S
+- Status: [ ] not done
+
+### Task 18: 프로젝트 지침과 문서화 가이드 갱신
+- Acceptance:
+  - 활성 지침·스킬·Admin 가이드의 RestDocs/AsciiDoc/Antora 절차 참조가 0건이다.
+  - `AGENTS.md`/`CLAUDE.md` 및 `.agents`/`.claude` 스킬 미러가 일치한다.
+  - 기존 Product OpenAPI 완료 plan은 후속 제거 사실과 모순되지 않게 보존된다.
+- Verification: 관련 문자열 검색 0건; `diff -rq .claude/skills .agents/skills`
+- Files (advisory): 지침 2개, 스킬 미러 6개, Admin 가이드, 완료 plan
+- Depends: 16, 17
+- Size: M
+- Status: [ ] not done
+
+### Final Verification
+- [ ] 로컬 통합 테스트 실행 0건
+- [ ] compile, compileTest, `unit_test`, `check_rule_test`, `build -x test` 통과
+- [ ] 활성 RestDocs·AsciiDoc·Antora 자산과 참조 0건, springdoc 양성 확인
+- [ ] 최종 push 후 PR CI의 `integration_test`, `admin_integration_test` 포함 전체 잡 통과
+- [ ] 외부 개발 URL HTTP 200은 merge·개발 배포 후 확인 항목으로 명시
+
+## Progress Log
+
+- 2026-08-02: Execution Mode를 delegated로 확정했다. 로컬 통합 테스트는 실행하지 않고 PR CI 결과만 확인한다.
+- 2026-08-02: Admin 13개 컨트롤러, 65 operation, `ResponseEntity<*>` 58건과 명시적 `GlobalResponse` 7건을 재확인했다.
+- 2026-08-02: 공통 OpenAPI customizer를 mono로 이동하면 batch까지 영향이 확장되므로 admin-api 내부 구현으로 범위를 유지하기로 계획했다.
+- 2026-08-02: 빈 문서 CORS set의 실제 동작을 cross-origin 403, Origin 없는 무인증 GET 200으로 정밀화했다.
+- 2026-08-02: Task 1 완료. Admin springdoc 의존성·OpenAPI 설정·PUBLIC 스펙 경로를 추가했고 `compileKotlin`, `compileTestKotlin`이 통과했다. 로컬 통합 테스트는 실행하지 않았다.


### PR DESCRIPTION
## 변경 내용

- Admin 런타임 OpenAPI를 `/admin/api/v1/openapi.admin.json`으로 추가하고 인증 없이 조회할 수 있게 했습니다.
- Product/Admin 문서 경로를 일반 API와 분리된 빈 `docs-allowed-origins` CORS 정책으로 구성했습니다.
- Admin 13개 컨트롤러의 65개 operation에 한국어 문서와 실제 `GlobalResponse` data 스키마를 추가했습니다.
- `ResponseEntity<*>`를 명시적 응답 타입으로 바꾸고 회귀 rule 및 OpenAPI 품질·보안 통합 테스트를 추가했습니다.

## 체크포인트

Admin OpenAPI가 기존 문서를 대체할 수 있는지 PR CI로 먼저 검증합니다. 통합 테스트 통과 후 같은 PR에서 Product/Admin RestDocs·AsciiDoc·Antora 구성을 제거합니다.

## 로컬 검증

- `:bottlenote-admin-api:compileKotlin`
- `:bottlenote-admin-api:compileTestKotlin`
- `:bottlenote-admin-api:unit_test`
- `check_rule_test`
- Product compile/test compile 및 `unit_test`
- 로컬 통합 테스트 실행 0건

Related to bottle-note/workspace#366