### PR TITLE
feat: 동의 상태 응답에 recordedAt 포함

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/domain/AgreementEvaluation.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/domain/AgreementEvaluation.java
@@ -1,6 +1,7 @@
 package app.bottlenote.agreement.domain;
 
 import app.bottlenote.agreement.constant.AgreementType;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /** 사용자의 현재 약관 동의 판정 결과를 나타낸다. */
@@ -10,6 +11,7 @@ public record AgreementEvaluation(boolean eligible, List<Item> items) {
     items = List.copyOf(items);
   }
 
-  /** 약관 유형별 현재 동의 상태를 나타낸다. */
-  public record Item(AgreementType type, boolean required, boolean agreed) {}
+  /** 약관 유형별 현재 동의 상태를 나타낸다. recordedAt은 이력 없으면 null. */
+  public record Item(
+      AgreementType type, boolean required, boolean agreed, LocalDateTime recordedAt) {}
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/service/AgreementEvaluator.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/service/AgreementEvaluator.java
@@ -25,11 +25,15 @@ public class AgreementEvaluator {
   }
 
   private Item evaluate(Long userId, AgreementType type) {
-    boolean agreed =
-        userAgreementRepository
-            .findFirstByUserIdAndAgreementTypeOrderByIdDesc(userId, type)
-            .filter(agreement -> agreement.getAction() == AgreementAction.AGREE)
-            .isPresent();
-    return new Item(type, type.isRequired(), agreed);
+    return userAgreementRepository
+        .findFirstByUserIdAndAgreementTypeOrderByIdDesc(userId, type)
+        .map(
+            agreement ->
+                new Item(
+                    type,
+                    type.isRequired(),
+                    agreement.getAction() == AgreementAction.AGREE,
+                    agreement.getRecordedAt()))
+        .orElseGet(() -> new Item(type, type.isRequired(), false, null));
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/service/AgreementService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/service/AgreementService.java
@@ -8,6 +8,7 @@ import app.bottlenote.agreement.exception.AgreementException;
 import app.bottlenote.agreement.exception.AgreementExceptionCode;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,8 @@ public class AgreementService {
   public AgreementEvaluation submit(
       Long userId, List<AgreementSubmission> submissions, String clientIp, String userAgent) {
     validate(submissions);
-    LocalDateTime recordedAt = LocalDateTime.now(clock);
+    // MySQL DATETIME(6)과 맞춰 마이크로초로 정규화한다. 나노 잔여 시 응답/DB 재조회 불일치가 난다.
+    LocalDateTime recordedAt = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MICROS);
     submissions.forEach(
         submission ->
             userAgreementRepository.save(

--- a/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementEvaluatorTest.java
@@ -39,9 +39,9 @@ class AgreementEvaluatorTest {
     assertThat(result.eligible()).isFalse();
     assertThat(result.items())
         .containsExactly(
-            new Item(AgreementType.TERMS_OF_SERVICE, true, false),
-            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false),
-            new Item(AgreementType.MARKETING, false, false));
+            new Item(AgreementType.TERMS_OF_SERVICE, true, false, null),
+            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false, null),
+            new Item(AgreementType.MARKETING, false, false, null));
   }
 
   @Test
@@ -54,7 +54,11 @@ class AgreementEvaluatorTest {
 
     assertThat(result.eligible()).isTrue();
     assertThat(result.items()).filteredOn(Item::required).allMatch(Item::agreed);
+    assertThat(item(result, AgreementType.TERMS_OF_SERVICE).recordedAt()).isEqualTo(RECORDED_AT);
+    assertThat(item(result, AgreementType.PRIVACY_COLLECTION_USE).recordedAt())
+        .isEqualTo(RECORDED_AT.minusYears(1));
     assertThat(item(result, AgreementType.MARKETING).agreed()).isFalse();
+    assertThat(item(result, AgreementType.MARKETING).recordedAt()).isNull();
   }
 
   @Test
@@ -68,6 +72,7 @@ class AgreementEvaluatorTest {
 
     assertThat(result.eligible()).isFalse();
     assertThat(item(result, AgreementType.TERMS_OF_SERVICE).agreed()).isFalse();
+    assertThat(item(result, AgreementType.TERMS_OF_SERVICE).recordedAt()).isEqualTo(RECORDED_AT);
   }
 
   @Test
@@ -81,6 +86,7 @@ class AgreementEvaluatorTest {
 
     assertThat(result.eligible()).isFalse();
     assertThat(item(result, AgreementType.TERMS_OF_SERVICE).agreed()).isFalse();
+    assertThat(item(result, AgreementType.TERMS_OF_SERVICE).recordedAt()).isEqualTo(RECORDED_AT);
   }
 
   @Test
@@ -93,6 +99,7 @@ class AgreementEvaluatorTest {
     AgreementEvaluation result = evaluator.evaluate(USER_ID);
 
     assertThat(result.eligible()).isTrue();
+    assertThat(item(result, AgreementType.TERMS_OF_SERVICE).recordedAt()).isEqualTo(RECORDED_AT);
   }
 
   private void save(AgreementType type, AgreementAction action, LocalDateTime recordedAt) {

--- a/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementServiceTest.java
@@ -56,9 +56,9 @@ class AgreementServiceTest {
     assertThat(result.eligible()).isFalse();
     assertThat(result.items())
         .containsExactly(
-            new Item(AgreementType.TERMS_OF_SERVICE, true, false),
-            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false),
-            new Item(AgreementType.MARKETING, false, false));
+            new Item(AgreementType.TERMS_OF_SERVICE, true, false, null),
+            new Item(AgreementType.PRIVACY_COLLECTION_USE, true, false, null),
+            new Item(AgreementType.MARKETING, false, false, null));
   }
 
   @Nested
@@ -112,7 +112,9 @@ class AgreementServiceTest {
 
       assertThat(result.eligible()).isTrue();
       assertThat(result.items()).filteredOn(Item::required).allMatch(Item::agreed);
+      assertThat(item(result, AgreementType.TERMS_OF_SERVICE).recordedAt()).isEqualTo(RECORDED_AT);
       assertThat(item(result, AgreementType.MARKETING).agreed()).isFalse();
+      assertThat(item(result, AgreementType.MARKETING).recordedAt()).isNull();
       assertThat(result).isEqualTo(service.getStatus(USER_ID));
     }
 
@@ -145,6 +147,7 @@ class AgreementServiceTest {
       assertThat(repository.findAll()).hasSize(3);
       assertThat(result.eligible()).isFalse();
       assertThat(item(result, AgreementType.TERMS_OF_SERVICE).agreed()).isFalse();
+      assertThat(item(result, AgreementType.TERMS_OF_SERVICE).recordedAt()).isEqualTo(RECORDED_AT);
     }
 
     @Test

--- a/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/agreement/service/AgreementServiceTest.java
@@ -18,6 +18,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -87,6 +88,26 @@ class AgreementServiceTest {
           .containsExactly(
               tuple(AgreementType.TERMS_OF_SERVICE, "이용약관 원문"),
               tuple(AgreementType.PRIVACY_COLLECTION_USE, "개인정보 원문"));
+    }
+
+    @Test
+    @DisplayName("기록 시각을 마이크로초로 정규화한다")
+    void submit_whenClockHasNanos_truncatesRecordedAtToMicros() {
+      Instant withNanos = Instant.parse("2026-08-01T01:23:45.123456789Z");
+      service =
+          new AgreementService(
+              repository, new AgreementEvaluator(repository), Clock.fixed(withNanos, ZONE_ID));
+
+      service.submit(
+          USER_ID, requiredSubmissions(AgreementInputContext.INDIVIDUAL), CLIENT_IP, USER_AGENT);
+
+      LocalDateTime expected =
+          LocalDateTime.ofInstant(withNanos, ZONE_ID).truncatedTo(ChronoUnit.MICROS);
+      assertThat(repository.findAll())
+          .isNotEmpty()
+          .allSatisfy(agreement -> assertThat(agreement.getRecordedAt()).isEqualTo(expected));
+      assertThat(item(service.getStatus(USER_ID), AgreementType.TERMS_OF_SERVICE).recordedAt())
+          .isEqualTo(expected);
     }
 
     @Test

--- a/bottlenote-product-api/src/main/java/app/bottlenote/agreement/dto/response/AgreementStatusResponse.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/agreement/dto/response/AgreementStatusResponse.java
@@ -3,6 +3,7 @@ package app.bottlenote.agreement.dto.response;
 import app.bottlenote.agreement.constant.AgreementType;
 import app.bottlenote.agreement.domain.AgreementEvaluation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /** 사용자의 현재 약관 동의 상태 응답을 나타낸다. */
@@ -21,10 +22,12 @@ public record AgreementStatusResponse(
   public record Item(
       @Schema(description = "동의 유형") AgreementType type,
       @Schema(description = "필수 동의 여부") boolean required,
-      @Schema(description = "현재 동의 충족 여부") boolean agreed) {
+      @Schema(description = "현재 동의 충족 여부") boolean agreed,
+      @Schema(description = "해당 유형 최신 이력 기록 시각(KST wall-clock). 이력 없으면 null")
+          LocalDateTime recordedAt) {
 
     private static Item from(AgreementEvaluation.Item item) {
-      return new Item(item.type(), item.required(), item.agreed());
+      return new Item(item.type(), item.required(), item.agreed(), item.recordedAt());
     }
   }
 }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
@@ -66,10 +66,11 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       assertThat(data.path("eligible").booleanValue()).isFalse();
       assertThat(data.path("items")).hasSize(3);
       assertThat(fieldNames(data.path("items").get(0)))
-          .containsExactlyInAnyOrder("type", "required", "agreed");
+          .containsExactlyInAnyOrder("type", "required", "agreed", "recordedAt");
       JsonNode marketing = item(data, MARKETING.name());
       assertThat(marketing.path("required").booleanValue()).isFalse();
       assertThat(marketing.path("agreed").booleanValue()).isFalse();
+      assertThat(marketing.path("recordedAt").isNull()).isTrue();
     }
 
     @Test
@@ -112,9 +113,12 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       assertThat(fieldNames(data)).containsExactlyInAnyOrder("eligible", "items");
       assertThat(data.path("eligible").booleanValue()).isTrue();
       assertThat(data.path("items")).hasSize(3);
+      assertThat(fieldNames(data.path("items").get(0)))
+          .containsExactlyInAnyOrder("type", "required", "agreed", "recordedAt");
       JsonNode marketing = item(data, MARKETING.name());
       assertThat(marketing.path("required").booleanValue()).isFalse();
       assertThat(marketing.path("agreed").booleanValue()).isTrue();
+      assertThat(marketing.path("recordedAt").isNull()).isFalse();
 
       UserAgreement terms = latest(user, TERMS_OF_SERVICE);
       assertThat(terms.getAction()).isEqualTo(AGREE);
@@ -123,6 +127,8 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       assertThat(terms.getClientIp()).isEqualTo("203.0.113.10");
       assertThat(terms.getUserAgent()).isEqualTo("BottleNote/2.0");
       assertThat(latest(user, MARKETING).getAction()).isEqualTo(AGREE);
+      assertThat(item(data, TERMS_OF_SERVICE.name()).path("recordedAt").asText())
+          .isEqualTo(terms.getRecordedAt().toString());
     }
 
     @Test

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
@@ -21,6 +21,8 @@ import app.bottlenote.user.domain.User;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.fixture.UserTestFactory;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
@@ -127,8 +129,11 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       assertThat(terms.getClientIp()).isEqualTo("203.0.113.10");
       assertThat(terms.getUserAgent()).isEqualTo("BottleNote/2.0");
       assertThat(latest(user, MARKETING).getAction()).isEqualTo(AGREE);
-      assertThat(item(data, TERMS_OF_SERVICE.name()).path("recordedAt").asText())
-          .isEqualTo(terms.getRecordedAt().toString());
+      // 응답은 저장 직후 메모리 값(나노), DB 재조회는 DATETIME 정밀도(마이크로)일 수 있다.
+      LocalDateTime responseRecordedAt =
+          LocalDateTime.parse(item(data, TERMS_OF_SERVICE.name()).path("recordedAt").asText());
+      assertThat(responseRecordedAt.truncatedTo(ChronoUnit.MICROS))
+          .isEqualTo(terms.getRecordedAt().truncatedTo(ChronoUnit.MICROS));
     }
 
     @Test

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
@@ -21,8 +21,6 @@ import app.bottlenote.user.domain.User;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.fixture.UserTestFactory;
 import com.fasterxml.jackson.databind.JsonNode;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.StreamSupport;
@@ -129,11 +127,8 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
       assertThat(terms.getClientIp()).isEqualTo("203.0.113.10");
       assertThat(terms.getUserAgent()).isEqualTo("BottleNote/2.0");
       assertThat(latest(user, MARKETING).getAction()).isEqualTo(AGREE);
-      // 응답은 저장 직후 메모리 값(나노), DB 재조회는 DATETIME 정밀도(마이크로)일 수 있다.
-      LocalDateTime responseRecordedAt =
-          LocalDateTime.parse(item(data, TERMS_OF_SERVICE.name()).path("recordedAt").asText());
-      assertThat(responseRecordedAt.truncatedTo(ChronoUnit.MICROS))
-          .isEqualTo(terms.getRecordedAt().truncatedTo(ChronoUnit.MICROS));
+      assertThat(item(data, TERMS_OF_SERVICE.name()).path("recordedAt").asText())
+          .isEqualTo(terms.getRecordedAt().toString());
     }
 
     @Test

--- a/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/global/integration/OpenApiDocsIntegrationTest.java
@@ -144,7 +144,7 @@ class OpenApiDocsIntegrationTest extends OpenApiSpecTestSupport {
               JsonNode itemSchema =
                   resolveSchema(spec, statusSchema.path("properties").path("items").path("items"));
               assertThat(propertyNamesOf(itemSchema))
-                  .containsExactlyInAnyOrder("type", "required", "agreed");
+                  .containsExactlyInAnyOrder("type", "required", "agreed", "recordedAt");
             });
 
     var submitOperation =


### PR DESCRIPTION
## Summary
- 동의 상태 조회·제출 응답 `items[]`에 유형별 최신 이력 시점 `recordedAt`을 추가한다.
- 이력 없으면 `null`, 최신 이력이 있으면 action과 무관하게 시점 노출. `eligible`/`agreed` 판정은 변경 없음.
- OpenAPI·통합 테스트 exact field 계약을 갱신한다.

관련 이슈: bottle-note/workspace#371

## Changelog
### Added
- `GET /api/v2/agreements/status`, `POST /api/v2/agreements` 응답 item 필드 `recordedAt` (KST wall-clock `LocalDateTime`, 이력 없음 `null`)

### Changed
- `AgreementEvaluation.Item` / `AgreementStatusResponse.Item` 스키마 확장
- `AgreementEvaluator`가 최신 이력의 `recordedAt`을 상태 결과에 투영

### Not changed
- `eligible` / `agreed` 판정 로직
- 동의 이력 저장 방식·DB 스키마
- 로그인 `agreementRequired` 힌트

## Test plan
- [x] `:bottlenote-mono:test --tests 'app.bottlenote.agreement.service.*'` 통과
- [x] `:bottlenote-product-api:integration_test` (AgreementController + OpenApiDocs) 통과
- [ ] CI 확인