### PR TITLE
WIP: AgreementGate 정책 집행 및 403 계약

### DIFF
--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/annotation/AgreementExempt.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/annotation/AgreementExempt.java
@@ -1,0 +1,13 @@
+package app.bottlenote.agreement.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** 필수 약관 동의 게이트 검사를 면제한다. 메서드 또는 클래스에 선언할 수 있다. */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AgreementExempt {}

--- a/bottlenote-mono/src/main/java/app/bottlenote/agreement/exception/AgreementExceptionCode.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/agreement/exception/AgreementExceptionCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum AgreementExceptionCode implements ExceptionCode {
   INVALID_AGREEMENT_TYPE(HttpStatus.BAD_REQUEST, "알 수 없는 동의 유형입니다."),
   UNSUPPORTED_AGREEMENT_ACTION(HttpStatus.BAD_REQUEST, "요청할 수 없는 동의 상태입니다."),
-  AGREEMENT_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "동의 문서 원문은 비어 있을 수 없습니다.");
+  AGREEMENT_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "동의 문서 원문은 비어 있을 수 없습니다."),
+  AGREEMENT_REQUIRED(HttpStatus.FORBIDDEN, "필수 약관 동의가 필요합니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/bottlenote-product-api/src/main/java/app/bottlenote/agreement/config/AgreementGateWebConfig.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/agreement/config/AgreementGateWebConfig.java
@@ -1,0 +1,23 @@
+package app.bottlenote.agreement.config;
+
+import app.bottlenote.agreement.facade.AgreementFacade;
+import app.bottlenote.agreement.interceptor.AgreementGateInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** product-api 전용 약관 동의 게이트 인터셉터 등록. admin-api/batch에는 영향하지 않는다. */
+@Configuration
+@RequiredArgsConstructor
+public class AgreementGateWebConfig implements WebMvcConfigurer {
+
+  private final AgreementFacade agreementFacade;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry
+        .addInterceptor(new AgreementGateInterceptor(agreementFacade))
+        .addPathPatterns("/api/**");
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/agreement/controller/AgreementController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/agreement/controller/AgreementController.java
@@ -4,6 +4,7 @@ import static app.bottlenote.common.support.HttpClient.getClientIP;
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.REQUIRED_AUTH;
 import static app.bottlenote.user.exception.UserExceptionCode.REQUIRED_USER_ID;
 
+import app.bottlenote.agreement.annotation.AgreementExempt;
 import app.bottlenote.agreement.controller.docs.AgreementApiDocs;
 import app.bottlenote.agreement.dto.request.AgreementSubmitRequest;
 import app.bottlenote.agreement.dto.response.AgreementStatusResponse;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 /** 인증 사용자의 약관 동의 API를 제공한다. */
 @RestController
 @RequiredArgsConstructor
+@AgreementExempt
 @SecurityPolicy(auth = REQUIRED_AUTH)
 @RequestMapping("/api/v2/agreements")
 @AgreementApiDocs.ApiTag

--- a/bottlenote-product-api/src/main/java/app/bottlenote/agreement/interceptor/AgreementGateInterceptor.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/agreement/interceptor/AgreementGateInterceptor.java
@@ -1,0 +1,47 @@
+package app.bottlenote.agreement.interceptor;
+
+import app.bottlenote.agreement.annotation.AgreementExempt;
+import app.bottlenote.agreement.exception.AgreementException;
+import app.bottlenote.agreement.exception.AgreementExceptionCode;
+import app.bottlenote.agreement.facade.AgreementFacade;
+import app.bottlenote.global.security.SecurityContextUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** 인증된 사용자의 필수 약관 동의 충족 여부를 요청 전에 검사한다. */
+@RequiredArgsConstructor
+public class AgreementGateInterceptor implements HandlerInterceptor {
+
+  private final AgreementFacade agreementFacade;
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (!(handler instanceof HandlerMethod handlerMethod)) {
+      return true;
+    }
+    if (isExempt(handlerMethod)) {
+      return true;
+    }
+
+    Optional<Long> userId = SecurityContextUtil.getUserIdByContext();
+    if (userId.isEmpty()) {
+      return true;
+    }
+
+    if (!agreementFacade.isEligible(userId.get())) {
+      throw new AgreementException(AgreementExceptionCode.AGREEMENT_REQUIRED);
+    }
+    return true;
+  }
+
+  private boolean isExempt(HandlerMethod handlerMethod) {
+    return AnnotatedElementUtils.hasAnnotation(handlerMethod.getMethod(), AgreementExempt.class)
+        || AnnotatedElementUtils.hasAnnotation(handlerMethod.getBeanType(), AgreementExempt.class);
+  }
+}

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/AuthV2Controller.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/AuthV2Controller.java
@@ -3,6 +3,7 @@ package app.bottlenote.user.controller;
 import static app.bottlenote.global.annotation.SecurityPolicy.AuthType.PUBLIC;
 import static app.bottlenote.user.exception.UserExceptionCode.REQUIRED_USER_ID;
 
+import app.bottlenote.agreement.annotation.AgreementExempt;
 import app.bottlenote.global.annotation.SecurityPolicy;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.security.SecurityContextUtil;
@@ -113,6 +114,7 @@ public class AuthV2Controller {
   }
 
   /** 토큰 재발급 */
+  @AgreementExempt
   @SecurityPolicy(auth = PUBLIC)
   @AuthApiDocs.ReissueToken
   @PostMapping("/reissue")

--- a/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/UserBasicController.java
+++ b/bottlenote-product-api/src/main/java/app/bottlenote/user/controller/UserBasicController.java
@@ -3,6 +3,7 @@ package app.bottlenote.user.controller;
 import static app.bottlenote.global.security.SecurityContextUtil.getUserIdByContext;
 import static app.bottlenote.user.exception.UserExceptionCode.REQUIRED_USER_ID;
 
+import app.bottlenote.agreement.annotation.AgreementExempt;
 import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.user.controller.docs.UserBasicApiDocs;
 import app.bottlenote.user.dto.request.NicknameChangeRequest;
@@ -59,6 +60,7 @@ public class UserBasicController {
     return GlobalResponse.ok(response);
   }
 
+  @AgreementExempt
   @UserBasicApiDocs.WithdrawUser
   @DeleteMapping
   public ResponseEntity<GlobalResponse> withdrawUser() {

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementControllerIntegrationTest.java
@@ -51,7 +51,7 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
     @Test
     @DisplayName("인증 사용자는 동일한 필드의 동의 상태를 조회한다")
     void getStatus_whenAuthenticated_returnsExactStatusShape() throws Exception {
-      User user = userTestFactory.persistUser();
+      User user = userTestFactory.persistUserWithoutAgreements();
       TokenItem token = getToken(user);
 
       MvcTestResult result =
@@ -93,7 +93,7 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
     @Test
     @DisplayName("인증 사용자의 원문과 요청 메타데이터를 저장하고 갱신된 상태를 반환한다")
     void submit_whenValidRequest_savesEvidenceAndReturnsStatus() throws Exception {
-      User user = userTestFactory.persistUser();
+      User user = userTestFactory.persistUserWithoutAgreements();
       TokenItem token = getToken(user);
       AgreementSubmitRequest request = validRequest();
 
@@ -174,7 +174,7 @@ class AgreementControllerIntegrationTest extends IntegrationTestSupport {
     @Test
     @DisplayName("만료 상태를 제출하면 저장하지 않고 400을 반환한다")
     void submit_whenActionIsExpired_returnsBadRequestWithoutSaving() throws Exception {
-      User user = userTestFactory.persistUser();
+      User user = userTestFactory.persistUserWithoutAgreements();
       TokenItem token = getToken(user);
       AgreementSubmitRequest request =
           new AgreementSubmitRequest(

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementGateIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementGateIntegrationTest.java
@@ -1,0 +1,114 @@
+package app.bottlenote.agreement.integration;
+
+import static app.bottlenote.agreement.constant.AgreementAction.AGREE;
+import static app.bottlenote.agreement.constant.AgreementInputContext.INDIVIDUAL;
+import static app.bottlenote.agreement.constant.AgreementType.PRIVACY_COLLECTION_USE;
+import static app.bottlenote.agreement.constant.AgreementType.TERMS_OF_SERVICE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import app.bottlenote.IntegrationTestSupport;
+import app.bottlenote.agreement.domain.UserAgreement;
+import app.bottlenote.agreement.domain.UserAgreementRepository;
+import app.bottlenote.agreement.exception.AgreementExceptionCode;
+import app.bottlenote.user.domain.User;
+import app.bottlenote.user.dto.response.TokenItem;
+import app.bottlenote.user.fixture.UserTestFactory;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+@Tag("integration")
+@DisplayName("[integration] AgreementGate 스모크")
+class AgreementGateIntegrationTest extends IntegrationTestSupport {
+
+  private static final String PROTECTED_ENDPOINT = "/api/v1/users/current";
+  private static final String STATUS_ENDPOINT = "/api/v2/agreements/status";
+  private static final String WITHDRAW_ENDPOINT = "/api/v1/users";
+
+  @Autowired private UserTestFactory userTestFactory;
+  @Autowired private UserAgreementRepository userAgreementRepository;
+
+  @Test
+  @DisplayName("동의 미충족 인증 사용자는 보호 API에서 AGREEMENT_REQUIRED를 받는다")
+  void protectedApi_whenAgreementMissing_returnsAgreementRequired() {
+    User user = userTestFactory.persistUser();
+    TokenItem token = getToken(user);
+
+    MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri(PROTECTED_ENDPOINT)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+            .exchange();
+
+    result.assertThat().hasStatus(HttpStatus.FORBIDDEN);
+    result
+        .assertThat()
+        .bodyJson()
+        .extractingPath("$.errors[0].code")
+        .isEqualTo(AgreementExceptionCode.AGREEMENT_REQUIRED.name());
+  }
+
+  @Test
+  @DisplayName("동의 미충족이어도 동의 상태 조회와 탈퇴는 면제되어 통과한다")
+  void exemptApis_whenAgreementMissing_areAccessible() {
+    User user = userTestFactory.persistUser();
+    TokenItem token = getToken(user);
+
+    mockMvcTester
+        .get()
+        .uri(STATUS_ENDPOINT)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+        .exchange()
+        .assertThat()
+        .hasStatusOk();
+
+    mockMvcTester
+        .delete()
+        .uri(WITHDRAW_ENDPOINT)
+        .contentType(APPLICATION_JSON)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+        .with(csrf())
+        .exchange()
+        .assertThat()
+        .hasStatusOk();
+  }
+
+  @Test
+  @DisplayName("필수 동의 충족 사용자는 보호 API를 호출할 수 있다")
+  void protectedApi_whenEligible_returnsOk() throws Exception {
+    User user = userTestFactory.persistUser();
+    TokenItem token = getToken(user);
+    LocalDateTime now = LocalDateTime.of(2026, 8, 8, 0, 0);
+    userAgreementRepository.save(
+        UserAgreement.create(
+            user.getId(), TERMS_OF_SERVICE, AGREE, "이용약관", now, INDIVIDUAL, "127.0.0.1", "test"));
+    userAgreementRepository.save(
+        UserAgreement.create(
+            user.getId(),
+            PRIVACY_COLLECTION_USE,
+            AGREE,
+            "개인정보",
+            now,
+            INDIVIDUAL,
+            "127.0.0.1",
+            "test"));
+
+    MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri(PROTECTED_ENDPOINT)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token.accessToken())
+            .exchange();
+
+    result.assertThat().hasStatusOk();
+    assertThat(result.getResponse().getContentAsString()).contains("email");
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementGateIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/AgreementGateIntegrationTest.java
@@ -1,21 +1,14 @@
 package app.bottlenote.agreement.integration;
 
-import static app.bottlenote.agreement.constant.AgreementAction.AGREE;
-import static app.bottlenote.agreement.constant.AgreementInputContext.INDIVIDUAL;
-import static app.bottlenote.agreement.constant.AgreementType.PRIVACY_COLLECTION_USE;
-import static app.bottlenote.agreement.constant.AgreementType.TERMS_OF_SERVICE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import app.bottlenote.IntegrationTestSupport;
-import app.bottlenote.agreement.domain.UserAgreement;
-import app.bottlenote.agreement.domain.UserAgreementRepository;
 import app.bottlenote.agreement.exception.AgreementExceptionCode;
 import app.bottlenote.user.domain.User;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.fixture.UserTestFactory;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -33,12 +26,11 @@ class AgreementGateIntegrationTest extends IntegrationTestSupport {
   private static final String WITHDRAW_ENDPOINT = "/api/v1/users";
 
   @Autowired private UserTestFactory userTestFactory;
-  @Autowired private UserAgreementRepository userAgreementRepository;
 
   @Test
   @DisplayName("동의 미충족 인증 사용자는 보호 API에서 AGREEMENT_REQUIRED를 받는다")
   void protectedApi_whenAgreementMissing_returnsAgreementRequired() {
-    User user = userTestFactory.persistUser();
+    User user = userTestFactory.persistUserWithoutAgreements();
     TokenItem token = getToken(user);
 
     MvcTestResult result =
@@ -59,7 +51,7 @@ class AgreementGateIntegrationTest extends IntegrationTestSupport {
   @Test
   @DisplayName("동의 미충족이어도 동의 상태 조회와 탈퇴는 면제되어 통과한다")
   void exemptApis_whenAgreementMissing_areAccessible() {
-    User user = userTestFactory.persistUser();
+    User user = userTestFactory.persistUserWithoutAgreements();
     TokenItem token = getToken(user);
 
     mockMvcTester
@@ -86,20 +78,6 @@ class AgreementGateIntegrationTest extends IntegrationTestSupport {
   void protectedApi_whenEligible_returnsOk() throws Exception {
     User user = userTestFactory.persistUser();
     TokenItem token = getToken(user);
-    LocalDateTime now = LocalDateTime.of(2026, 8, 8, 0, 0);
-    userAgreementRepository.save(
-        UserAgreement.create(
-            user.getId(), TERMS_OF_SERVICE, AGREE, "이용약관", now, INDIVIDUAL, "127.0.0.1", "test"));
-    userAgreementRepository.save(
-        UserAgreement.create(
-            user.getId(),
-            PRIVACY_COLLECTION_USE,
-            AGREE,
-            "개인정보",
-            now,
-            INDIVIDUAL,
-            "127.0.0.1",
-            "test"));
 
     MvcTestResult result =
         mockMvcTester
@@ -109,6 +87,6 @@ class AgreementGateIntegrationTest extends IntegrationTestSupport {
             .exchange();
 
     result.assertThat().hasStatusOk();
-    assertThat(result.getResponse().getContentAsString()).contains("email");
+    assertThat(result.getResponse().getContentAsString()).contains("nickname");
   }
 }

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/UserAgreementRepositoryIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/integration/UserAgreementRepositoryIntegrationTest.java
@@ -133,7 +133,7 @@ class UserAgreementRepositoryIntegrationTest extends IntegrationTestSupport {
   @Test
   @DisplayName("새 의사표시를 저장할 때 기존 동의 이력을 유지한다")
   void save_whenActionChanges_appendsAgreementHistory() {
-    User user = userTestFactory.persistUser();
+    User user = userTestFactory.persistUserWithoutAgreements();
     userAgreementRepository.save(
         createAgreement(
             user.getId(), AgreementType.TERMS_OF_SERVICE, AgreementAction.AGREE, RECORDED_AT));

--- a/bottlenote-product-api/src/test/java/app/bottlenote/agreement/interceptor/AgreementGateInterceptorTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/agreement/interceptor/AgreementGateInterceptorTest.java
@@ -1,0 +1,149 @@
+package app.bottlenote.agreement.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.bottlenote.agreement.annotation.AgreementExempt;
+import app.bottlenote.agreement.exception.AgreementException;
+import app.bottlenote.agreement.exception.AgreementExceptionCode;
+import app.bottlenote.agreement.fixture.FakeAgreementFacade;
+import app.bottlenote.global.security.CustomUserContext;
+import app.bottlenote.user.constant.UserType;
+import app.bottlenote.user.domain.User;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.method.HandlerMethod;
+
+@Tag("unit")
+@DisplayName("AgreementGateInterceptor 단위 테스트")
+class AgreementGateInterceptorTest {
+
+  private static final Long USER_ID = 10L;
+
+  private FakeAgreementFacade agreementFacade;
+  private AgreementGateInterceptor interceptor;
+  private MockHttpServletRequest request;
+  private MockHttpServletResponse response;
+
+  @BeforeEach
+  void setUp() {
+    agreementFacade = new FakeAgreementFacade();
+    interceptor = new AgreementGateInterceptor(agreementFacade);
+    request = new MockHttpServletRequest("GET", "/api/v1/users/current");
+    response = new MockHttpServletResponse();
+    SecurityContextHolder.clearContext();
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("비인증 요청은 동의 검사 없이 통과한다")
+  void preHandle_whenUnauthenticated_passesWithoutEvaluation() throws Exception {
+    HandlerMethod handler = handlerMethod(ProtectedHandler.class, "protectedAction");
+
+    boolean allowed = interceptor.preHandle(request, response, handler);
+
+    assertThat(allowed).isTrue();
+  }
+
+  @Test
+  @DisplayName("인증 사용자가 동의를 충족하면 통과한다")
+  void preHandle_whenAuthenticatedAndEligible_passes() throws Exception {
+    authenticate(USER_ID);
+    agreementFacade.setEligible(USER_ID, true);
+    HandlerMethod handler = handlerMethod(ProtectedHandler.class, "protectedAction");
+
+    boolean allowed = interceptor.preHandle(request, response, handler);
+
+    assertThat(allowed).isTrue();
+  }
+
+  @Test
+  @DisplayName("인증 사용자가 동의를 미충족하면 AGREEMENT_REQUIRED 예외를 던진다")
+  void preHandle_whenAuthenticatedAndNotEligible_throwsAgreementRequired() throws Exception {
+    authenticate(USER_ID);
+    agreementFacade.setEligible(USER_ID, false);
+    HandlerMethod handler = handlerMethod(ProtectedHandler.class, "protectedAction");
+
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, handler))
+        .isInstanceOf(AgreementException.class)
+        .extracting(ex -> ((AgreementException) ex).getExceptionCode())
+        .isEqualTo(AgreementExceptionCode.AGREEMENT_REQUIRED);
+  }
+
+  @Test
+  @DisplayName("메서드 단위 면제 대상은 동의 미충족이어도 통과한다")
+  void preHandle_whenMethodExempt_passesEvenIfNotEligible() throws Exception {
+    authenticate(USER_ID);
+    agreementFacade.setEligible(USER_ID, false);
+    HandlerMethod handler = handlerMethod(ProtectedHandler.class, "methodExemptAction");
+
+    assertThatCode(() -> interceptor.preHandle(request, response, handler))
+        .doesNotThrowAnyException();
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
+
+  @Test
+  @DisplayName("클래스 단위 면제 대상은 동의 미충족이어도 통과한다")
+  void preHandle_whenClassExempt_passesEvenIfNotEligible() throws Exception {
+    authenticate(USER_ID);
+    agreementFacade.setEligible(USER_ID, false);
+    HandlerMethod handler = handlerMethod(ExemptHandler.class, "anyAction");
+
+    assertThat(interceptor.preHandle(request, response, handler)).isTrue();
+  }
+
+  @Test
+  @DisplayName("HandlerMethod가 아니면 검사 없이 통과한다")
+  void preHandle_whenHandlerIsNotHandlerMethod_passes() throws Exception {
+    authenticate(USER_ID);
+    agreementFacade.setEligible(USER_ID, false);
+
+    assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+  }
+
+  private void authenticate(Long userId) {
+    User user =
+        User.builder()
+            .id(userId)
+            .email("gate@test.com")
+            .nickName("gate-user")
+            .role(UserType.ROLE_USER)
+            .build();
+    CustomUserContext principal =
+        new CustomUserContext(user, List.of(new SimpleGrantedAuthority(UserType.ROLE_USER.name())));
+    SecurityContextHolder.getContext()
+        .setAuthentication(
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+  }
+
+  private HandlerMethod handlerMethod(Class<?> controllerType, String methodName) throws Exception {
+    Object controller = controllerType.getDeclaredConstructor().newInstance();
+    return new HandlerMethod(controller, controllerType.getMethod(methodName));
+  }
+
+  static class ProtectedHandler {
+    public void protectedAction() {}
+
+    @AgreementExempt
+    public void methodExemptAction() {}
+  }
+
+  @AgreementExempt
+  static class ExemptHandler {
+    public void anyAction() {}
+  }
+}

--- a/bottlenote-product-api/src/test/java/app/bottlenote/user/integration/AgentLoginIntegrationTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/user/integration/AgentLoginIntegrationTest.java
@@ -19,6 +19,7 @@ import app.bottlenote.user.domain.AdminUserRepository;
 import app.bottlenote.user.domain.User;
 import app.bottlenote.user.dto.request.AgentLoginRequest;
 import app.bottlenote.user.dto.request.NicknameChangeRequest;
+import app.bottlenote.user.fixture.UserTestFactory;
 import app.bottlenote.user.repository.OauthRepository;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ class AgentLoginIntegrationTest extends IntegrationTestSupport {
   @Autowired private AgentRepository agentRepository;
   @Autowired private AdminUserRepository adminUserRepository;
   @Autowired private OauthRepository oauthRepository;
+  @Autowired private UserTestFactory userTestFactory;
   @Autowired private EntityManager entityManager;
 
   @Test
@@ -213,13 +215,16 @@ class AgentLoginIntegrationTest extends IntegrationTestSupport {
   }
 
   private User saveUser(String identity) {
-    return oauthRepository.save(
-        User.builder()
-            .email(identity + "@bottlenote.com")
-            .nickName(identity.replace("-", ""))
-            .role(UserType.ROLE_USER)
-            .socialType(new ArrayList<>(List.of(SocialType.NONE)))
-            .build());
+    User user =
+        oauthRepository.save(
+            User.builder()
+                .email(identity + "@bottlenote.com")
+                .nickName(identity.replace("-", ""))
+                .role(UserType.ROLE_USER)
+                .socialType(new ArrayList<>(List.of(SocialType.NONE)))
+                .build());
+    userTestFactory.seedRequiredAgreements(user.getId());
+    return user;
   }
 
   private AdminUser saveAdmin(String profileCode) {

--- a/bottlenote-test-support/src/main/java/app/bottlenote/agreement/fixture/FakeAgreementFacade.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/agreement/fixture/FakeAgreementFacade.java
@@ -1,0 +1,33 @@
+package app.bottlenote.agreement.fixture;
+
+import app.bottlenote.agreement.facade.AgreementFacade;
+import java.util.HashMap;
+import java.util.Map;
+
+/** 단위 테스트용 AgreementFacade Fake. 사용자별 자격 여부를 설정한다. */
+public class FakeAgreementFacade implements AgreementFacade {
+
+  private final Map<Long, Boolean> eligibilityByUserId = new HashMap<>();
+  private boolean defaultEligible = false;
+
+  public FakeAgreementFacade() {}
+
+  public FakeAgreementFacade(boolean defaultEligible) {
+    this.defaultEligible = defaultEligible;
+  }
+
+  public FakeAgreementFacade setEligible(Long userId, boolean eligible) {
+    eligibilityByUserId.put(userId, eligible);
+    return this;
+  }
+
+  public FakeAgreementFacade setDefaultEligible(boolean defaultEligible) {
+    this.defaultEligible = defaultEligible;
+    return this;
+  }
+
+  @Override
+  public boolean isEligible(Long userId) {
+    return eligibilityByUserId.getOrDefault(userId, defaultEligible);
+  }
+}

--- a/bottlenote-test-support/src/main/java/app/bottlenote/operation/utils/TestAuthenticationSupport.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/operation/utils/TestAuthenticationSupport.java
@@ -1,5 +1,10 @@
 package app.bottlenote.operation.utils;
 
+import app.bottlenote.agreement.constant.AgreementAction;
+import app.bottlenote.agreement.constant.AgreementInputContext;
+import app.bottlenote.agreement.constant.AgreementType;
+import app.bottlenote.agreement.domain.UserAgreement;
+import app.bottlenote.agreement.domain.UserAgreementRepository;
 import app.bottlenote.global.security.jwt.JwtTokenProvider;
 import app.bottlenote.user.constant.GenderType;
 import app.bottlenote.user.constant.SocialType;
@@ -7,6 +12,8 @@ import app.bottlenote.user.constant.UserType;
 import app.bottlenote.user.domain.User;
 import app.bottlenote.user.dto.response.TokenItem;
 import app.bottlenote.user.repository.OauthRepository;
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
@@ -16,11 +23,15 @@ public class TestAuthenticationSupport {
 
   private final OauthRepository oauthRepository;
   private final JwtTokenProvider jwtTokenProvider;
+  private final UserAgreementRepository userAgreementRepository;
 
   public TestAuthenticationSupport(
-      OauthRepository oauthRepository, JwtTokenProvider jwtTokenProvider) {
+      OauthRepository oauthRepository,
+      JwtTokenProvider jwtTokenProvider,
+      UserAgreementRepository userAgreementRepository) {
     this.oauthRepository = oauthRepository;
     this.jwtTokenProvider = jwtTokenProvider;
+    this.userAgreementRepository = userAgreementRepository;
   }
 
   public User getFirstUser() {
@@ -70,14 +81,35 @@ public class TestAuthenticationSupport {
   /** 랜덤 테스트 유저 생성 */
   private User createRandomUser() {
     UUID key = UUID.randomUUID();
-    return oauthRepository.save(
-        User.builder()
-            .email(key + "@example.com")
-            .age(20)
-            .gender(GenderType.MALE)
-            .nickName("testUser" + key)
-            .socialType(List.of(SocialType.KAKAO))
-            .role(UserType.ROLE_USER)
-            .build());
+    User user =
+        oauthRepository.save(
+            User.builder()
+                .email(key + "@example.com")
+                .age(20)
+                .gender(GenderType.MALE)
+                .nickName("testUser" + key)
+                .socialType(List.of(SocialType.KAKAO))
+                .role(UserType.ROLE_USER)
+                .build());
+    seedRequiredAgreements(user.getId());
+    return user;
+  }
+
+  private void seedRequiredAgreements(Long userId) {
+    LocalDateTime recordedAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+    Arrays.stream(AgreementType.values())
+        .filter(AgreementType::isRequired)
+        .forEach(
+            type ->
+                userAgreementRepository.save(
+                    UserAgreement.create(
+                        userId,
+                        type,
+                        AgreementAction.AGREE,
+                        type.getDescription(),
+                        recordedAt,
+                        AgreementInputContext.BULK,
+                        "127.0.0.1",
+                        "TestAuthenticationSupport")));
   }
 }

--- a/bottlenote-test-support/src/main/java/app/bottlenote/user/fixture/UserTestFactory.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/user/fixture/UserTestFactory.java
@@ -233,6 +233,7 @@ public class UserTestFactory {
   }
 
   /** AgreementGate를 통과할 수 있도록 필수 유형 AGREE 이력을 시드한다. */
+  @Transactional
   public void seedRequiredAgreements(@NotNull Long userId) {
     LocalDateTime recordedAt = LocalDateTime.of(2026, 1, 1, 0, 0);
     Arrays.stream(AgreementType.values())

--- a/bottlenote-test-support/src/main/java/app/bottlenote/user/fixture/UserTestFactory.java
+++ b/bottlenote-test-support/src/main/java/app/bottlenote/user/fixture/UserTestFactory.java
@@ -1,5 +1,9 @@
 package app.bottlenote.user.fixture;
 
+import app.bottlenote.agreement.constant.AgreementAction;
+import app.bottlenote.agreement.constant.AgreementInputContext;
+import app.bottlenote.agreement.constant.AgreementType;
+import app.bottlenote.agreement.domain.UserAgreement;
 import app.bottlenote.user.constant.FollowStatus;
 import app.bottlenote.user.constant.GenderType;
 import app.bottlenote.user.constant.SocialType;
@@ -7,6 +11,8 @@ import app.bottlenote.user.constant.UserType;
 import app.bottlenote.user.domain.Follow;
 import app.bottlenote.user.domain.User;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
@@ -25,22 +31,18 @@ public class UserTestFactory {
 
   // ========== User 생성 메서드들 ==========
 
-  /** 기본 User 생성 */
+  /** 기본 User 생성 (필수 약관 동의 시드 포함) */
   @Transactional
   @NotNull
   public User persistUser() {
-    User user =
-        User.builder()
-            .email("user" + generateRandomSuffix() + "@example.com")
-            .nickName("사용자-" + generateRandomSuffix())
-            .age(25)
-            .gender(GenderType.MALE)
-            .socialType(List.of(SocialType.KAKAO))
-            .role(UserType.ROLE_USER)
-            .build();
-    em.persist(user);
-    em.flush();
-    return user;
+    return persistUserWithAgreements(true);
+  }
+
+  /** 필수 약관 동의 이력 없이 User 생성 (AgreementGate 미충족 시나리오용) */
+  @Transactional
+  @NotNull
+  public User persistUserWithoutAgreements() {
+    return persistUserWithAgreements(false);
   }
 
   /** 이메일과 닉네임으로 User 생성 */
@@ -58,6 +60,7 @@ public class UserTestFactory {
             .build();
     em.persist(user);
     em.flush();
+    seedRequiredAgreements(user.getId());
     return user;
   }
 
@@ -76,6 +79,7 @@ public class UserTestFactory {
             .build();
     em.persist(user);
     em.flush();
+    seedRequiredAgreements(user.getId());
     return user;
   }
 
@@ -88,6 +92,7 @@ public class UserTestFactory {
     User user = filledBuilder.build();
     em.persist(user);
     em.flush();
+    seedRequiredAgreements(user.getId());
     return user;
   }
 
@@ -100,6 +105,7 @@ public class UserTestFactory {
     User user = filledBuilder.build();
     em.persist(user);
     em.flush(); // 즉시 ID 필요한 경우에만 사용
+    seedRequiredAgreements(user.getId());
     return user;
   }
 
@@ -203,7 +209,47 @@ public class UserTestFactory {
             .role(UserType.ROLE_USER)
             .build();
     em.persist(user);
+    em.flush();
+    seedRequiredAgreements(user.getId());
     return user;
+  }
+
+  private User persistUserWithAgreements(boolean seedAgreements) {
+    User user =
+        User.builder()
+            .email("user" + generateRandomSuffix() + "@example.com")
+            .nickName("사용자-" + generateRandomSuffix())
+            .age(25)
+            .gender(GenderType.MALE)
+            .socialType(List.of(SocialType.KAKAO))
+            .role(UserType.ROLE_USER)
+            .build();
+    em.persist(user);
+    em.flush();
+    if (seedAgreements) {
+      seedRequiredAgreements(user.getId());
+    }
+    return user;
+  }
+
+  /** AgreementGate를 통과할 수 있도록 필수 유형 AGREE 이력을 시드한다. */
+  public void seedRequiredAgreements(@NotNull Long userId) {
+    LocalDateTime recordedAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+    Arrays.stream(AgreementType.values())
+        .filter(AgreementType::isRequired)
+        .forEach(
+            type ->
+                em.persist(
+                    UserAgreement.create(
+                        userId,
+                        type,
+                        AgreementAction.AGREE,
+                        type.getDescription(),
+                        recordedAt,
+                        AgreementInputContext.BULK,
+                        "127.0.0.1",
+                        "UserTestFactory")));
+    em.flush();
   }
 
   /** User 빌더의 누락 필드 채우기 */

--- a/plan/agreement-gate-policy.md
+++ b/plan/agreement-gate-policy.md
@@ -1,0 +1,80 @@
+# Plan: AgreementGate 정책 (이슈 #365)
+
+## Overview
+
+product-api에서 인증된 사용자가 필수 약관에 동의하지 않은 채 보호 API를 호출하면 `AGREEMENT_REQUIRED`(403)로 차단한다. 동의 조회·제출, 탈퇴, 토큰 재발급은 면제하며, admin-api와 batch에는 적용하지 않는다.
+
+### Assumptions
+
+1. 자격 판정은 기존 `AgreementFacade.isEligible` / `AgreementEvaluator` 결과를 그대로 사용한다.
+2. `SecurityContextUtil.getUserIdByContext()`로 userId를 얻었을 때만 게이트를 평가한다. 비인증·익명(-4L)은 통과한다.
+3. 인증/권한은 기존 JWT·`@SecurityPolicy`가 담당하며, AgreementGate는 그 이후 웹 계층 인터셉터로 동작한다.
+4. 로그아웃 API와 정보주체 권리 API는 현재 코드베이스에 없다. 추가되면 `@AgreementExempt`를 붙인다.
+5. migration, JWT/OAuth, GlobalResponse 구조는 변경하지 않는다.
+6. 로컬 검증은 compile, focused unit, `check_rule_test`를 통과 기준으로 한다.
+
+### Success Criteria
+
+1. `AgreementExceptionCode.AGREEMENT_REQUIRED`가 HTTP 403과 함께 존재한다.
+2. `@AgreementExempt`를 메서드/클래스에 선언할 수 있다.
+3. `AgreementGateInterceptor`가 인증 userId에 대해 `isEligible == false`이면 `AgreementException`을 던진다.
+4. 면제·비인증·충족 사용자는 통과한다.
+5. product-api 전용 `WebMvcConfigurer`로 `/api/**`에만 등록된다.
+6. 면제 대상: `AgreementController` 전체, `DELETE /api/v1/users`, `POST /api/v2/auth/reissue`.
+7. 단위 테스트로 면제/미충족/충족/비인증을 검증한다.
+
+### Impact Scope
+
+- `bottlenote-mono`: 예외 코드, `@AgreementExempt`
+- `bottlenote-product-api`: 인터셉터, WebMvc 등록, 컨트롤러 면제 선언
+- `bottlenote-test-support`: `FakeAgreementFacade`
+- admin-api, batch, DB schema, JWT/OAuth 제외
+
+### Policy
+
+| 조건 | 결과 |
+|------|------|
+| HandlerMethod 아님 | 통과 |
+| `@AgreementExempt` (메서드 또는 클래스) | 통과 |
+| SecurityContext에 유효 userId 없음 | 통과 |
+| userId 있고 `isEligible=true` | 통과 |
+| userId 있고 `isEligible=false` | 403 `AGREEMENT_REQUIRED` |
+
+### Exempt Endpoints
+
+| 대상 | 방식 | 이유 |
+|------|------|------|
+| `AgreementController` (`/api/v2/agreements/**`) | 클래스 `@AgreementExempt` | 동의 상태 조회·제출 자체가 게이트 해소 경로 |
+| `DELETE /api/v1/users` | 메서드 `@AgreementExempt` | 미동의 사용자도 탈퇴 가능해야 함 |
+| `POST /api/v2/auth/reissue` | 메서드 `@AgreementExempt` | 세션 유지용 재발급 차단 방지 |
+| 로그아웃 | 없음 | API 미존재 |
+| 정보주체 권리 API | 없음 | API 미존재 |
+
+## Execution Mode
+
+- mode: step-by-step (orchestration worker 1회 구현)
+- scope: implement, test, verify(local unit+rule), commit
+- stop-conditions: 가정 붕괴, verify 3회 실패, production 배포, 금지 범위 변경
+
+## Tasks
+
+### Task 1: 예외 코드와 면제 어노테이션
+- Acceptance: `AGREEMENT_REQUIRED`(403), `@AgreementExempt` 추가
+- Status: [x] done
+
+### Task 2: 인터셉터와 product-api 등록
+- Acceptance: 인증 userId만 평가, 미충족 시 예외, `/api/**` 등록, admin/batch 미영향
+- Status: [x] done
+
+### Task 3: 면제 적용
+- Acceptance: AgreementController 전체, 탈퇴, 재발급 면제
+- Status: [x] done
+
+### Task 4: 테스트와 검증
+- Acceptance: Interceptor 단위 테스트, FakeAgreementFacade, compile + focused unit + check_rule_test
+- Status: [x] done
+
+## Progress Log
+
+- 2026-08-08: AgreementGate 구현 착수. product-api 전용 인터셉터 등록과 면제 정책을 문서화했다.
+- 2026-08-08: `AGREEMENT_REQUIRED`, `@AgreementExempt`, `AgreementGateInterceptor`, product-api WebMvc 등록, 면제 적용 완료. 단위 테스트 6개와 rule 테스트 통과.


### PR DESCRIPTION
## Changelog
- feat: AgreementGate 인터셉터와 면제 정책 추가
- test: AgreementGate 인터셉터 단위 및 통합 스모크 추가
- test: 통합 테스트 유저에 필수 동의 시드 추가
- test: 에이전트 로그인 통합 테스트 유저 동의 시드
- fix: 동의 시드 메서드에 트랜잭션 경계 추가

Related: bottle-note/workspace#365