### PR TITLE
fix: 어드민 테이스팅 태그 중복 저장 방지

### DIFF
--- a/bottlenote-admin-api/src/test/kotlin/app/integration/alcohols/AdminAlcoholsIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/alcohols/AdminAlcoholsIntegrationTest.kt
@@ -434,6 +434,62 @@ class AdminAlcoholsIntegrationTest : IntegrationTestSupport() {
 		}
 
 		@Test
+		@DisplayName("중복 tastingTagIds로 생성해도 상세 태그는 한 번만 노출된다")
+		fun createAlcoholWithDuplicateTastingTagIds() {
+			// given
+			val region = alcoholTestFactory.persistRegion()
+			val distillery = alcoholTestFactory.persistDistillery()
+			val tag = tastingTagTestFactory.persistTastingTag("오크", "Oak")
+
+			val request =
+				mapOf(
+					"korName" to "중복 태그 위스키",
+					"engName" to "Duplicate Tag Whisky",
+					"abv" to "40%",
+					"type" to AlcoholType.WHISKY.name,
+					"korCategory" to "싱글 몰트",
+					"engCategory" to "Single Malt",
+					"categoryGroup" to AlcoholCategoryGroup.SINGLE_MALT.name,
+					"regionId" to region.id,
+					"distilleryId" to distillery.id,
+					"age" to "12",
+					"cask" to "American Oak",
+					"imageUrl" to "https://example.com/test.jpg",
+					"description" to "테스트 설명",
+					"volume" to "700ml",
+					"tastingTagIds" to listOf(tag.id, tag.id, tag.id)
+				)
+
+			// when
+			val createResult =
+				mockMvcTester
+					.post()
+					.uri("/v1/alcohols")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+					.exchange()
+
+			assertThat(createResult)
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.code")
+				.isEqualTo("ALCOHOL_CREATED")
+
+			// then
+			val alcoholId = extractData(createResult, Map::class.java)["targetId"]
+			assertThat(
+				mockMvcTester
+					.get()
+					.uri("/v1/alcohols/$alcoholId")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.tastingTags.length()")
+				.isEqualTo(1)
+		}
+
+		@Test
 		@DisplayName("존재하지 않는 태그 ID로 생성 시 실패한다")
 		fun createAlcoholWithInvalidTastingTag() {
 			// given

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/alcohols/AdminTastingTagIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/alcohols/AdminTastingTagIntegrationTest.kt
@@ -436,6 +436,41 @@ class AdminTastingTagIntegrationTest : IntegrationTestSupport() {
 					.content(mapper.writeValueAsString(request))
 			).hasStatus4xxClientError()
 		}
+
+		@Test
+		@DisplayName("이미 연결된 위스키를 다시 요청해도 멱등적으로 성공하고 상세 alcohol은 1개다")
+		fun addAlcoholsToTagIdempotent() {
+			// given
+			val tag = tastingTagTestFactory.persistTastingTag()
+			val alcohol = alcoholTestFactory.persistAlcohol()
+			tastingTagTestFactory.linkAlcoholToTag(alcohol, tag)
+
+			val request = mapOf("alcoholIds" to listOf(alcohol.id, alcohol.id))
+
+			// when
+			assertThat(
+				mockMvcTester
+					.post()
+					.uri("/v1/tasting-tags/${tag.id}/alcohols")
+					.header("Authorization", "Bearer $accessToken")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(mapper.writeValueAsString(request))
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.code")
+				.isEqualTo("TASTING_TAG_ALCOHOL_ADDED")
+
+			// then
+			assertThat(
+				mockMvcTester
+					.get()
+					.uri("/v1/tasting-tags/${tag.id}")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.alcohols.length()")
+				.isEqualTo(1)
+		}
 	}
 
 	@Nested

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTags.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTags.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +25,12 @@ import org.hibernate.annotations.Comment;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Comment("알코올과 테이스팅 태그 연관관계 해소 테이블 ")
 @Entity(name = "alcohol_tasting_tags")
-@Table(name = "alcohols_tasting_tags")
+@Table(
+    name = "alcohols_tasting_tags",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_alcohols_tasting_tags_alcohol_tag",
+            columnNames = {"alcohol_id", "tasting_tag_id"}))
 public class AlcoholsTastingTags extends BaseTimeEntity {
 
   @Id

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTagsRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTagsRepository.java
@@ -13,6 +13,4 @@ public interface AlcoholsTastingTagsRepository {
   boolean existsByTastingTagId(Long tastingTagId);
 
   void deleteByAlcoholId(Long alcoholId);
-
-  boolean existsByAlcoholIdAndTastingTagId(Long alcoholId, Long tastingTagId);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTagsRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTagsRepository.java
@@ -13,4 +13,6 @@ public interface AlcoholsTastingTagsRepository {
   boolean existsByTastingTagId(Long tastingTagId);
 
   void deleteByAlcoholId(Long alcoholId);
+
+  boolean existsByAlcoholIdAndTastingTagId(Long alcoholId, Long tastingTagId);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTagsRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/domain/AlcoholsTastingTagsRepository.java
@@ -1,10 +1,13 @@
 package app.bottlenote.alcohols.domain;
 
 import java.util.List;
+import java.util.Set;
 
 public interface AlcoholsTastingTagsRepository {
 
   List<AlcoholsTastingTags> findByTastingTagId(Long tastingTagId);
+
+  Set<Long> findAlcoholIdsByTastingTagId(Long tastingTagId);
 
   <S extends AlcoholsTastingTags> List<S> saveAll(Iterable<S> alcoholsTastingTags);
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/exception/AlcoholExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/exception/AlcoholExceptionCode.java
@@ -18,6 +18,7 @@ public enum AlcoholExceptionCode implements ExceptionCode {
   TASTING_TAG_HAS_ALCOHOLS(HttpStatus.CONFLICT, "연결된 위스키가 존재하는 태그는 삭제할 수 없습니다."),
   TASTING_TAG_PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 태그를 찾을 수 없습니다."),
   TASTING_TAG_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "태그 계층 구조는 최대 3단계까지 가능합니다."),
+  TASTING_TAG_MAPPING_DUPLICATE(HttpStatus.CONFLICT, "이미 연결된 주류-태그 매핑입니다."),
   CURATION_NOT_FOUND(HttpStatus.NOT_FOUND, "큐레이션을 찾을 수 없습니다."),
   CURATION_DUPLICATE_NAME(HttpStatus.CONFLICT, "동일한 이름의 큐레이션이 이미 존재합니다."),
   CURATION_ALCOHOL_NOT_INCLUDED(HttpStatus.BAD_REQUEST, "해당 위스키가 큐레이션에 포함되어 있지 않습니다."),

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaAlcoholsTastingTagsRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaAlcoholsTastingTagsRepository.java
@@ -4,6 +4,7 @@ import app.bottlenote.alcohols.domain.AlcoholsTastingTags;
 import app.bottlenote.alcohols.domain.AlcoholsTastingTagsRepository;
 import app.bottlenote.common.annotation.JpaRepositoryImpl;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +17,11 @@ public interface JpaAlcoholsTastingTagsRepository
   @Override
   @Query("select att from alcohol_tasting_tags att where att.tastingTag.id = :tastingTagId")
   List<AlcoholsTastingTags> findByTastingTagId(@Param("tastingTagId") Long tastingTagId);
+
+  @Override
+  @Query(
+      "select att.alcohol.id from alcohol_tasting_tags att where att.tastingTag.id = :tastingTagId")
+  Set<Long> findAlcoholIdsByTastingTagId(@Param("tastingTagId") Long tastingTagId);
 
   @Override
   @Modifying

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaAlcoholsTastingTagsRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaAlcoholsTastingTagsRepository.java
@@ -36,14 +36,4 @@ public interface JpaAlcoholsTastingTagsRepository
   @Modifying
   @Query("delete from alcohol_tasting_tags att where att.alcohol.id = :alcoholId")
   void deleteByAlcoholId(@Param("alcoholId") Long alcoholId);
-
-  @Override
-  @Query(
-      """
-      select case when count(att) > 0 then true else false end
-      from alcohol_tasting_tags att
-      where att.alcohol.id = :alcoholId and att.tastingTag.id = :tastingTagId
-      """)
-  boolean existsByAlcoholIdAndTastingTagId(
-      @Param("alcoholId") Long alcoholId, @Param("tastingTagId") Long tastingTagId);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaAlcoholsTastingTagsRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/repository/JpaAlcoholsTastingTagsRepository.java
@@ -36,4 +36,14 @@ public interface JpaAlcoholsTastingTagsRepository
   @Modifying
   @Query("delete from alcohol_tasting_tags att where att.alcohol.id = :alcoholId")
   void deleteByAlcoholId(@Param("alcoholId") Long alcoholId);
+
+  @Override
+  @Query(
+      """
+      select case when count(att) > 0 then true else false end
+      from alcohol_tasting_tags att
+      where att.alcohol.id = :alcoholId and att.tastingTag.id = :tastingTagId
+      """)
+  boolean existsByAlcoholIdAndTastingTagId(
+      @Param("alcoholId") Long alcoholId, @Param("tastingTagId") Long tastingTagId);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholCommandService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholCommandService.java
@@ -6,6 +6,7 @@ import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.ALCOHOL_HAS
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.ALCOHOL_NOT_FOUND;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.DISTILLERY_NOT_FOUND;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.REGION_NOT_FOUND;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_MAPPING_DUPLICATE;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_NOT_FOUND;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.ALCOHOL_CREATED;
 import static app.bottlenote.global.dto.response.AdminResultResponse.ResultCode.ALCOHOL_DELETED;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -172,7 +174,11 @@ public class AdminAlcoholCommandService {
                         .orElseThrow(() -> new AlcoholException(TASTING_TAG_NOT_FOUND)))
             .map(tag -> AlcoholsTastingTags.of(alcohol, tag))
             .toList();
-    alcoholsTastingTagsRepository.saveAll(mappings);
+    try {
+      alcoholsTastingTagsRepository.saveAll(mappings);
+    } catch (DataIntegrityViolationException ex) {
+      throw new AlcoholException(TASTING_TAG_MAPPING_DUPLICATE);
+    }
   }
 
   private void publishImageActivatedEvent(String imageUrl, Long alcoholId) {

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholCommandService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholCommandService.java
@@ -164,6 +164,7 @@ public class AdminAlcoholCommandService {
   private void saveTastingTags(Alcohol alcohol, List<Long> tagIds) {
     List<AlcoholsTastingTags> mappings =
         tagIds.stream()
+            .distinct()
             .map(
                 tagId ->
                     tastingTagRepository

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholQueryService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholQueryService.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -164,6 +165,10 @@ public class AlcoholQueryService {
                         att.getTastingTag().getId(),
                         att.getTastingTag().getKorName(),
                         att.getTastingTag().getEngName()))
+            .collect(
+                Collectors.toMap(TastingTagInfo::id, tag -> tag, (existing, ignored) -> existing))
+            .values()
+            .stream()
             .toList();
 
     return new AdminAlcoholDetailResponse(

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
@@ -25,8 +25,9 @@ import app.bottlenote.alcohols.dto.response.AdminTastingTagDetailResponse;
 import app.bottlenote.alcohols.dto.response.TastingTagNodeItem;
 import app.bottlenote.alcohols.exception.AlcoholException;
 import app.bottlenote.global.dto.response.AdminResultResponse;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.ahocorasick.trie.Emit;
@@ -175,17 +176,22 @@ public class TastingTagService {
             .findById(tagId)
             .orElseThrow(() -> new AlcoholException(TASTING_TAG_NOT_FOUND));
 
-    List<AlcoholsTastingTags> newMappings = new ArrayList<>();
-    for (Long alcoholId : alcoholIds.stream().distinct().toList()) {
-      if (alcoholsTastingTagsRepository.existsByAlcoholIdAndTastingTagId(alcoholId, tagId)) {
-        continue;
-      }
-      Alcohol alcohol =
-          alcoholQueryRepository
-              .findById(alcoholId)
-              .orElseThrow(() -> new AlcoholException(ALCOHOL_NOT_FOUND));
-      newMappings.add(AlcoholsTastingTags.of(alcohol, tag));
-    }
+    Set<Long> existingAlcoholIds =
+        alcoholsTastingTagsRepository.findByTastingTagId(tagId).stream()
+            .map(att -> att.getAlcohol().getId())
+            .collect(Collectors.toSet());
+
+    List<AlcoholsTastingTags> newMappings =
+        alcoholIds.stream()
+            .distinct()
+            .filter(alcoholId -> !existingAlcoholIds.contains(alcoholId))
+            .map(
+                alcoholId ->
+                    alcoholQueryRepository
+                        .findById(alcoholId)
+                        .orElseThrow(() -> new AlcoholException(ALCOHOL_NOT_FOUND)))
+            .map(alcohol -> AlcoholsTastingTags.of(alcohol, tag))
+            .toList();
 
     alcoholsTastingTagsRepository.saveAll(newMappings);
     return AdminResultResponse.of(TASTING_TAG_ALCOHOL_ADDED, tagId);

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
@@ -4,6 +4,7 @@ import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.ALCOHOL_NOT
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_DUPLICATE_NAME;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_HAS_ALCOHOLS;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_HAS_CHILDREN;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_MAPPING_DUPLICATE;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_MAX_DEPTH_EXCEEDED;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_NOT_FOUND;
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_PARENT_NOT_FOUND;
@@ -34,6 +35,7 @@ import org.ahocorasick.trie.Emit;
 import org.ahocorasick.trie.Trie;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,7 +100,13 @@ public class TastingTagService {
 
     List<AdminAlcoholItem> alcohols =
         alcoholsTastingTagsRepository.findByTastingTagId(tagId).stream()
-            .map(att -> toAdminAlcoholItem(att.getAlcohol()))
+            .map(AlcoholsTastingTags::getAlcohol)
+            .collect(
+                Collectors.toMap(
+                    Alcohol::getId, alcohol -> alcohol, (existing, ignored) -> existing))
+            .values()
+            .stream()
+            .map(this::toAdminAlcoholItem)
             .toList();
 
     return AdminTastingTagDetailResponse.of(tagNode, alcohols);
@@ -177,9 +185,7 @@ public class TastingTagService {
             .orElseThrow(() -> new AlcoholException(TASTING_TAG_NOT_FOUND));
 
     Set<Long> existingAlcoholIds =
-        alcoholsTastingTagsRepository.findByTastingTagId(tagId).stream()
-            .map(att -> att.getAlcohol().getId())
-            .collect(Collectors.toSet());
+        alcoholsTastingTagsRepository.findAlcoholIdsByTastingTagId(tagId);
 
     List<AlcoholsTastingTags> newMappings =
         alcoholIds.stream()
@@ -193,7 +199,11 @@ public class TastingTagService {
             .map(alcohol -> AlcoholsTastingTags.of(alcohol, tag))
             .toList();
 
-    alcoholsTastingTagsRepository.saveAll(newMappings);
+    try {
+      alcoholsTastingTagsRepository.saveAll(newMappings);
+    } catch (DataIntegrityViolationException ex) {
+      throw new AlcoholException(TASTING_TAG_MAPPING_DUPLICATE);
+    }
     return AdminResultResponse.of(TASTING_TAG_ALCOHOL_ADDED, tagId);
   }
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/TastingTagService.java
@@ -176,7 +176,10 @@ public class TastingTagService {
             .orElseThrow(() -> new AlcoholException(TASTING_TAG_NOT_FOUND));
 
     List<AlcoholsTastingTags> newMappings = new ArrayList<>();
-    for (Long alcoholId : alcoholIds) {
+    for (Long alcoholId : alcoholIds.stream().distinct().toList()) {
+      if (alcoholsTastingTagsRepository.existsByAlcoholIdAndTastingTagId(alcoholId, tagId)) {
+        continue;
+      }
       Alcohol alcohol =
           alcoholQueryRepository
               .findById(alcoholId)

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/TastingTagServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/TastingTagServiceTest.java
@@ -1,11 +1,17 @@
 package app.bottlenote.alcohols.service;
 
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.ALCOHOL_NOT_FOUND;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_MAPPING_DUPLICATE;
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.TASTING_TAG_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import app.bottlenote.alcohols.domain.AlcoholQueryRepository;
-import app.bottlenote.alcohols.domain.AlcoholsTastingTagsRepository;
+import app.bottlenote.alcohols.domain.Alcohol;
+import app.bottlenote.alcohols.domain.AlcoholsTastingTags;
 import app.bottlenote.alcohols.domain.TastingTag;
+import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.alcohols.fixture.InMemoryAlcoholQueryRepository;
+import app.bottlenote.alcohols.fixture.InMemoryAlcoholsTastingTagsRepository;
 import app.bottlenote.alcohols.fixture.InMemoryTastingTagRepository;
 import java.util.List;
 import java.util.stream.Stream;
@@ -24,15 +30,15 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 class TastingTagServiceTest {
 
   InMemoryTastingTagRepository tastingTagRepository;
-  AlcoholsTastingTagsRepository alcoholsTastingTagsRepository;
-  AlcoholQueryRepository alcoholQueryRepository;
+  InMemoryAlcoholsTastingTagsRepository alcoholsTastingTagsRepository;
+  InMemoryAlcoholQueryRepository alcoholQueryRepository;
   TastingTagService tastingTagService;
 
   @BeforeEach
   void setUp() {
     tastingTagRepository = new InMemoryTastingTagRepository();
-    alcoholsTastingTagsRepository = mock(AlcoholsTastingTagsRepository.class);
-    alcoholQueryRepository = mock(AlcoholQueryRepository.class);
+    alcoholsTastingTagsRepository = new InMemoryAlcoholsTastingTagsRepository();
+    alcoholQueryRepository = new InMemoryAlcoholQueryRepository();
     tastingTagService =
         new TastingTagService(
             tastingTagRepository, alcoholsTastingTagsRepository, alcoholQueryRepository);
@@ -138,6 +144,95 @@ class TastingTagServiceTest {
 
       // then
       assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("addAlcoholsToTag 메서드")
+  class AddAlcoholsToTag {
+
+    @Test
+    @DisplayName("요청 alcoholId 중복은 한 번만 저장한다")
+    void 요청_중복_alcoholId는_한_번만_저장한다() {
+      TastingTag tag = tastingTagRepository.findByKorName("오크").orElseThrow();
+      Alcohol alcohol = alcoholQueryRepository.save(Alcohol.builder().korName("위스키1").build());
+
+      tastingTagService.addAlcoholsToTag(tag.getId(), List.of(alcohol.getId(), alcohol.getId()));
+
+      assertThat(alcoholsTastingTagsRepository.count()).isEqualTo(1);
+      assertThat(alcoholsTastingTagsRepository.findAlcoholIdsByTastingTagId(tag.getId()))
+          .containsExactly(alcohol.getId());
+    }
+
+    @Test
+    @DisplayName("이미 연결된 주류는 skip 하여 멱등적으로 성공한다")
+    void 이미_연결된_주류는_skip한다() {
+      TastingTag tag = tastingTagRepository.findByKorName("오크").orElseThrow();
+      Alcohol alcohol = alcoholQueryRepository.save(Alcohol.builder().korName("위스키1").build());
+      alcoholsTastingTagsRepository.saveAll(List.of(AlcoholsTastingTags.of(alcohol, tag)));
+
+      tastingTagService.addAlcoholsToTag(tag.getId(), List.of(alcohol.getId()));
+
+      assertThat(alcoholsTastingTagsRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 태그면 TASTING_TAG_NOT_FOUND 예외를 던진다")
+    void 태그_미존재_예외() {
+      assertThatThrownBy(() -> tastingTagService.addAlcoholsToTag(999L, List.of(1L)))
+          .isInstanceOf(AlcoholException.class)
+          .extracting(ex -> ((AlcoholException) ex).getExceptionCode())
+          .isEqualTo(TASTING_TAG_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 주류면 ALCOHOL_NOT_FOUND 예외를 던진다")
+    void 주류_미존재_예외() {
+      TastingTag tag = tastingTagRepository.findByKorName("오크").orElseThrow();
+
+      assertThatThrownBy(() -> tastingTagService.addAlcoholsToTag(tag.getId(), List.of(999L)))
+          .isInstanceOf(AlcoholException.class)
+          .extracting(ex -> ((AlcoholException) ex).getExceptionCode())
+          .isEqualTo(ALCOHOL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("유니크 제약 위반 시 TASTING_TAG_MAPPING_DUPLICATE 로 변환한다")
+    void 유니크_위반_시_매핑_중복_예외() {
+      TastingTag tag = tastingTagRepository.findByKorName("오크").orElseThrow();
+      Alcohol alcohol = alcoholQueryRepository.save(Alcohol.builder().korName("위스키1").build());
+      alcoholsTastingTagsRepository.saveAll(List.of(AlcoholsTastingTags.of(alcohol, tag)));
+
+      // 사전 skip을 우회해 저장 단계에서 중복이 나도록, 기존 매핑 조회 결과를 비우는 대신
+      // 동일 매핑을 강제로 한 번 더 저장 시도한다.
+      assertThatThrownBy(
+              () ->
+                  alcoholsTastingTagsRepository.saveAll(
+                      List.of(AlcoholsTastingTags.of(alcohol, tag))))
+          .isInstanceOf(org.springframework.dao.DataIntegrityViolationException.class);
+
+      // 서비스 계층 변환: 동시성으로 사전 체크가 빈 사이 중복 insert 가 발생한 경우를 모사
+      InMemoryAlcoholsTastingTagsRepository racingRepo =
+          new InMemoryAlcoholsTastingTagsRepository() {
+            @Override
+            public java.util.Set<Long> findAlcoholIdsByTastingTagId(Long tastingTagId) {
+              return java.util.Set.of();
+            }
+
+            @Override
+            public <S extends AlcoholsTastingTags> List<S> saveAll(
+                Iterable<S> alcoholsTastingTags) {
+              throw new org.springframework.dao.DataIntegrityViolationException("duplicate");
+            }
+          };
+      TastingTagService racingService =
+          new TastingTagService(tastingTagRepository, racingRepo, alcoholQueryRepository);
+
+      assertThatThrownBy(
+              () -> racingService.addAlcoholsToTag(tag.getId(), List.of(alcohol.getId())))
+          .isInstanceOf(AlcoholException.class)
+          .extracting(ex -> ((AlcoholException) ex).getExceptionCode())
+          .isEqualTo(TASTING_TAG_MAPPING_DUPLICATE);
     }
   }
 

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import app.bottlenote.user.domain.User;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.fixture.UserTestFactory;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
@@ -127,8 +128,10 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       assertThat(terms.getClientIp()).isEqualTo("203.0.113.10");
       assertThat(terms.getUserAgent()).isEqualTo("BottleNote/2.0");
       assertThat(latest(user, MARKETING).getAction()).isEqualTo(AGREE);
-      assertThat(item(data, TERMS_OF_SERVICE.name()).path("recordedAt").asText())
-          .isEqualTo(terms.getRecordedAt().toString());
+      // JSON 문자열과 LocalDateTime#toString()은 소수부 자리수가 다를 수 있어 시각 값으로 비교한다.
+      LocalDateTime responseRecordedAt =
+          LocalDateTime.parse(item(data, TERMS_OF_SERVICE.name()).path("recordedAt").asText());
+      assertThat(responseRecordedAt).isEqualTo(terms.getRecordedAt());
     }
 
     @Test

--- a/bottlenote-test-support/src/main/java/app/bottlenote/alcohols/fixture/InMemoryAlcoholsTastingTagsRepository.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/alcohols/fixture/InMemoryAlcoholsTastingTagsRepository.java
@@ -1,0 +1,89 @@
+package app.bottlenote.alcohols.fixture;
+
+import app.bottlenote.alcohols.domain.AlcoholsTastingTags;
+import app.bottlenote.alcohols.domain.AlcoholsTastingTagsRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class InMemoryAlcoholsTastingTagsRepository implements AlcoholsTastingTagsRepository {
+
+  private final List<AlcoholsTastingTags> mappings = new ArrayList<>();
+  private final AtomicLong idSequence = new AtomicLong(1);
+
+  @Override
+  public List<AlcoholsTastingTags> findByTastingTagId(Long tastingTagId) {
+    return mappings.stream()
+        .filter(att -> Objects.equals(att.getTastingTag().getId(), tastingTagId))
+        .toList();
+  }
+
+  @Override
+  public Set<Long> findAlcoholIdsByTastingTagId(Long tastingTagId) {
+    return mappings.stream()
+        .filter(att -> Objects.equals(att.getTastingTag().getId(), tastingTagId))
+        .map(att -> att.getAlcohol().getId())
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public <S extends AlcoholsTastingTags> List<S> saveAll(Iterable<S> alcoholsTastingTags) {
+    List<S> saved = new ArrayList<>();
+    for (S mapping : alcoholsTastingTags) {
+      Long alcoholId = mapping.getAlcohol().getId();
+      Long tagId = mapping.getTastingTag().getId();
+      boolean duplicate =
+          mappings.stream()
+              .anyMatch(
+                  existing ->
+                      Objects.equals(existing.getAlcohol().getId(), alcoholId)
+                          && Objects.equals(existing.getTastingTag().getId(), tagId));
+      if (duplicate) {
+        throw new DataIntegrityViolationException(
+            "duplicate alcohol-tasting-tag mapping: " + alcoholId + "/" + tagId);
+      }
+      if (mapping.getId() == null) {
+        ReflectionTestUtils.setField(mapping, "id", idSequence.getAndIncrement());
+      }
+      mappings.add(mapping);
+      saved.add(mapping);
+    }
+    return saved;
+  }
+
+  @Override
+  public void deleteByTastingTagIdAndAlcoholIdIn(Long tastingTagId, List<Long> alcoholIds) {
+    mappings.removeIf(
+        att ->
+            Objects.equals(att.getTastingTag().getId(), tastingTagId)
+                && alcoholIds.contains(att.getAlcohol().getId()));
+  }
+
+  @Override
+  public boolean existsByTastingTagId(Long tastingTagId) {
+    return mappings.stream()
+        .anyMatch(att -> Objects.equals(att.getTastingTag().getId(), tastingTagId));
+  }
+
+  @Override
+  public void deleteByAlcoholId(Long alcoholId) {
+    mappings.removeIf(att -> Objects.equals(att.getAlcohol().getId(), alcoholId));
+  }
+
+  public List<AlcoholsTastingTags> findAll() {
+    return List.copyOf(mappings);
+  }
+
+  public int count() {
+    return mappings.size();
+  }
+
+  public void clear() {
+    mappings.clear();
+  }
+}


### PR DESCRIPTION
## 변경 내용

### 문제
어드민 주류 상세 조회 API(`GET /admin/api/v1/alcohols/{id}`) 응답의 `tastingTags` 배열에 동일 태그가 중복 노출됨.
예: 5885번 위스키에서 id=127 "오크" 태그가 2번 출력.

### 원인
- `alcohols_tasting_tags` 조인 테이블에 유니크 제약조건이 없음
- 서비스 레이어에서 태그 저장 시 입력값 중복 제거 및 기존 매핑 존재 여부를 확인하지 않음
- `AlcoholsTastingTags` 엔티티에 `equals/hashCode`가 없어 `Set`으로도 중복 row를 걸러내지 못함

### 수정
- `AdminAlcoholCommandService.saveTastingTags()`: `tagIds.distinct()` 적용 (create/update 시 입력 배열 내 중복 ID 방지)
- `TastingTagService.addAlcoholsToTag()`: `alcoholIds.distinct()` + 기존 매핑 존재 시 skip (exists 체크 추가)
- `AlcoholsTastingTagsRepository` / `JpaAlcoholsTastingTagsRepository`: `existsByAlcoholIdAndTastingTagId()` 메서드 추가

### 영향 범위
- `AdminAlcoholCommandService` — 주류 생성/수정 시 태그 저장
- `TastingTagService` — 태그에 주류 일괄 추가

### 기존 중복 데이터 정리
배포 후 아래 쿼리로 기존 중복 row 제거 필요:
```sql
DELETE t1 FROM alcohols_tasting_tags t1
INNER JOIN alcohols_tasting_tags t2
WHERE t1.id > t2.id
  AND t1.alcohol_id = t2.alcohol_id
  AND t1.tasting_tag_id = t2.tasting_tag_id;
```