### PR TITLE
chore: CI 테스트 잡을 독립 DAG로 분리

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -38,7 +38,7 @@ jobs:
             printf '%s\n' "| Event | \`$EVENT_NAME\` |"
             printf '%s\n' "| Ref | \`$HEAD_REF\` |"
             printf '%s\n' "| Commit | \`$COMMIT_SHA\` |"
-            echo '| Parallel jobs | Unit, Rule, Mono Integration, Admin Integration, Product Integration, Application Build |'
+            echo '| Parallel jobs | Unit, Rule, Mono Integration, Admin Integration (2 shards), Product Integration (3 shards), Application Build |'
           } >> "$GITHUB_STEP_SUMMARY"
 
   unit_tests:
@@ -165,10 +165,14 @@ jobs:
           fail_on_failure: true
 
   admin_integration_tests:
-    name: admin-integration-tests
+    name: admin-integration-tests (${{ matrix.shard }}/2)
     needs: prepare_ci
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - name: checkout code
         uses: actions/checkout@v7
@@ -189,7 +193,20 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: run admin integration tests
-        run: ./gradlew :bottlenote-admin-api:admin_integration_test
+        run: >-
+          ./gradlew
+          :bottlenote-admin-api:admin_integration_test
+          -PadminIntegrationShard=${{ matrix.shard }}
+          -PciCommitSha=${{ github.sha }}
+
+      - name: upload admin shard manifest
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: admin-integration-shard-${{ matrix.shard }}
+          path: bottlenote-admin-api/build/ci/admin-shard-${{ matrix.shard }}.json
+          if-no-files-found: error
+          retention-days: 1
 
       - name: verify admin integration test results
         run: test -n "$(find bottlenote-admin-api/build/test-results/admin_integration_test -name 'TEST-*.xml' -print -quit)"
@@ -206,10 +223,14 @@ jobs:
           fail_on_failure: true
 
   product_integration_tests:
-    name: product-integration-tests
+    name: product-integration-tests (${{ matrix.shard }}/3)
     needs: prepare_ci
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - name: checkout code
         uses: actions/checkout@v7
@@ -230,7 +251,20 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: run product integration tests
-        run: ./gradlew :bottlenote-product-api:integration_test
+        run: >-
+          ./gradlew
+          :bottlenote-product-api:integration_test
+          -PproductIntegrationShard=${{ matrix.shard }}
+          -PciCommitSha=${{ github.sha }}
+
+      - name: upload product shard manifest
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: product-integration-shard-${{ matrix.shard }}
+          path: bottlenote-product-api/build/ci/product-shard-${{ matrix.shard }}.json
+          if-no-files-found: error
+          retention-days: 1
 
       - name: verify product integration test results
         run: test -n "$(find bottlenote-product-api/build/test-results/integration_test -name 'TEST-*.xml' -print -quit)"
@@ -311,3 +345,38 @@ jobs:
             needs.application_build.result != 'success'
           }}
         run: exit 1
+
+      - name: download integration shard manifests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: '*-integration-shard-*'
+          path: build/ci/manifests
+          merge-multiple: true
+
+      - name: verify integration shard manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest_dir='build/ci/manifests'
+          mapfile -t manifests < <(find "$manifest_dir" -type f -name '*-shard-*.json' | sort)
+          test "${#manifests[@]}" -eq 5
+
+          jq -s -e '
+            [.[] | "\(.module):\(.shard)"] | sort
+              == ["admin:1", "admin:2", "product:1", "product:2", "product:3"]
+          ' "${manifests[@]}" >/dev/null
+
+          jq -s -e --arg sha '${{ github.sha }}' '
+            def valid_module($module; $count):
+              map(select(.module == $module)) as $items
+              | ($items | length == $count)
+                and ([$items[].sha] | unique == [$sha])
+                and ([$items[].discoveryDigest] | unique | length == 1)
+                and ([$items[].allClasses] | unique | length == 1)
+                and ([$items[].shardCount] | unique == [$count])
+                and ([$items[].planned[]] | sort == ($items[0].allClasses | sort))
+                and ([$items[].planned[]] | length
+                  == ([$items[].planned[]] | unique | length))
+                and all($items[]; .planned == .executed);
+            valid_module("product"; 3) and valid_module("admin"; 2)
+          ' "${manifests[@]}" >/dev/null

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -9,63 +9,50 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: "ci-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 env:
-  GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2"
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4"
 
 jobs:
-  prepare:
+  prepare_ci:
+    name: prepare-ci
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: publish execution plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          {
+            echo '## CI execution plan'
+            echo '| Item | Value |'
+            echo '| --- | --- |'
+            printf '%s\n' "| Event | \`$EVENT_NAME\` |"
+            printf '%s\n' "| Ref | \`$HEAD_REF\` |"
+            printf '%s\n' "| Commit | \`$COMMIT_SHA\` |"
+            echo '| Parallel jobs | Unit, Rule, Mono Integration, Admin Integration, Product Integration, Application Build |'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  unit_tests:
+    name: unit-tests
+    needs: prepare_ci
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: echo
-        run: |
-          echo "Branch: ${{ github.event.pull_request.base.ref || github.ref_name }}"
-
       - name: checkout code
         uses: actions/checkout@v7
         with:
           submodules: true
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
-      - name: setup jdk
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-      - name: setup gradle cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: install dependencies & compile
-        run: |
-          ./gradlew dependencies
-          ./gradlew compileJava compileTestJava
-
-      - name: cache workspace
-        uses: actions/cache@v6
-        with:
-          path: |
-            .gradle
-            build
-            */build
-          key: workspace-${{ github.sha }}
-  unit-tests:
-    needs: prepare
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v7
-        with:
-          submodules: true
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - name: setup jdk
         uses: actions/setup-java@v5
@@ -73,37 +60,31 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: setup gradle cache
-        uses: actions/cache@v6
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: restore workspace cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            .gradle
-            build
-            */build
-          key: workspace-${{ github.sha }}
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: run unit tests
         run: ./gradlew unit_test
 
-      - name: upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: unit-test-results-${{ github.run_number }}
-          path: |
-            */build/reports/tests/unit_test/
-            */build/test-results/unit_test/
+      - name: verify unit test results
+        run: test -n "$(find . -path '*/build/test-results/unit_test/TEST-*.xml' -print -quit)"
 
-  rule-tests:
-    needs: prepare
+      - name: publish unit test summary
+        if: ${{ !cancelled() && hashFiles('*/build/test-results/unit_test/TEST-*.xml') != '' }}
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: '*/build/test-results/unit_test/TEST-*.xml'
+          annotate_only: true
+          detailed_summary: false
+          include_passed: false
+          require_tests: true
+          fail_on_failure: true
+
+  rule_tests:
+    name: rule-tests
+    needs: prepare_ci
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -112,6 +93,7 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - name: setup jdk
         uses: actions/setup-java@v5
@@ -119,111 +101,40 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: setup gradle cache
-        uses: actions/cache@v6
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      - name: restore workspace cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            .gradle
-            build
-            */build
-          key: workspace-${{ github.sha }}
-
-      - name: run rules tests
+      - name: run architecture rule tests
         run: ./gradlew check_rule_test
 
-      - name: upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
+      - name: verify architecture rule test results
+        run: test -n "$(find . -path '*/build/test-results/check_rule_test/TEST-*.xml' -print -quit)"
+
+      - name: publish architecture rule test summary
+        if: ${{ !cancelled() && hashFiles('*/build/test-results/check_rule_test/TEST-*.xml') != '' }}
+        uses: mikepenz/action-junit-report@v6
         with:
-          name: rule-test-results-${{ github.run_number }}
-          path: |
-            */build/reports/tests/check_rule_test/
-            */build/test-results/check_rule_test/
+          report_paths: '*/build/test-results/check_rule_test/TEST-*.xml'
+          annotate_only: true
+          detailed_summary: false
+          include_passed: false
+          require_tests: true
+          fail_on_failure: true
 
-  integration-tests:
-    needs: prepare
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - name: product
-            task: integration_test
-          - name: admin
-            task: admin_integration_test
-    services:
-      docker:
-        image: docker:24.0
-        options: --privileged
-        ports:
-          - 1234:1234
-        env:
-          DOCKER_TLS_CERTDIR: ""
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v7
-        with:
-          submodules: true
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-
-      - name: setup jdk
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-
-      - name: setup gradle cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: restore workspace cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            .gradle
-            build
-            */build
-          key: workspace-${{ github.sha }}
-
-      - name: run ${{ matrix.name }} integration tests
-        run: ./gradlew ${{ matrix.task }}
-
-      - name: upload test results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.name }}-integration-test-results-${{ github.run_number }}
-          path: |
-            */build/reports/tests/${{ matrix.task }}/
-            */build/test-results/${{ matrix.task }}/
-
-  product-ci-final-build:
-    needs: [ unit-tests, rule-tests, integration-tests ]
+  mono_integration_tests:
+    name: mono-integration-tests
+    needs: prepare_ci
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-      pull-requests: write
     steps:
       - name: checkout code
         uses: actions/checkout@v7
         with:
           submodules: true
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - name: setup jdk
         uses: actions/setup-java@v5
@@ -231,34 +142,172 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: setup gradle cache
-        uses: actions/cache@v6
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      - name: restore workspace cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            .gradle
-            build
-            */build
-          key: workspace-${{ github.sha }}
+      - name: run mono integration tests
+        run: ./gradlew :bottlenote-mono:integration_test
 
-      - name: build project
-        run: ./gradlew build -x test --build-cache --parallel
+      - name: verify mono integration test results
+        run: test -n "$(find bottlenote-mono/build/test-results/integration_test -name 'TEST-*.xml' -print -quit)"
 
-      - name: download all test results
-        uses: actions/download-artifact@v8
-        with:
-          pattern: '*-test-results'
-          merge-multiple: true
-
-      - name: publish test report
+      - name: publish mono integration test summary
+        if: ${{ !cancelled() && hashFiles('bottlenote-mono/build/test-results/integration_test/TEST-*.xml') != '' }}
         uses: mikepenz/action-junit-report@v6
-        if: always()
         with:
-          report_paths: '**/build/test-results/**/TEST-*.xml'
+          report_paths: 'bottlenote-mono/build/test-results/integration_test/TEST-*.xml'
+          annotate_only: true
+          detailed_summary: false
+          include_passed: false
+          require_tests: true
+          fail_on_failure: true
+
+  admin_integration_tests:
+    name: admin-integration-tests
+    needs: prepare_ci
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          persist-credentials: false
+
+      - name: setup jdk
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: run admin integration tests
+        run: ./gradlew :bottlenote-admin-api:admin_integration_test
+
+      - name: verify admin integration test results
+        run: test -n "$(find bottlenote-admin-api/build/test-results/admin_integration_test -name 'TEST-*.xml' -print -quit)"
+
+      - name: publish admin integration test summary
+        if: ${{ !cancelled() && hashFiles('bottlenote-admin-api/build/test-results/admin_integration_test/TEST-*.xml') != '' }}
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: 'bottlenote-admin-api/build/test-results/admin_integration_test/TEST-*.xml'
+          annotate_only: true
+          detailed_summary: false
+          include_passed: false
+          require_tests: true
+          fail_on_failure: true
+
+  product_integration_tests:
+    name: product-integration-tests
+    needs: prepare_ci
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          persist-credentials: false
+
+      - name: setup jdk
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: run product integration tests
+        run: ./gradlew :bottlenote-product-api:integration_test
+
+      - name: verify product integration test results
+        run: test -n "$(find bottlenote-product-api/build/test-results/integration_test -name 'TEST-*.xml' -print -quit)"
+
+      - name: publish product integration test summary
+        if: ${{ !cancelled() && hashFiles('bottlenote-product-api/build/test-results/integration_test/TEST-*.xml') != '' }}
+        uses: mikepenz/action-junit-report@v6
+        with:
+          report_paths: 'bottlenote-product-api/build/test-results/integration_test/TEST-*.xml'
+          annotate_only: true
+          detailed_summary: false
+          include_passed: false
+          require_tests: true
+          fail_on_failure: true
+
+  application_build:
+    name: application-build
+    needs: prepare_ci
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          persist-credentials: false
+
+      - name: setup jdk
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: build applications
+        run: ./gradlew assemble --build-cache --parallel
+
+  final_gate:
+    name: product-ci-final-build
+    if: ${{ always() }}
+    timeout-minutes: 5
+    needs:
+      - unit_tests
+      - rule_tests
+      - mono_integration_tests
+      - admin_integration_tests
+      - product_integration_tests
+      - application_build
+    runs-on: ubuntu-latest
+    steps:
+      - name: publish ci result
+        run: |
+          {
+            echo '## CI result'
+            echo '| Job | Result |'
+            echo '| --- | --- |'
+            echo '| Unit tests | ${{ needs.unit_tests.result }} |'
+            echo '| Architecture rule tests | ${{ needs.rule_tests.result }} |'
+            echo '| Mono integration tests | ${{ needs.mono_integration_tests.result }} |'
+            echo '| Admin integration tests | ${{ needs.admin_integration_tests.result }} |'
+            echo '| Product integration tests | ${{ needs.product_integration_tests.result }} |'
+            echo '| Application build | ${{ needs.application_build.result }} |'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: enforce ci result
+        if: >-
+          ${{
+            needs.unit_tests.result != 'success' ||
+            needs.rule_tests.result != 'success' ||
+            needs.mono_integration_tests.result != 'success' ||
+            needs.admin_integration_tests.result != 'success' ||
+            needs.product_integration_tests.result != 'success' ||
+            needs.application_build.result != 'success'
+          }}
+        run: exit 1

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ subprojects {
 	tasks.withType(JavaCompile).configureEach {
 		options.compilerArgs << '-parameters'
 	}
+	tasks.withType(Test).configureEach {
+		outputs.upToDateWhen { false }
+		outputs.cacheIf { false }
+	}
 	plugins.withId('com.diffplug.spotless') {
 		tasks.named('compileJava').configure {
 			dependsOn 'spotlessApply'
@@ -186,6 +190,8 @@ tasks.register('check_rule_test') {
 	group = 'verification'
 	dependsOn subprojects.findAll { it.tasks.findByName('check_rule_test') }.collect { it.tasks.check_rule_test }
 }
+
+apply from: 'gradle/integration-sharding.gradle'
 
 tasks.register('batch_test') {
 	description = '배치 모듈 테스트 실행 (@Tag("batch"))'

--- a/gradle/integration-sharding.gradle
+++ b/gradle/integration-sharding.gradle
@@ -1,0 +1,183 @@
+import java.net.URLClassLoader
+import java.security.MessageDigest
+import org.gradle.api.tasks.testing.Test
+
+def shardSpecs = [
+    product: [
+        project: project(':bottlenote-product-api'),
+        task: 'integration_test',
+        property: 'productIntegrationShard',
+        tag: 'integration',
+        count: 3
+    ],
+    admin: [
+        project: project(':bottlenote-admin-api'),
+        task: 'admin_integration_test',
+        property: 'adminIntegrationShard',
+        tag: 'admin_integration',
+        count: 2
+    ]
+]
+
+def normalizeClassName = { String className ->
+    int nestedClassSeparator = className.indexOf('$')
+    nestedClassSeparator >= 0 ? className.substring(0, nestedClassSeparator) : className
+}
+
+def sha256 = { String value ->
+    MessageDigest.getInstance('SHA-256')
+        .digest(value.getBytes('UTF-8'))
+        .encodeHex()
+        .toString()
+}
+
+def commitSha = {
+    String configuredSha = rootProject.providers.gradleProperty('ciCommitSha').orNull
+    if (configuredSha != null) {
+        return configuredSha
+    }
+    return rootProject.providers.exec {
+        commandLine 'git', 'rev-parse', 'HEAD'
+    }.standardOutput.asText.get().trim()
+}
+
+def discoverTestClasses = { Test task, String tag ->
+    Set<File> classpathFiles = new LinkedHashSet<>()
+    classpathFiles.addAll(task.testClassesDirs.files)
+    classpathFiles.addAll(task.classpath.files)
+    URL[] urls = classpathFiles.collect { it.toURI().toURL() } as URL[]
+    ClassLoader previousClassLoader = Thread.currentThread().contextClassLoader
+
+    try (URLClassLoader loader = new URLClassLoader(urls, ClassLoader.getPlatformClassLoader())) {
+        Thread.currentThread().contextClassLoader = loader
+        Class<?> selectorsClass = loader.loadClass('org.junit.platform.engine.discovery.DiscoverySelectors')
+        Class<?> tagFilterClass = loader.loadClass('org.junit.platform.launcher.TagFilter')
+        Class<?> requestBuilderClass =
+            loader.loadClass('org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder')
+        Class<?> launcherFactoryClass =
+            loader.loadClass('org.junit.platform.launcher.core.LauncherFactory')
+
+        Set<Object> roots = task.testClassesDirs.files.collect { it.toPath() } as Set<Object>
+        Object selector = selectorsClass.selectClasspathRoots(roots)
+        Object tagFilter = tagFilterClass.includeTags(tag)
+        Object request = requestBuilderClass.request()
+            .selectors(selector)
+            .filters(tagFilter)
+            .build()
+        Object testPlan = launcherFactoryClass.create().discover(request)
+        Set<String> classes = new TreeSet<>()
+
+        testPlan.roots.each { root ->
+            testPlan.getDescendants(root).each { identifier ->
+                Object source = identifier.source.orElse(null)
+                def classNameMethod = source?.class?.methods?.find { it.name == 'getClassName' }
+                if (classNameMethod != null) {
+                    classes.add(normalizeClassName(classNameMethod.invoke(source) as String))
+                }
+            }
+        }
+        return classes as List<String>
+    } finally {
+        Thread.currentThread().contextClassLoader = previousClassLoader
+    }
+}
+
+def partitionClasses = { List<String> classes, int count ->
+    Map<String, List<String>> shards = (1..count).collectEntries { [(it.toString()): []] }
+    classes.sort().eachWithIndex { String className, int index ->
+        shards[((index % count) + 1).toString()].add(className)
+    }
+    return shards
+}
+
+shardSpecs.each { String name, Map<String, Object> spec ->
+    Project targetProject = spec.project as Project
+    targetProject.tasks.named(spec.task as String, Test).configure { Test task ->
+        String shard = rootProject.providers.gradleProperty(spec.property as String).orNull
+        if (shard == null) {
+            return
+        }
+
+        Set<String> executedClasses = Collections.synchronizedSet(new TreeSet<>())
+        Map<String, Object> executionPlan = [:]
+
+        task.doFirst {
+            List<String> classes = discoverTestClasses(task, spec.tag as String)
+            if (classes.isEmpty()) {
+                throw new GradleException("No ${spec.tag} test classes discovered for ${name}")
+            }
+
+            Map<String, List<String>> shards = partitionClasses(classes, spec.count as int)
+            List<String> assignedClasses = shards[shard]
+            if (assignedClasses == null || assignedClasses.isEmpty()) {
+                throw new GradleException("Invalid ${spec.property}: ${shard}")
+            }
+
+            task.filter {
+                assignedClasses.each { String className ->
+                    includeTestsMatching(className)
+                    includeTestsMatching("${className}\$*")
+                }
+                failOnNoMatchingTests = true
+            }
+            executionPlan.putAll([
+                sha: commitSha(),
+                discoveryDigest: sha256("${spec.tag}\n${spec.count}\n${classes.join('\n')}"),
+                allClasses: classes,
+                assignedClasses: assignedClasses
+            ])
+        }
+
+        task.afterTest { descriptor, result ->
+            if (descriptor.className != null) {
+                executedClasses.add(normalizeClassName(descriptor.className))
+            }
+        }
+        task.doLast {
+            List<String> assignedClasses = executionPlan.assignedClasses as List<String>
+            Set<String> plannedClassSet = assignedClasses.toSet()
+            if (executedClasses != plannedClassSet) {
+                throw new GradleException(
+                    "${name} shard ${shard} execution mismatch: " +
+                        "missing=${plannedClassSet - executedClasses}, unexpected=${executedClasses - plannedClassSet}")
+            }
+
+            File manifestFile = targetProject.layout.buildDirectory
+                .file("ci/${name}-shard-${shard}.json").get().asFile
+            manifestFile.parentFile.mkdirs()
+            manifestFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson([
+                version: 1,
+                sha: executionPlan.sha,
+                discoveryDigest: executionPlan.discoveryDigest,
+                module: name,
+                shard: shard as int,
+                shardCount: spec.count,
+                allClasses: executionPlan.allClasses,
+                planned: assignedClasses,
+                executed: executedClasses as List
+            ]))
+        }
+    }
+}
+
+tasks.register('verifyIntegrationTestShardDiscovery') {
+    description = 'JUnit Platform discovery와 자동 shard partition 검증'
+    group = 'verification'
+    dependsOn shardSpecs.collect { name, spec ->
+        (spec.project as Project).tasks.named('testClasses')
+    }
+
+    doLast {
+        shardSpecs.each { String name, Map<String, Object> spec ->
+            Test task = (spec.project as Project).tasks.named(spec.task as String, Test).get()
+            List<String> classes = discoverTestClasses(task, spec.tag as String)
+            Map<String, List<String>> shards = partitionClasses(classes, spec.count as int)
+            if (classes.isEmpty() || shards.values().any { it.isEmpty() } ||
+                shards.values().flatten().toSet() != classes.toSet()) {
+                throw new GradleException("Invalid ${name} integration shard discovery")
+            }
+            logger.lifecycle("{} integration shard discovery: classes={}, shards={}",
+                name, classes.size(), shards.collectEntries { key, value -> [key, value.size()] })
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항
- prepare-ci를 실행 정보만 기록하는 경량 시작 job으로 구성
- Unit, Rule, Mono Integration, Admin Integration, Product Integration, Application Build를 독립 job으로 병렬 실행
- 테스트 결과가 0개면 실패하도록 fail-closed 검증 추가
- product-ci-final-build에서 전체 job 결과를 요약하고 최종 성공 여부 판정

## 설계 원칙
- 단일 workflow 유지
- Test task에 build cache를 적용하지 않아 테스트 순수성 유지
- checkout credential을 저장하지 않고 summary에 secret 또는 원본 XML을 노출하지 않음
- 기존 required check 이름 product-ci-final-build 유지

## 검증
- actionlint 통과
- git diff --check 통과
- 로컬 Gradle 검증은 설치된 Java 25와 프로젝트 Java 21 요구사항 불일치로 실행 불가하며 GitHub Actions에서 확인