### PR TITLE
feat: Admin/Product 페이지네이션 계약 분리

### DIFF
--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
@@ -6,7 +6,7 @@ import app.bottlenote.alcohols.dto.request.AdminAlcoholUpsertRequest
 import app.bottlenote.alcohols.presentation.docs.AdminAlcoholsApiDocs
 import app.bottlenote.alcohols.service.AdminAlcoholCommandService
 import app.bottlenote.alcohols.service.AdminAlcoholLookupService
-import app.bottlenote.alcohols.service.AlcoholQueryService
+import app.bottlenote.alcohols.service.AdminAlcoholQueryService
 import app.bottlenote.global.data.response.GlobalResponse
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/alcohols")
 @AdminAlcoholsApiDocs.ApiTag
 class AdminAlcoholsController(
-	private val alcoholQueryService: AlcoholQueryService,
+	private val adminAlcoholQueryService: AdminAlcoholQueryService,
 	private val adminAlcoholCommandService: AdminAlcoholCommandService,
 	private val adminAlcoholLookupService: AdminAlcoholLookupService
 ) {
@@ -30,17 +30,17 @@ class AdminAlcoholsController(
 	@GetMapping
 	fun searchAlcohols(
 		@ModelAttribute request: AdminAlcoholSearchRequest
-	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(alcoholQueryService.searchAdminAlcohols(request))
+	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(adminAlcoholQueryService.searchAdminAlcohols(request))
 
 	@AdminAlcoholsApiDocs.GetAlcoholDetail
 	@GetMapping("/{alcoholId}")
 	fun getAlcoholDetail(
 		@PathVariable alcoholId: Long
-	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(alcoholQueryService.findAdminAlcoholDetailById(alcoholId))
+	): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminAlcoholQueryService.findAdminAlcoholDetailById(alcoholId))
 
 	@AdminAlcoholsApiDocs.GetCategoryReference
 	@GetMapping("/categories/reference")
-	fun getCategoryReference(): ResponseEntity<GlobalResponse> = GlobalResponse.ok(alcoholQueryService.findAllCategoryReferenceMap())
+	fun getCategoryReference(): ResponseEntity<GlobalResponse> = GlobalResponse.ok(adminAlcoholQueryService.findAllCategoryReferenceMap())
 
 	@AdminAlcoholsApiDocs.CreateAlcohol
 	@PostMapping

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/AdminAlcoholsController.kt
@@ -1,14 +1,13 @@
 package app.bottlenote.alcohols.presentation
 
+import app.bottlenote.alcohols.dto.request.AdminAlcoholLookupRequest
 import app.bottlenote.alcohols.dto.request.AdminAlcoholSearchRequest
 import app.bottlenote.alcohols.dto.request.AdminAlcoholUpsertRequest
-import app.bottlenote.alcohols.dto.request.AlcoholLookupRequest
 import app.bottlenote.alcohols.presentation.docs.AdminAlcoholsApiDocs
 import app.bottlenote.alcohols.service.AdminAlcoholCommandService
-import app.bottlenote.alcohols.service.AlcoholLookupService
+import app.bottlenote.alcohols.service.AdminAlcoholLookupService
 import app.bottlenote.alcohols.service.AlcoholQueryService
 import app.bottlenote.global.data.response.GlobalResponse
-import app.bottlenote.global.service.meta.MetaService.createMetaInfo
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -19,21 +18,13 @@ import org.springframework.web.bind.annotation.*
 class AdminAlcoholsController(
 	private val alcoholQueryService: AlcoholQueryService,
 	private val adminAlcoholCommandService: AdminAlcoholCommandService,
-	private val alcoholLookupService: AlcoholLookupService
+	private val adminAlcoholLookupService: AdminAlcoholLookupService
 ) {
 	@AdminAlcoholsApiDocs.GetAlcoholLookups
 	@GetMapping("/lookup")
 	fun getAlcoholLookups(
-		@ModelAttribute @Valid request: AlcoholLookupRequest
-	): ResponseEntity<GlobalResponse> {
-		val page = alcoholLookupService.lookup(request)
-		return GlobalResponse.ok(
-			page.content(),
-			createMetaInfo()
-				.add("searchParameters", request)
-				.add("pagination", page.pagination())
-		)
-	}
+		@ModelAttribute @Valid request: AdminAlcoholLookupRequest
+	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(adminAlcoholLookupService.lookup(request))
 
 	@AdminAlcoholsApiDocs.SearchAlcohols
 	@GetMapping

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminAlcoholsApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/alcohols/presentation/docs/AdminAlcoholsApiDocs.kt
@@ -25,10 +25,11 @@ object AdminAlcoholsApiDocs {
 	@Operation(
 		summary = "위스키 룩업 목록을 조회한다",
 		description = """
-			검색어, 카테고리, 지역, 증류소, 커서로 위스키 룩업 목록을 커서 방식으로 조회합니다.
+			검색어, 카테고리, 지역, 증류소, 페이지 번호, 페이지 크기로 위스키 룩업 목록을 조회합니다.
 
 			다른 화면에서 위스키를 빠르게 선택할 때 쓰는 경량 목록이며, Redis 스냅샷을 우선 사용하고 비어 있으면 DB로 폴백합니다.
-			다음 페이지 정보는 meta.pagination에, 요청 파라미터는 meta.searchParameters에 담깁니다.
+			page를 지정하지 않으면 0부터, size를 지정하지 않으면 20건씩 조회합니다.
+			페이지 정보는 meta.page, meta.size, meta.totalElements, meta.totalPages에 담깁니다.
 			""",
 		responses = [
 			ApiResponse(

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/AdminHelpController.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/AdminHelpController.kt
@@ -2,7 +2,6 @@ package app.bottlenote.support.help.presentation
 
 import app.bottlenote.global.data.response.GlobalResponse
 import app.bottlenote.global.security.SecurityContextUtil
-import app.bottlenote.global.service.meta.MetaService
 import app.bottlenote.support.help.dto.request.AdminHelpAnswerRequest
 import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest
 import app.bottlenote.support.help.presentation.docs.AdminHelpApiDocs
@@ -23,13 +22,7 @@ class AdminHelpController(
 	@GetMapping
 	fun getHelpList(
 		@ModelAttribute request: AdminHelpPageableRequest
-	): ResponseEntity<GlobalResponse> {
-		val page = adminHelpService.getHelpList(request)
-		return GlobalResponse.ok(
-			page.content(),
-			MetaService.createMetaInfo().add("pagination", page.pagination())
-		)
-	}
+	): ResponseEntity<GlobalResponse> = ResponseEntity.ok(adminHelpService.getHelpList(request))
 
 	@AdminHelpApiDocs.GetHelpDetail
 	@GetMapping("/{helpId}")

--- a/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/docs/AdminHelpApiDocs.kt
+++ b/bottlenote-admin-api/src/main/kotlin/app/bottlenote/support/help/presentation/docs/AdminHelpApiDocs.kt
@@ -4,6 +4,7 @@ import app.bottlenote.support.help.dto.response.AdminHelpAnswerResponse
 import app.bottlenote.support.help.dto.response.AdminHelpDetailResponse
 import app.bottlenote.support.help.dto.response.AdminHelpListResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -22,16 +23,22 @@ object AdminHelpApiDocs {
 	@Operation(
 		summary = "문의 목록을 조회한다",
 		description = """
-			처리 상태, 문의 유형, 커서, 페이지 크기로 문의 목록을 커서 방식으로 조회합니다.
+			처리 상태, 문의 유형, 페이지 번호, 페이지 크기로 문의 목록을 조회합니다.
 
-			cursor를 지정하지 않으면 처음부터, size를 지정하지 않으면 20건씩 조회합니다.
-			다음 페이지 정보는 meta.pagination에 담깁니다.
+			page를 지정하지 않으면 0부터, size를 지정하지 않으면 20건씩 조회합니다.
+			페이지 정보는 meta.page, meta.size, meta.totalElements, meta.totalPages에 담깁니다.
 			""",
 		responses = [
 			ApiResponse(
 				responseCode = "200",
 				description = "문의 목록",
-				content = [Content(schema = Schema(implementation = AdminHelpListResponse::class))]
+				content = [
+					Content(
+						array = ArraySchema(
+							schema = Schema(implementation = AdminHelpListResponse.AdminHelpInfo::class)
+						)
+					)
+				]
 			)
 		]
 	)

--- a/bottlenote-admin-api/src/main/resources/application.yml
+++ b/bottlenote-admin-api/src/main/resources/application.yml
@@ -38,12 +38,6 @@ spring:
     time-zone: Asia/Seoul
 
 bottlenote:
-  pagination:
-    cursor:
-      current-key-id: v1
-      current-secret: ${PAGINATION_CURSOR_SECRET:pagination-cursor-secret}
-      previous-key-id: ${PAGINATION_CURSOR_PREVIOUS_KEY_ID:}
-      previous-secret: ${PAGINATION_CURSOR_PREVIOUS_SECRET:}
   access-control:
     # 전역 spring.data.redis.timeout(15s)과 분리 — Redis 장애 시 요청 스레드 점유 상한
     redis-command-timeout: 200ms

--- a/bottlenote-admin-api/src/test/kotlin/app/integration/help/AdminHelpIntegrationTest.kt
+++ b/bottlenote-admin-api/src/test/kotlin/app/integration/help/AdminHelpIntegrationTest.kt
@@ -55,11 +55,49 @@ class AdminHelpIntegrationTest : IntegrationTestSupport() {
 				mockMvcTester
 					.get()
 					.uri("/v1/helps")
+					.param("page", "0")
+					.param("size", "2")
 					.header("Authorization", "Bearer $accessToken")
 			).hasStatusOk()
 				.bodyJson()
 				.extractingPath("$.success")
 				.isEqualTo(true)
+
+			assertThat(
+				mockMvcTester
+					.get()
+					.uri("/v1/helps")
+					.param("page", "0")
+					.param("size", "2")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.meta.page")
+				.isEqualTo(0)
+
+			assertThat(
+				mockMvcTester
+					.get()
+					.uri("/v1/helps")
+					.param("page", "0")
+					.param("size", "2")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.meta.size")
+				.isEqualTo(2)
+
+			assertThat(
+				mockMvcTester
+					.get()
+					.uri("/v1/helps")
+					.param("page", "0")
+					.param("size", "2")
+					.header("Authorization", "Bearer $accessToken")
+			).hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.data.length()")
+				.isEqualTo(2)
 		}
 
 		@Test

--- a/bottlenote-admin-api/src/test/resources/application-test.yml
+++ b/bottlenote-admin-api/src/test/resources/application-test.yml
@@ -1,8 +1,4 @@
 bottlenote:
-  pagination:
-    cursor:
-      current-key-id: v1
-      current-secret: test-pagination-cursor-secret
   access-control:
     enabled: false
 

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminAlcoholLookupRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/dto/request/AdminAlcoholLookupRequest.java
@@ -1,0 +1,32 @@
+package app.bottlenote.alcohols.dto.request;
+
+import app.bottlenote.alcohols.constant.AlcoholCategoryGroup;
+import lombok.Builder;
+
+/**
+ * @param page 페이지 번호 (0부터)
+ * @param size 페이지 크기
+ */
+public record AdminAlcoholLookupRequest(
+    String keyword, String category, Long regionId, Long distilleryId, Integer page, Integer size) {
+
+  public static final int DEFAULT_SIZE = 20;
+  public static final int MAX_SIZE = 100;
+
+  @Builder
+  public AdminAlcoholLookupRequest {
+    page = page != null && page >= 0 ? page : 0;
+    if (size == null || size < 1) {
+      size = DEFAULT_SIZE;
+    } else {
+      size = Math.min(size, MAX_SIZE);
+    }
+  }
+
+  public AlcoholCategoryGroup categoryGroup() {
+    if (category == null || category.isBlank() || "ALL".equalsIgnoreCase(category)) {
+      return null;
+    }
+    return AlcoholCategoryGroup.fromCategory(category);
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/scheduled/AlcoholLookupSyncScheduler.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/scheduled/AlcoholLookupSyncScheduler.java
@@ -1,7 +1,7 @@
 package app.bottlenote.alcohols.scheduled;
 
-import app.bottlenote.alcohols.service.AlcoholLookupService;
 import app.bottlenote.alcohols.service.AlcoholLookupService.AlcoholLookupSyncResult;
+import app.bottlenote.alcohols.service.AlcoholLookupSnapshotService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -16,11 +16,11 @@ import org.springframework.stereotype.Component;
     name = "enable",
     havingValue = "true")
 public class AlcoholLookupSyncScheduler {
-  private final AlcoholLookupService alcoholLookupService;
+  private final AlcoholLookupSnapshotService alcoholLookupSnapshotService;
 
   @Scheduled(cron = "${schedules.alcohol.lookup.sync.cron:0 */5 * * * *}")
   public void syncLookupSnapshot() {
-    AlcoholLookupSyncResult result = alcoholLookupService.syncSnapshot();
+    AlcoholLookupSyncResult result = alcoholLookupSnapshotService.syncSnapshot();
     if (result.changed()) {
       log.info("Alcohol lookup snapshot 동기화 완료: {}건", result.count());
     }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholLookupService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholLookupService.java
@@ -1,0 +1,31 @@
+package app.bottlenote.alcohols.service;
+
+import app.bottlenote.alcohols.dto.request.AdminAlcoholLookupRequest;
+import app.bottlenote.alcohols.dto.response.AlcoholLookupItem;
+import app.bottlenote.global.data.response.GlobalResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAlcoholLookupService {
+  private final AlcoholLookupSnapshotService snapshotService;
+
+  @Transactional(readOnly = true)
+  public GlobalResponse lookup(AdminAlcoholLookupRequest request) {
+    List<AlcoholLookupItem> filtered =
+        snapshotService.findFilteredItems(
+            request.keyword(), request.categoryGroup(), request.regionId(), request.distilleryId());
+    int from = Math.min(request.page() * request.size(), filtered.size());
+    int to = Math.min(from + request.size(), filtered.size());
+    return GlobalResponse.fromPage(
+        new PageImpl<>(
+            filtered.subList(from, to),
+            PageRequest.of(request.page(), request.size()),
+            filtered.size()));
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholQueryService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AdminAlcoholQueryService.java
@@ -1,0 +1,106 @@
+package app.bottlenote.alcohols.service;
+
+import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.ALCOHOL_NOT_FOUND;
+
+import app.bottlenote.alcohols.constant.AlcoholCategoryGroup;
+import app.bottlenote.alcohols.domain.Alcohol;
+import app.bottlenote.alcohols.domain.AlcoholQueryRepository;
+import app.bottlenote.alcohols.dto.request.AdminAlcoholSearchRequest;
+import app.bottlenote.alcohols.dto.response.AdminAlcoholDetailResponse;
+import app.bottlenote.alcohols.dto.response.AdminAlcoholDetailResponse.TastingTagInfo;
+import app.bottlenote.alcohols.dto.response.CategoryItem;
+import app.bottlenote.alcohols.dto.response.CategoryPairItem;
+import app.bottlenote.alcohols.exception.AlcoholException;
+import app.bottlenote.alcohols.repository.CustomAlcoholQueryRepository.AdminAlcoholDetailProjection;
+import app.bottlenote.global.data.response.GlobalResponse;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAlcoholQueryService {
+  private final AlcoholQueryRepository alcoholQueryRepository;
+
+  @Transactional(readOnly = true)
+  public GlobalResponse searchAdminAlcohols(AdminAlcoholSearchRequest request) {
+    return GlobalResponse.fromPage(alcoholQueryRepository.searchAdminAlcohols(request));
+  }
+
+  @Transactional(readOnly = true)
+  public Map<AlcoholCategoryGroup, List<CategoryPairItem>> findAllCategoryReferenceMap() {
+    Map<AlcoholCategoryGroup, List<CategoryPairItem>> grouped =
+        new EnumMap<>(AlcoholCategoryGroup.class);
+    for (AlcoholCategoryGroup group : AlcoholCategoryGroup.values()) {
+      grouped.put(group, new ArrayList<>());
+    }
+
+    for (CategoryItem item : alcoholQueryRepository.findAllCategoryItems()) {
+      AlcoholCategoryGroup group = item.categoryGroup();
+      if (group == null) continue;
+      grouped.get(group).add(new CategoryPairItem(item.korCategory(), item.engCategory()));
+    }
+
+    return grouped;
+  }
+
+  @Transactional(readOnly = true)
+  public AdminAlcoholDetailResponse findAdminAlcoholDetailById(Long alcoholId) {
+    AdminAlcoholDetailProjection projection =
+        alcoholQueryRepository
+            .findAdminAlcoholDetailById(alcoholId)
+            .orElseThrow(() -> new AlcoholException(ALCOHOL_NOT_FOUND));
+
+    Alcohol alcohol =
+        alcoholQueryRepository
+            .findById(alcoholId)
+            .orElseThrow(() -> new AlcoholException(ALCOHOL_NOT_FOUND));
+
+    List<TastingTagInfo> tastingTags =
+        alcohol.getAlcoholsTastingTags().stream()
+            .map(
+                att ->
+                    new TastingTagInfo(
+                        att.getTastingTag().getId(),
+                        att.getTastingTag().getKorName(),
+                        att.getTastingTag().getEngName()))
+            .collect(
+                Collectors.toMap(TastingTagInfo::id, tag -> tag, (existing, ignored) -> existing))
+            .values()
+            .stream()
+            .toList();
+
+    return new AdminAlcoholDetailResponse(
+        projection.alcoholId(),
+        projection.korName(),
+        projection.engName(),
+        projection.imageUrl(),
+        projection.type(),
+        projection.korCategory(),
+        projection.engCategory(),
+        projection.categoryGroup(),
+        projection.abv(),
+        projection.age(),
+        projection.cask(),
+        projection.volume(),
+        projection.description(),
+        projection.regionId(),
+        projection.korRegion(),
+        projection.engRegion(),
+        projection.distilleryId(),
+        projection.korDistillery(),
+        projection.engDistillery(),
+        tastingTags,
+        projection.avgRating(),
+        projection.totalRatingsCount(),
+        projection.reviewCount(),
+        projection.pickCount(),
+        projection.createdAt(),
+        projection.modifiedAt());
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholLookupService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholLookupService.java
@@ -1,129 +1,26 @@
 package app.bottlenote.alcohols.service;
 
-import app.bottlenote.alcohols.constant.AlcoholCategoryGroup;
-import app.bottlenote.alcohols.domain.AlcoholLookupSnapshotStore;
-import app.bottlenote.alcohols.domain.AlcoholQueryRepository;
 import app.bottlenote.alcohols.dto.request.AlcoholLookupRequest;
 import app.bottlenote.alcohols.dto.response.AlcoholLookupItem;
 import app.bottlenote.alcohols.dto.response.AlcoholLookupListResponse;
-import app.bottlenote.alcohols.dto.response.AlcoholLookupSnapshotItem;
 import app.bottlenote.global.pagination.CursorClaims;
 import app.bottlenote.global.pagination.CursorKeys;
 import app.bottlenote.global.pagination.HmacCursorCodec;
 import app.bottlenote.global.pagination.PageResponse;
 import app.bottlenote.global.pagination.Pagination;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AlcoholLookupService {
-  private final AlcoholQueryRepository alcoholQueryRepository;
-  private final AlcoholLookupSnapshotStore snapshotStore;
+  private final AlcoholLookupSnapshotService snapshotService;
   private final HmacCursorCodec cursorCodec;
-  private final AtomicReference<LocalLookupSnapshot> localSnapshot =
-      new AtomicReference<>(LocalLookupSnapshot.empty());
-
-  @Value("${alcohol.lookup.local-cache.enabled:false}")
-  private boolean localCacheEnabled;
-
-  @Value("${alcohol.lookup.local-cache.version-check-interval-ms:1000}")
-  private long localCacheVersionCheckIntervalMs;
 
   @Transactional(readOnly = true)
   public PageResponse<AlcoholLookupListResponse> lookup(AlcoholLookupRequest request) {
-    if (localCacheEnabled) {
-      return filterAndSlice(findLocalCachedItemsWithFallback(), request);
-    }
-    return filterAndSlice(findRedisItemsWithFallback(), request);
-  }
-
-  @Transactional(readOnly = true)
-  public AlcoholLookupSyncResult syncSnapshot() {
-    List<AlcoholLookupSnapshotItem> items = findDatabaseItems();
-    if (items.isEmpty()) {
-      log.warn("Alcohol lookup DB 원천 데이터가 0건이라 Redis snapshot 갱신을 건너뜁니다.");
-      return AlcoholLookupSyncResult.unchanged(0);
-    }
-
-    try {
-      List<AlcoholLookupSnapshotItem> currentItems = snapshotStore.findAll();
-      if (currentItems.equals(items)) {
-        return AlcoholLookupSyncResult.unchanged(items.size());
-      }
-    } catch (Exception e) {
-      log.warn("Alcohol lookup 기존 snapshot 비교 실패. 새 snapshot으로 갱신합니다.", e);
-    }
-
-    snapshotStore.replaceAll(items);
-    return AlcoholLookupSyncResult.changed(items.size());
-  }
-
-  private List<AlcoholLookupSnapshotItem> findLocalCachedItemsWithFallback() {
-    long now = System.currentTimeMillis();
-    LocalLookupSnapshot cached = localSnapshot.get();
-    if (cached.isFresh(now, localCacheVersionCheckIntervalMs)) {
-      return cached.items();
-    }
-
-    try {
-      Optional<String> redisVersion = snapshotStore.findVersion();
-      if (cached.hasItems()
-          && redisVersion.isPresent()
-          && redisVersion.get().equals(cached.version())) {
-        localSnapshot.set(cached.checkedAt(now));
-        return cached.items();
-      }
-
-      List<AlcoholLookupSnapshotItem> items = snapshotStore.findAll();
-      if (!items.isEmpty()) {
-        localSnapshot.set(LocalLookupSnapshot.of(redisVersion.orElse("unversioned"), items, now));
-        return items;
-      }
-      log.info("Alcohol lookup Redis snapshot이 비어 있어 fallback 경로를 사용합니다.");
-    } catch (Exception e) {
-      log.warn("Alcohol lookup local cache 갱신 실패. fallback 경로를 사용합니다.", e);
-    }
-    if (cached.hasItems()) {
-      localSnapshot.set(cached.checkedAt(now));
-      log.warn("Alcohol lookup stale local cache를 사용합니다. Redis/DB 부하 보호를 우선합니다.");
-      return cached.items();
-    }
-    return findDatabaseItems();
-  }
-
-  private List<AlcoholLookupSnapshotItem> findRedisItemsWithFallback() {
-    try {
-      List<AlcoholLookupSnapshotItem> items = snapshotStore.findAll();
-      if (!items.isEmpty()) {
-        return items;
-      }
-      log.info("Alcohol lookup Redis snapshot이 비어 있어 DB fallback 경로를 사용합니다.");
-    } catch (Exception e) {
-      log.warn("Alcohol lookup Redis snapshot 조회 실패. DB fallback 경로를 사용합니다.", e);
-    }
-    return findDatabaseItems();
-  }
-
-  private List<AlcoholLookupSnapshotItem> findDatabaseItems() {
-    return alcoholQueryRepository.findAllLookupItems().stream()
-        .map(AlcoholLookupSnapshotItem::from)
-        .toList();
-  }
-
-  private PageResponse<AlcoholLookupListResponse> filterAndSlice(
-      List<AlcoholLookupSnapshotItem> items, AlcoholLookupRequest request) {
-    AlcoholCategoryGroup categoryGroup = request.categoryGroup();
-    List<String> keywords = parseKeywords(request.keyword());
     String context = lookupContext(request);
     Long lastId = null;
     if (request.cursor() != null) {
@@ -132,19 +29,15 @@ public class AlcoholLookupService {
     }
     Long seekAfter = lastId;
     List<AlcoholLookupItem> fetched =
-        items.stream()
-            .filter(item -> matchesKeywords(item, keywords))
-            .filter(item -> categoryGroup == null || categoryGroup == item.categoryGroup())
-            .filter(
-                item -> request.regionId() == null || request.regionId().equals(item.regionId()))
-            .filter(
-                item ->
-                    request.distilleryId() == null
-                        || request.distilleryId().equals(item.distilleryId()))
+        snapshotService
+            .findFilteredItems(
+                request.keyword(),
+                request.categoryGroup(),
+                request.regionId(),
+                request.distilleryId())
+            .stream()
             .filter(item -> seekAfter == null || item.alcoholId() > seekAfter)
-            .sorted(java.util.Comparator.comparing(AlcoholLookupSnapshotItem::alcoholId))
             .limit(request.size() + 1L)
-            .map(AlcoholLookupSnapshotItem::toLookupItem)
             .toList();
     Pagination.PageSlice<AlcoholLookupItem> slice =
         Pagination.fromOverflow(
@@ -154,6 +47,11 @@ public class AlcoholLookupService {
                 cursorCodec.encode(
                     context, java.util.Map.of("id", String.valueOf(item.alcoholId()))));
     return PageResponse.of(new AlcoholLookupListResponse(slice.items()), slice.pagination());
+  }
+
+  @Transactional(readOnly = true)
+  public AlcoholLookupSyncResult syncSnapshot() {
+    return snapshotService.syncSnapshot();
   }
 
   private static String lookupContext(AlcoholLookupRequest request) {
@@ -167,54 +65,13 @@ public class AlcoholLookupService {
         + request.distilleryId();
   }
 
-  private List<String> parseKeywords(String keyword) {
-    if (keyword == null || keyword.isBlank()) {
-      return List.of();
-    }
-    return Arrays.stream(keyword.trim().toLowerCase(Locale.ROOT).split("\\s+"))
-        .filter(value -> !value.isBlank())
-        .toList();
-  }
-
-  private boolean matchesKeywords(AlcoholLookupSnapshotItem item, List<String> keywords) {
-    if (keywords.isEmpty()) {
-      return true;
-    }
-    return keywords.stream().allMatch(item.normalizedSearchText()::contains);
-  }
-
-  private record LocalLookupSnapshot(
-      String version, List<AlcoholLookupSnapshotItem> items, long checkedAtMillis) {
-
-    private static LocalLookupSnapshot empty() {
-      return new LocalLookupSnapshot("", List.of(), 0L);
-    }
-
-    private static LocalLookupSnapshot of(
-        String version, List<AlcoholLookupSnapshotItem> items, long checkedAtMillis) {
-      return new LocalLookupSnapshot(version, List.copyOf(items), checkedAtMillis);
-    }
-
-    private boolean hasItems() {
-      return !items.isEmpty();
-    }
-
-    private boolean isFresh(long now, long checkIntervalMillis) {
-      return hasItems() && now - checkedAtMillis < Math.max(checkIntervalMillis, 0L);
-    }
-
-    private LocalLookupSnapshot checkedAt(long checkedAtMillis) {
-      return new LocalLookupSnapshot(version, items, checkedAtMillis);
-    }
-  }
-
   public record AlcoholLookupSyncResult(int count, boolean changed) {
 
-    private static AlcoholLookupSyncResult changed(int count) {
+    public static AlcoholLookupSyncResult changed(int count) {
       return new AlcoholLookupSyncResult(count, true);
     }
 
-    private static AlcoholLookupSyncResult unchanged(int count) {
+    public static AlcoholLookupSyncResult unchanged(int count) {
       return new AlcoholLookupSyncResult(count, false);
     }
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholLookupSnapshotService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholLookupSnapshotService.java
@@ -1,0 +1,169 @@
+package app.bottlenote.alcohols.service;
+
+import app.bottlenote.alcohols.constant.AlcoholCategoryGroup;
+import app.bottlenote.alcohols.domain.AlcoholLookupSnapshotStore;
+import app.bottlenote.alcohols.domain.AlcoholQueryRepository;
+import app.bottlenote.alcohols.dto.response.AlcoholLookupItem;
+import app.bottlenote.alcohols.dto.response.AlcoholLookupSnapshotItem;
+import app.bottlenote.alcohols.service.AlcoholLookupService.AlcoholLookupSyncResult;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlcoholLookupSnapshotService {
+  private final AlcoholQueryRepository alcoholQueryRepository;
+  private final AlcoholLookupSnapshotStore snapshotStore;
+  private final AtomicReference<LocalLookupSnapshot> localSnapshot =
+      new AtomicReference<>(LocalLookupSnapshot.empty());
+
+  @Value("${alcohol.lookup.local-cache.enabled:false}")
+  private boolean localCacheEnabled;
+
+  @Value("${alcohol.lookup.local-cache.version-check-interval-ms:1000}")
+  private long localCacheVersionCheckIntervalMs;
+
+  @Transactional(readOnly = true)
+  public List<AlcoholLookupItem> findFilteredItems(
+      String keyword, AlcoholCategoryGroup categoryGroup, Long regionId, Long distilleryId) {
+    List<String> keywords = parseKeywords(keyword);
+    return findItems().stream()
+        .filter(item -> matchesKeywords(item, keywords))
+        .filter(item -> categoryGroup == null || categoryGroup == item.categoryGroup())
+        .filter(item -> regionId == null || regionId.equals(item.regionId()))
+        .filter(item -> distilleryId == null || distilleryId.equals(item.distilleryId()))
+        .sorted(java.util.Comparator.comparing(AlcoholLookupSnapshotItem::alcoholId))
+        .map(AlcoholLookupSnapshotItem::toLookupItem)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public AlcoholLookupSyncResult syncSnapshot() {
+    List<AlcoholLookupSnapshotItem> items = findDatabaseItems();
+    if (items.isEmpty()) {
+      log.warn("Alcohol lookup DB 원천 데이터가 0건이라 Redis snapshot 갱신을 건너뜁니다.");
+      return AlcoholLookupSyncResult.unchanged(0);
+    }
+
+    try {
+      List<AlcoholLookupSnapshotItem> currentItems = snapshotStore.findAll();
+      if (currentItems.equals(items)) {
+        return AlcoholLookupSyncResult.unchanged(items.size());
+      }
+    } catch (Exception e) {
+      log.warn("Alcohol lookup 기존 snapshot 비교 실패. 새 snapshot으로 갱신합니다.", e);
+    }
+
+    snapshotStore.replaceAll(items);
+    return AlcoholLookupSyncResult.changed(items.size());
+  }
+
+  private List<AlcoholLookupSnapshotItem> findItems() {
+    if (localCacheEnabled) {
+      return findLocalCachedItemsWithFallback();
+    }
+    return findRedisItemsWithFallback();
+  }
+
+  private List<AlcoholLookupSnapshotItem> findLocalCachedItemsWithFallback() {
+    long now = System.currentTimeMillis();
+    LocalLookupSnapshot cached = localSnapshot.get();
+    if (cached.isFresh(now, localCacheVersionCheckIntervalMs)) {
+      return cached.items();
+    }
+
+    try {
+      Optional<String> redisVersion = snapshotStore.findVersion();
+      if (cached.hasItems()
+          && redisVersion.isPresent()
+          && redisVersion.get().equals(cached.version())) {
+        localSnapshot.set(cached.checkedAt(now));
+        return cached.items();
+      }
+
+      List<AlcoholLookupSnapshotItem> items = snapshotStore.findAll();
+      if (!items.isEmpty()) {
+        localSnapshot.set(LocalLookupSnapshot.of(redisVersion.orElse("unversioned"), items, now));
+        return items;
+      }
+      log.info("Alcohol lookup Redis snapshot이 비어 있어 fallback 경로를 사용합니다.");
+    } catch (Exception e) {
+      log.warn("Alcohol lookup local cache 갱신 실패. fallback 경로를 사용합니다.", e);
+    }
+    if (cached.hasItems()) {
+      localSnapshot.set(cached.checkedAt(now));
+      log.warn("Alcohol lookup stale local cache를 사용합니다. Redis/DB 부하 보호를 우선합니다.");
+      return cached.items();
+    }
+    return findDatabaseItems();
+  }
+
+  private List<AlcoholLookupSnapshotItem> findRedisItemsWithFallback() {
+    try {
+      List<AlcoholLookupSnapshotItem> items = snapshotStore.findAll();
+      if (!items.isEmpty()) {
+        return items;
+      }
+      log.info("Alcohol lookup Redis snapshot이 비어 있어 DB fallback 경로를 사용합니다.");
+    } catch (Exception e) {
+      log.warn("Alcohol lookup Redis snapshot 조회 실패. DB fallback 경로를 사용합니다.", e);
+    }
+    return findDatabaseItems();
+  }
+
+  private List<AlcoholLookupSnapshotItem> findDatabaseItems() {
+    return alcoholQueryRepository.findAllLookupItems().stream()
+        .map(AlcoholLookupSnapshotItem::from)
+        .toList();
+  }
+
+  private List<String> parseKeywords(String keyword) {
+    if (keyword == null || keyword.isBlank()) {
+      return List.of();
+    }
+    return Arrays.stream(keyword.trim().toLowerCase(Locale.ROOT).split("\\s+"))
+        .filter(value -> !value.isBlank())
+        .toList();
+  }
+
+  private boolean matchesKeywords(AlcoholLookupSnapshotItem item, List<String> keywords) {
+    if (keywords.isEmpty()) {
+      return true;
+    }
+    return keywords.stream().allMatch(item.normalizedSearchText()::contains);
+  }
+
+  private record LocalLookupSnapshot(
+      String version, List<AlcoholLookupSnapshotItem> items, long checkedAtMillis) {
+
+    private static LocalLookupSnapshot empty() {
+      return new LocalLookupSnapshot("", List.of(), 0L);
+    }
+
+    private static LocalLookupSnapshot of(
+        String version, List<AlcoholLookupSnapshotItem> items, long checkedAtMillis) {
+      return new LocalLookupSnapshot(version, List.copyOf(items), checkedAtMillis);
+    }
+
+    private boolean hasItems() {
+      return !items.isEmpty();
+    }
+
+    private boolean isFresh(long now, long checkIntervalMillis) {
+      return hasItems() && now - checkedAtMillis < Math.max(checkIntervalMillis, 0L);
+    }
+
+    private LocalLookupSnapshot checkedAt(long checkedAtMillis) {
+      return new LocalLookupSnapshot(version, items, checkedAtMillis);
+    }
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholQueryService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/alcohols/service/AlcoholQueryService.java
@@ -2,24 +2,15 @@ package app.bottlenote.alcohols.service;
 
 import static app.bottlenote.alcohols.exception.AlcoholExceptionCode.ALCOHOL_NOT_FOUND;
 
-import app.bottlenote.alcohols.constant.AlcoholCategoryGroup;
 import app.bottlenote.alcohols.constant.SearchSortType;
-import app.bottlenote.alcohols.domain.Alcohol;
 import app.bottlenote.alcohols.domain.AlcoholQueryRepository;
 import app.bottlenote.alcohols.dto.dsl.ExploreStandardCriteria;
-import app.bottlenote.alcohols.dto.request.AdminAlcoholSearchRequest;
 import app.bottlenote.alcohols.dto.request.ExploreStandardRequest;
-import app.bottlenote.alcohols.dto.response.AdminAlcoholDetailResponse;
-import app.bottlenote.alcohols.dto.response.AdminAlcoholDetailResponse.TastingTagInfo;
 import app.bottlenote.alcohols.dto.response.AlcoholDetailItem;
 import app.bottlenote.alcohols.dto.response.AlcoholDetailResponse;
-import app.bottlenote.alcohols.dto.response.CategoryItem;
-import app.bottlenote.alcohols.dto.response.CategoryPairItem;
 import app.bottlenote.alcohols.dto.response.ExploreStandardResponse;
 import app.bottlenote.alcohols.dto.response.FriendsDetailResponse;
 import app.bottlenote.alcohols.exception.AlcoholException;
-import app.bottlenote.alcohols.repository.CustomAlcoholQueryRepository.AdminAlcoholDetailProjection;
-import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.global.pagination.HmacCursorCodec;
 import app.bottlenote.global.pagination.PageResponse;
 import app.bottlenote.global.pagination.PaginationException;
@@ -28,13 +19,9 @@ import app.bottlenote.history.service.AlcoholViewHistoryService;
 import app.bottlenote.review.facade.ReviewFacade;
 import app.bottlenote.user.facade.FollowFacade;
 import app.bottlenote.user.facade.payload.FriendItem;
-import java.util.ArrayList;
-import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -116,83 +103,5 @@ public class AlcoholQueryService {
       }
     }
     return ThreadLocalRandom.current().nextLong();
-  }
-
-  @Transactional(readOnly = true)
-  public GlobalResponse searchAdminAlcohols(AdminAlcoholSearchRequest request) {
-    return GlobalResponse.fromPage(alcoholQueryRepository.searchAdminAlcohols(request));
-  }
-
-  /** 카테고리 레퍼런스를 categoryGroup 기준으로 묶어 반환한다. enum 선언 순서로 키가 고정되며, 데이터가 없는 그룹도 빈 리스트로 포함된다. */
-  @Transactional(readOnly = true)
-  public Map<AlcoholCategoryGroup, List<CategoryPairItem>> findAllCategoryReferenceMap() {
-    Map<AlcoholCategoryGroup, List<CategoryPairItem>> grouped =
-        new EnumMap<>(AlcoholCategoryGroup.class);
-    for (AlcoholCategoryGroup group : AlcoholCategoryGroup.values()) {
-      grouped.put(group, new ArrayList<>());
-    }
-
-    for (CategoryItem item : alcoholQueryRepository.findAllCategoryItems()) {
-      AlcoholCategoryGroup group = item.categoryGroup();
-      if (group == null) continue;
-      grouped.get(group).add(new CategoryPairItem(item.korCategory(), item.engCategory()));
-    }
-
-    return grouped;
-  }
-
-  @Transactional(readOnly = true)
-  public AdminAlcoholDetailResponse findAdminAlcoholDetailById(Long alcoholId) {
-    AdminAlcoholDetailProjection projection =
-        alcoholQueryRepository
-            .findAdminAlcoholDetailById(alcoholId)
-            .orElseThrow(() -> new AlcoholException(ALCOHOL_NOT_FOUND));
-
-    Alcohol alcohol =
-        alcoholQueryRepository
-            .findById(alcoholId)
-            .orElseThrow(() -> new AlcoholException(ALCOHOL_NOT_FOUND));
-
-    List<TastingTagInfo> tastingTags =
-        alcohol.getAlcoholsTastingTags().stream()
-            .map(
-                att ->
-                    new TastingTagInfo(
-                        att.getTastingTag().getId(),
-                        att.getTastingTag().getKorName(),
-                        att.getTastingTag().getEngName()))
-            .collect(
-                Collectors.toMap(TastingTagInfo::id, tag -> tag, (existing, ignored) -> existing))
-            .values()
-            .stream()
-            .toList();
-
-    return new AdminAlcoholDetailResponse(
-        projection.alcoholId(),
-        projection.korName(),
-        projection.engName(),
-        projection.imageUrl(),
-        projection.type(),
-        projection.korCategory(),
-        projection.engCategory(),
-        projection.categoryGroup(),
-        projection.abv(),
-        projection.age(),
-        projection.cask(),
-        projection.volume(),
-        projection.description(),
-        projection.regionId(),
-        projection.korRegion(),
-        projection.engRegion(),
-        projection.distilleryId(),
-        projection.korDistillery(),
-        projection.engDistillery(),
-        tastingTags,
-        projection.avgRating(),
-        projection.totalRatingsCount(),
-        projection.reviewCount(),
-        projection.pickCount(),
-        projection.createdAt(),
-        projection.modifiedAt());
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/pagination/CursorProperties.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/pagination/CursorProperties.java
@@ -2,21 +2,15 @@ package app.bottlenote.global.pagination;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "bottlenote.pagination.cursor")
-public class CursorProperties implements InitializingBean {
+public class CursorProperties {
 
   private String currentKeyId = "v1";
   private String currentSecret;
   private String previousKeyId;
   private String previousSecret;
-
-  @Override
-  public void afterPropertiesSet() {
-    validate();
-  }
 
   public void validate() {
     if (isBlank(currentKeyId) || isBlank(currentSecret)) {

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/pagination/CursorSecretValidator.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/pagination/CursorSecretValidator.java
@@ -1,0 +1,21 @@
+package app.bottlenote.global.pagination;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app", name = "type", havingValue = "product")
+public class CursorSecretValidator implements InitializingBean {
+
+  private final CursorProperties properties;
+
+  public CursorSecretValidator(CursorProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    properties.validate();
+  }
+}

--- a/bottlenote-mono/src/main/java/app/bottlenote/global/pagination/HmacCursorCodec.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/global/pagination/HmacCursorCodec.java
@@ -39,7 +39,6 @@ public final class HmacCursorCodec {
 
   public HmacCursorCodec(CursorProperties properties, Clock clock) {
     Objects.requireNonNull(properties, "properties");
-    properties.validate();
     this.properties = properties;
     this.clock = Objects.requireNonNull(clock, "clock");
   }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/domain/HelpRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/domain/HelpRepository.java
@@ -8,6 +8,7 @@ import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 
 public interface HelpRepository {
 
@@ -26,5 +27,5 @@ public interface HelpRepository {
   PageResponse<HelpListResponse> getHelpList(
       HelpPageableRequest helpPageableRequest, Long currentUserId);
 
-  PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request);
+  Page<AdminHelpListResponse.AdminHelpInfo> getAdminHelpList(AdminHelpPageableRequest request);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/request/AdminHelpPageableRequest.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/dto/request/AdminHelpPageableRequest.java
@@ -1,20 +1,26 @@
 package app.bottlenote.support.help.dto.request;
 
-import app.bottlenote.global.pagination.PaginationRequest;
 import app.bottlenote.support.constant.StatusType;
 import app.bottlenote.support.help.constant.HelpType;
 import lombok.Builder;
 
+/**
+ * @param page 페이지 번호 (0부터)
+ * @param size 페이지 크기
+ */
 public record AdminHelpPageableRequest(
-    StatusType status, HelpType type, String cursor, Integer size) {
+    StatusType status, HelpType type, Integer page, Integer size) {
 
   public static final int DEFAULT_SIZE = 20;
   public static final int MAX_SIZE = 100;
 
   @Builder
   public AdminHelpPageableRequest {
-    PaginationRequest page = PaginationRequest.of(cursor, size, DEFAULT_SIZE, MAX_SIZE);
-    cursor = page.cursor();
-    size = page.size();
+    page = page != null && page >= 0 ? page : 0;
+    if (size == null || size < 1) {
+      size = DEFAULT_SIZE;
+    } else {
+      size = Math.min(size, MAX_SIZE);
+    }
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepository.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepository.java
@@ -5,6 +5,7 @@ import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
 import app.bottlenote.support.help.dto.request.HelpPageableRequest;
 import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
+import org.springframework.data.domain.Page;
 
 public interface CustomHelpQueryRepository {
 
@@ -24,5 +25,5 @@ public interface CustomHelpQueryRepository {
    * @param request 페이징 및 필터링 요청
    * @return 전체 문의글 목록
    */
-  PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request);
+  Page<AdminHelpListResponse.AdminHelpInfo> getAdminHelpList(AdminHelpPageableRequest request);
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepositoryImpl.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/repository/custom/CustomHelpQueryRepositoryImpl.java
@@ -20,6 +20,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -66,10 +69,9 @@ public class CustomHelpQueryRepositoryImpl implements CustomHelpQueryRepository 
   }
 
   @Override
-  public PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request) {
+  public Page<AdminHelpListResponse.AdminHelpInfo> getAdminHelpList(
+      AdminHelpPageableRequest request) {
     BooleanBuilder whereClause = new BooleanBuilder();
-    String context = "admin.help:" + request.status() + ":" + request.type();
-    int size = request.size();
 
     if (request.status() != null) {
       whereClause.and(help.status.eq(request.status()));
@@ -77,9 +79,8 @@ public class CustomHelpQueryRepositoryImpl implements CustomHelpQueryRepository 
     if (request.type() != null) {
       whereClause.and(help.type.eq(request.type()));
     }
-    whereClause.and(helpSeek(request.cursor(), context));
 
-    List<AdminHelpListResponse.AdminHelpInfo> fetch =
+    List<AdminHelpListResponse.AdminHelpInfo> content =
         queryFactory
             .select(supporter.adminHelpResponseConstructor())
             .from(help)
@@ -87,14 +88,13 @@ public class CustomHelpQueryRepositoryImpl implements CustomHelpQueryRepository 
             .on(help.userId.eq(user.id))
             .where(whereClause)
             .orderBy(help.createAt.desc(), help.id.desc())
-            .limit(size + 1L)
+            .offset((long) request.page() * request.size())
+            .limit(request.size())
             .fetch();
 
-    Pagination.PageSlice<AdminHelpListResponse.AdminHelpInfo> slice =
-        Pagination.fromOverflow(
-            fetch,
-            size,
-            item -> cursorCodec.encode(context, TimeIdCursor.keys(item.createAt(), item.helpId())));
-    return PageResponse.of(AdminHelpListResponse.of(slice.items()), slice.pagination());
+    Long total = queryFactory.select(help.id.count()).from(help).where(whereClause).fetchOne();
+
+    return new PageImpl<>(
+        content, PageRequest.of(request.page(), request.size()), total != null ? total : 0L);
   }
 }

--- a/bottlenote-mono/src/main/java/app/bottlenote/support/help/service/AdminHelpService.java
+++ b/bottlenote-mono/src/main/java/app/bottlenote/support/help/service/AdminHelpService.java
@@ -2,7 +2,7 @@ package app.bottlenote.support.help.service;
 
 import static app.bottlenote.support.help.exception.HelpExceptionCode.HELP_NOT_FOUND;
 
-import app.bottlenote.global.pagination.PageResponse;
+import app.bottlenote.global.data.response.GlobalResponse;
 import app.bottlenote.support.help.domain.Help;
 import app.bottlenote.support.help.domain.HelpRepository;
 import app.bottlenote.support.help.dto.request.AdminHelpAnswerRequest;
@@ -10,7 +10,6 @@ import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
 import app.bottlenote.support.help.dto.request.HelpImageItem;
 import app.bottlenote.support.help.dto.response.AdminHelpAnswerResponse;
 import app.bottlenote.support.help.dto.response.AdminHelpDetailResponse;
-import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.event.payload.HelpAnswerNotificationEvent;
 import app.bottlenote.support.help.exception.HelpException;
 import app.bottlenote.user.domain.User;
@@ -31,8 +30,8 @@ public class AdminHelpService {
   private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(readOnly = true)
-  public PageResponse<AdminHelpListResponse> getHelpList(AdminHelpPageableRequest request) {
-    return helpRepository.getAdminHelpList(request);
+  public GlobalResponse getHelpList(AdminHelpPageableRequest request) {
+    return GlobalResponse.fromPage(helpRepository.getAdminHelpList(request));
   }
 
   @Transactional(readOnly = true)

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminAlcoholLookupServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AdminAlcoholLookupServiceTest.java
@@ -1,0 +1,93 @@
+package app.bottlenote.alcohols.service;
+
+import static app.bottlenote.alcohols.constant.AlcoholCategoryGroup.SINGLE_MALT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.bottlenote.alcohols.dto.request.AdminAlcoholLookupRequest;
+import app.bottlenote.alcohols.dto.response.AlcoholLookupItem;
+import app.bottlenote.alcohols.dto.response.AlcoholLookupSnapshotItem;
+import app.bottlenote.alcohols.fixture.InMemoryAlcoholLookupSnapshotStore;
+import app.bottlenote.alcohols.fixture.InMemoryAlcoholQueryRepository;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("[unit] AdminAlcoholLookupService page/size 목록")
+class AdminAlcoholLookupServiceTest {
+
+  private InMemoryAlcoholLookupSnapshotStore snapshotStore;
+  private AdminAlcoholLookupService adminAlcoholLookupService;
+
+  @BeforeEach
+  void setUp() {
+    InMemoryAlcoholQueryRepository alcoholQueryRepository = new InMemoryAlcoholQueryRepository();
+    snapshotStore = new InMemoryAlcoholLookupSnapshotStore();
+    adminAlcoholLookupService =
+        new AdminAlcoholLookupService(
+            new AlcoholLookupSnapshotService(alcoholQueryRepository, snapshotStore));
+  }
+
+  @Test
+  @DisplayName("page와 size로 룩업 목록을 자른다")
+  void lookup_whenPageAndSize_returnsOffsetSlice() {
+    snapshotStore.replaceAll(createLookupSnapshotItems(5));
+
+    var response =
+        adminAlcoholLookupService.lookup(
+            AdminAlcoholLookupRequest.builder().keyword("macallan").page(1).size(2).build());
+
+    @SuppressWarnings("unchecked")
+    List<AlcoholLookupItem> content = (List<AlcoholLookupItem>) response.getData();
+    assertThat(content).extracting(AlcoholLookupItem::alcoholId).containsExactly(3L, 4L);
+    assertThat(response.getMeta())
+        .containsEntry("page", 1)
+        .containsEntry("size", 2)
+        .containsEntry("totalElements", 5L);
+  }
+
+  @Test
+  @DisplayName("Product lookup 요청 타입 없이 필터를 적용한다")
+  void lookup_whenKeywordFilter_returnsMatchingItems() {
+    snapshotStore.replaceAll(
+        List.of(
+            lookupSnapshotItem(1L, "맥캘란 12년", "Macallan 12", "맥캘란", "Macallan"),
+            lookupSnapshotItem(2L, "글렌피딕 12년", "Glenfiddich 12", "글렌피딕", "Glenfiddich")));
+
+    var response =
+        adminAlcoholLookupService.lookup(
+            AdminAlcoholLookupRequest.builder().keyword("macallan").build());
+
+    @SuppressWarnings("unchecked")
+    List<AlcoholLookupItem> content = (List<AlcoholLookupItem>) response.getData();
+    assertThat(content).extracting(AlcoholLookupItem::alcoholId).containsExactly(1L);
+  }
+
+  private List<AlcoholLookupSnapshotItem> createLookupSnapshotItems(int size) {
+    return LongStream.rangeClosed(1, size)
+        .mapToObj(id -> lookupSnapshotItem(id, "맥캘란 " + id, "Macallan " + id, "맥캘란", "Macallan"))
+        .toList();
+  }
+
+  private AlcoholLookupSnapshotItem lookupSnapshotItem(
+      Long alcoholId, String korName, String engName, String korDistillery, String engDistillery) {
+    return AlcoholLookupSnapshotItem.from(
+        new AlcoholLookupItem(
+            alcoholId,
+            korName,
+            engName,
+            "싱글몰트",
+            "Single Malt",
+            SINGLE_MALT,
+            1L,
+            "스페이사이드",
+            "Speyside",
+            10L,
+            korDistillery,
+            engDistillery,
+            "https://example.com/alcohol.png"));
+  }
+}

--- a/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AlcoholLookupServiceTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/alcohols/service/AlcoholLookupServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class AlcoholLookupServiceTest {
   private InMemoryAlcoholQueryRepository alcoholQueryRepository;
   private InMemoryAlcoholLookupSnapshotStore snapshotStore;
+  private AlcoholLookupSnapshotService snapshotService;
   private AlcoholLookupService alcoholLookupService;
 
   @BeforeEach
@@ -39,11 +40,10 @@ class AlcoholLookupServiceTest {
     CursorProperties properties = new CursorProperties();
     properties.setCurrentKeyId("v1");
     properties.setCurrentSecret("test-pagination-cursor-secret");
+    snapshotService = new AlcoholLookupSnapshotService(alcoholQueryRepository, snapshotStore);
     alcoholLookupService =
         new AlcoholLookupService(
-            alcoholQueryRepository,
-            snapshotStore,
-            new HmacCursorCodec(properties, Clock.systemUTC()));
+            snapshotService, new HmacCursorCodec(properties, Clock.systemUTC()));
   }
 
   @Test
@@ -125,8 +125,8 @@ class AlcoholLookupServiceTest {
   void lookup_whenLocalCacheEnabled_reusesParsedSnapshotWithinCheckInterval() {
     // given
     snapshotStore.replaceAll(createLookupSnapshotItems(100));
-    ReflectionTestUtils.setField(alcoholLookupService, "localCacheEnabled", true);
-    ReflectionTestUtils.setField(alcoholLookupService, "localCacheVersionCheckIntervalMs", 60_000L);
+    ReflectionTestUtils.setField(snapshotService, "localCacheEnabled", true);
+    ReflectionTestUtils.setField(snapshotService, "localCacheVersionCheckIntervalMs", 60_000L);
     AlcoholLookupRequest request =
         AlcoholLookupRequest.builder().keyword("macallan").size(20).build();
 
@@ -145,8 +145,8 @@ class AlcoholLookupServiceTest {
     // given
     snapshotStore.replaceAll(createLookupSnapshotItems(100));
     alcoholQueryRepository.save(createAlcohol(999L));
-    ReflectionTestUtils.setField(alcoholLookupService, "localCacheEnabled", true);
-    ReflectionTestUtils.setField(alcoholLookupService, "localCacheVersionCheckIntervalMs", 0L);
+    ReflectionTestUtils.setField(snapshotService, "localCacheEnabled", true);
+    ReflectionTestUtils.setField(snapshotService, "localCacheVersionCheckIntervalMs", 0L);
     AlcoholLookupRequest request =
         AlcoholLookupRequest.builder().keyword("macallan").size(20).build();
 

--- a/bottlenote-mono/src/test/java/app/bottlenote/global/pagination/PaginationConfigurationTest.java
+++ b/bottlenote-mono/src/test/java/app/bottlenote/global/pagination/PaginationConfigurationTest.java
@@ -15,9 +15,22 @@ class PaginationConfigurationTest {
       new ApplicationContextRunner().withUserConfiguration(PaginationConfiguration.class);
 
   @Test
-  @DisplayName("current-secret이 없으면 애플리케이션 컨텍스트 로드가 실패한다")
-  void missing_secret_fails_context_load() {
-    contextRunner.run(context -> assertThat(context).hasFailed());
+  @DisplayName("Admin처럼 app.type이 product가 아니면 secret 없이 코덱 빈을 만든다")
+  void missing_secret_allows_non_product_context() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasNotFailed();
+          assertThat(context).hasSingleBean(HmacCursorCodec.class);
+        });
+  }
+
+  @Test
+  @DisplayName("Product는 current-secret이 없으면 애플리케이션 컨텍스트 로드가 실패한다")
+  void missing_secret_fails_product_context_load() {
+    contextRunner
+        .withUserConfiguration(CursorSecretValidator.class)
+        .withPropertyValues("app.type=product")
+        .run(context -> assertThat(context).hasFailed());
   }
 
   @Test

--- a/bottlenote-product-api/src/test/java/app/bottlenote/support/help/fixture/InMemoryHelpRepository.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/support/help/fixture/InMemoryHelpRepository.java
@@ -9,11 +9,15 @@ import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
 import app.bottlenote.support.help.dto.request.HelpPageableRequest;
 import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
 import app.bottlenote.support.help.dto.response.HelpListResponse;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class InMemoryHelpRepository implements HelpRepository {
@@ -68,8 +72,34 @@ public class InMemoryHelpRepository implements HelpRepository {
   }
 
   @Override
-  public PageResponse<AdminHelpListResponse> getAdminHelpList(AdminHelpPageableRequest request) {
-    return PageResponse.of(AdminHelpListResponse.of(List.of()), new Pagination(false, null));
+  public Page<AdminHelpListResponse.AdminHelpInfo> getAdminHelpList(
+      AdminHelpPageableRequest request) {
+    List<AdminHelpListResponse.AdminHelpInfo> filtered =
+        database.values().stream()
+            .filter(help -> request.status() == null || request.status() == help.getStatus())
+            .filter(help -> request.type() == null || request.type() == help.getType())
+            .sorted(
+                Comparator.comparing(
+                        Help::getCreateAt, Comparator.nullsLast(Comparator.reverseOrder()))
+                    .thenComparing(Help::getId, Comparator.reverseOrder()))
+            .map(
+                help ->
+                    AdminHelpListResponse.AdminHelpInfo.builder()
+                        .helpId(help.getId())
+                        .userId(help.getUserId())
+                        .userNickname(null)
+                        .title(help.getTitle())
+                        .type(help.getType())
+                        .status(help.getStatus())
+                        .createAt(help.getCreateAt())
+                        .build())
+            .toList();
+    int from = Math.min(request.page() * request.size(), filtered.size());
+    int to = Math.min(from + request.size(), filtered.size());
+    return new PageImpl<>(
+        filtered.subList(from, to),
+        PageRequest.of(request.page(), request.size()),
+        filtered.size());
   }
 
   public void clear() {

--- a/bottlenote-product-api/src/test/java/app/bottlenote/support/help/service/AdminHelpServiceTest.java
+++ b/bottlenote-product-api/src/test/java/app/bottlenote/support/help/service/AdminHelpServiceTest.java
@@ -1,0 +1,62 @@
+package app.bottlenote.support.help.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import app.bottlenote.support.help.constant.HelpType;
+import app.bottlenote.support.help.domain.Help;
+import app.bottlenote.support.help.dto.request.AdminHelpPageableRequest;
+import app.bottlenote.support.help.dto.response.AdminHelpListResponse;
+import app.bottlenote.support.help.fixture.InMemoryHelpRepository;
+import app.bottlenote.user.fixture.InMemoryUserRepository;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+@DisplayName("[unit] AdminHelpService page/size 목록")
+class AdminHelpServiceTest {
+
+  @Test
+  @DisplayName("page와 size로 문의 목록을 자른다")
+  void getHelpList_whenPageAndSize_returnsOffsetSlice() {
+    InMemoryHelpRepository helpRepository = new InMemoryHelpRepository();
+    AdminHelpService service =
+        new AdminHelpService(helpRepository, new InMemoryUserRepository(), event -> {});
+    for (int i = 0; i < 5; i++) {
+      helpRepository.save(Help.create(1L, HelpType.WHISKEY, "제목" + i, "내용" + i));
+    }
+
+    var response = service.getHelpList(AdminHelpPageableRequest.builder().page(1).size(2).build());
+
+    @SuppressWarnings("unchecked")
+    List<AdminHelpListResponse.AdminHelpInfo> content =
+        (List<AdminHelpListResponse.AdminHelpInfo>) response.getData();
+    Map<String, Object> meta = response.getMeta();
+    assertThat(content).hasSize(2);
+    assertThat(meta)
+        .containsEntry("page", 1)
+        .containsEntry("size", 2)
+        .containsEntry("totalElements", 5L);
+  }
+
+  @Test
+  @DisplayName("유형 필터를 적용한다")
+  void getHelpList_whenTypeFilter_returnsMatchingItems() {
+    InMemoryHelpRepository helpRepository = new InMemoryHelpRepository();
+    AdminHelpService service =
+        new AdminHelpService(helpRepository, new InMemoryUserRepository(), event -> {});
+    helpRepository.save(Help.create(1L, HelpType.WHISKEY, "위스키", "내용"));
+    helpRepository.save(Help.create(1L, HelpType.REVIEW, "리뷰", "내용"));
+
+    var response =
+        service.getHelpList(AdminHelpPageableRequest.builder().type(HelpType.WHISKEY).build());
+
+    @SuppressWarnings("unchecked")
+    List<AdminHelpListResponse.AdminHelpInfo> content =
+        (List<AdminHelpListResponse.AdminHelpInfo>) response.getData();
+    assertThat(content).hasSize(1);
+    assertThat(content.getFirst().type()).isEqualTo(HelpType.WHISKEY);
+  }
+}

--- a/plan/admin-product-pagination-separation.md
+++ b/plan/admin-product-pagination-separation.md
@@ -89,11 +89,11 @@
 - Files (advisory): Admin lookup request/service, `AdminAlcoholsController`, `AdminAlcoholsApiDocs`, lookup unit test
 - Depends: 없음
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
 
 ### Checkpoint: after Task 2
-- [ ] Admin lookup이 Product lookup 요청/서비스를 직접 쓰지 않는다
-- [ ] Product lookup 계약이 유지된다
+- [x] Admin lookup이 Product lookup 요청/서비스를 직접 쓰지 않는다
+- [x] Product lookup 계약이 유지된다
 
 ### Task 3: Admin을 Product 목록 서비스에서 분리하고 cursor secret을 제거한다
 - Acceptance: Admin 컨트롤러가 Product 목록 Service(`AlcoholQueryService`, `AlcoholLookupService`)를 주입하지 않는다. Admin yml/테스트 yml에서 `PAGINATION_CURSOR_SECRET`이 없고, Admin 기동이 cursor secret 없이 된다.
@@ -109,3 +109,4 @@
 - 2026-08-16: Execution Mode 확정. delegated, scope=plan/implement/test/commit/push/pr. local verify 생략, PR 후 GitHub Actions 트래킹.
 - 2026-08-16: /plan. Task 3개로 분해. help 원복 → lookup 분리 → Product 서비스 분리+secret 제거.
 - 2026-08-16: Task 1 완료. Admin help를 page/size + fromPage로 원복. Product help HMAC 커서는 유지. AdminHelpServiceTest 통과.
+- 2026-08-16: Task 2 완료. AdminAlcoholLookupService/Request로 분리. Product AlcoholLookupService는 HMAC cursor 유지. 스냅샷 조회는 AlcoholLookupSnapshotService로 공유.

--- a/plan/admin-product-pagination-separation.md
+++ b/plan/admin-product-pagination-separation.md
@@ -101,7 +101,11 @@
 - Files (advisory): `AdminAlcoholQueryService`, `AdminAlcoholsController`, `AlcoholQueryService`, `PaginationConfiguration`, Admin `application.yml`, Admin `application-test.yml`
 - Depends: Task 2
 - Size: M
-- Status: [ ] not done
+- Status: [x] done
+
+### HMAC 빈이 Admin에 남는 이유
+
+Admin 컨트롤러는 Product 목록 Service를 더 이상 주입하지 않고, `PAGINATION_CURSOR_SECRET`도 yml에서 제거했다. 다만 Help/Alcohol/Review/User QueryDSL 구현체가 Product 커서와 Admin page/size를 같은 클래스에서 구현하므로 `HmacCursorCodec` 생성자는 여전히 필요하다. Product만 `CursorSecretValidator`로 secret 미주입 시 기동 실패한다.
 
 ## Progress Log
 
@@ -110,3 +114,4 @@
 - 2026-08-16: /plan. Task 3개로 분해. help 원복 → lookup 분리 → Product 서비스 분리+secret 제거.
 - 2026-08-16: Task 1 완료. Admin help를 page/size + fromPage로 원복. Product help HMAC 커서는 유지. AdminHelpServiceTest 통과.
 - 2026-08-16: Task 2 완료. AdminAlcoholLookupService/Request로 분리. Product AlcoholLookupService는 HMAC cursor 유지. 스냅샷 조회는 AlcoholLookupSnapshotService로 공유.
+- 2026-08-16: Task 3 완료. AdminAlcoholQueryService 분리, Admin yml cursor secret 제거. Product만 CursorSecretValidator로 secret 필수.

--- a/plan/admin-product-pagination-separation.md
+++ b/plan/admin-product-pagination-separation.md
@@ -1,0 +1,111 @@
+# Plan: Admin/Product 페이지네이션 계약 분리
+
+## Overview
+
+#402에서 Product 목록을 HMAC keyset cursor로 옮기며 Admin help·lookup이 같은 계약을 따라갔다. Admin과 Product의 페이지네이션 계약을 모듈 경계에서 분리한다.
+
+- Issue: bottle-note/workspace#404
+- 선행: bottle-note/workspace#402
+- 계약: bottle-note/workspace#385
+- 대상: Admin help 목록 원복, Admin 위스키 룩업 분리, Admin의 Product 목록 구현 직접 의존 제거, 불필요 cursor secret 제거
+- 제외: Product 목록 HMAC cursor 20개 재구현, Admin 목록 전면 커서 전환, FE 전환(#394)
+
+### Assumptions
+
+1. #404만 구현한다. Product `GET /api/v1/help`를 포함한 Product 목록 20개의 HMAC cursor 계약은 유지한다.
+2. Admin help "원복"은 예전 숫자 `cursor`+`pageSize` offset이 아니라, 다른 Admin 목록과 같은 `page`+`size`와 `GlobalResponse.fromPage` 응답(meta.page / size / totalElements / totalPages)이다.
+3. Admin 위스키 룩업은 Product `AlcoholLookupService` / `AlcoholLookupRequest`를 직접 쓰지 않는다. 요청은 `page`+`size`이고, 응답도 Admin 전용이다.
+4. Admin 컨트롤러는 Product 목록 Service/Repository(커서 코덱·`PageResponse` HMAC 타입을 끌어오는 경로)를 직접 쓰지 않는다. Product 페이징 타입만 바꿔도 Admin 목록 컨트롤러가 다시 깨지면 안 된다. 여기에는 Admin이 `AlcoholQueryService`를 통해 Product explore/cursor 빈에 묶이는 결합도 포함된다.
+5. 룩업 분리 후 Admin이 `CursorProperties` / HMAC 코덱을 쓰지 않으면 `PAGINATION_CURSOR_SECRET`을 Admin yml(테스트 yml 포함)에서 제거한다. 빈 스캔 때문에 기동이 시크릿을 계속 요구하면 그 의존을 끊는다. 남기면 이유를 plan에 문서화한다.
+6. DB 스키마·Flyway 변경은 없다.
+7. 이미 `page`+`size`인 Admin 목록(위스키 검색, 리뷰, 유저, 배너, 큐레이션, 스펙 큐레이션, 지역, 증류소, 테이스팅 태그)은 바꾸지 않는다.
+8. Access-control IP ban/signal의 `max` 상한 목록과 `GET /v2/curation-specs` 전량 참조 목록은 #404 변환 대상이 아니다. 감사 결과만 남긴다.
+9. 테스트는 Fake/InMemory를 우선하고, Admin 통합 테스트로 help·lookup의 page/size 계약을 확인한다.
+
+### Success Criteria
+
+- Product 목록 API 20개는 HMAC cursor 계약(`cursor`+`size`, `meta.pagination`)을 유지한다.
+- Admin `GET /helps`는 `page`+`size`로 동작하고 Product `GET /api/v1/help` 커서와 독립이다.
+- Admin `GET /alcohols/lookup`은 Product lookup 서비스/요청을 직접 쓰지 않고 `page`+`size`로 동작한다.
+- Product pagination 타입 변경만으로 Admin 목록 컨트롤러가 컴파일/기동에서 다시 깨지지 않는다.
+- Admin 기동이 Product cursor secret에 의존하지 않는다. yml에서 제거되어 있다.
+- Admin 목록 API 전수 감사 결과가 plan에 기록되어 있다. #404 범위 밖 예외(access-control `max`, curation-specs 전량)가 명시되어 있다.
+
+### Impact Scope
+
+- `bottlenote-admin-api`: help/lookup 컨트롤러·문서·yml, 기동 시 cursor secret 제거
+- `bottlenote-mono`: Admin help 목록 계약, Admin 룩업 전용 경로, Admin이 Product 목록 구현을 직접 쓰지 않도록 분리
+- `bottlenote-product-api`: Product help/lookup 계약 유지. 공유 시그니처가 바뀌면 테스트 더블만 맞춤
+- Persistence: 스키마 변경 없음
+- 외부 API: Admin help/lookup 요청·응답 키가 page/size로 바뀜. Product 공개 계약은 불변
+
+### Admin 목록 감사 (조사 결과)
+
+| 엔드포인트 | 현재 계약 | #404 조치 |
+|---|---|---|
+| `GET /helps` | HMAC `cursor`+`size` | page/size로 원복 |
+| `GET /alcohols/lookup` | Product lookup 공유, HMAC cursor | Admin 전용 page/size로 분리 |
+| `GET /alcohols` | page/size | 유지 |
+| `GET /reviews` | page/size | 유지 |
+| `GET /users` | page/size | 유지 |
+| `GET /banners` | page/size | 유지 |
+| `GET /curations` | page/size | 유지 |
+| `GET /v2/curations` | page/size | 유지 |
+| `GET /v2/curations/feed` | page/size | 유지 |
+| `GET /regions` | page/size | 유지 |
+| `GET /distilleries` | page/size | 유지 |
+| `GET /tasting-tags` | page/size | 유지 |
+| `GET /v2/curation-specs` | 전량 참조 목록 | 범위 밖 |
+| `GET /access-control` | `max` 상한 | 범위 밖 |
+| `GET /access-control/signals` | `max` 상한 | 범위 밖 |
+
+## Execution Mode
+
+- mode: delegated
+- scope: plan, implement, test, commit, push, pr
+- verify: local `/verify` 생략. PR 오픈 후 GitHub Actions로 트래킹한다.
+- stop-conditions:
+  1. 가정 붕괴 시 즉시 정지하고 재개봉
+  2. GitHub Actions 실패를 3회 시도 안에 해결하지 못하면 `/debug` 보고 후 정지
+  3. scope 밖 행동(머지, 인프라 변경, 파일 대량 삭제) 직전 정지
+
+## Tasks
+
+### Task 1: Admin help 목록을 page/size로 원복
+- Acceptance: Admin `GET /helps`가 `page`+`size`와 `GlobalResponse.fromPage` meta(page/size/totalElements/totalPages)로 동작한다. Product `GET /api/v1/help` HMAC cursor는 유지된다.
+- Verification: `./gradlew :bottlenote-mono:compileJava :bottlenote-admin-api:compileKotlin :bottlenote-product-api:compileJava -q`
+- Files (advisory): `AdminHelpPageableRequest`, `HelpRepository`, `CustomHelpQueryRepository`, `CustomHelpQueryRepositoryImpl`, `AdminHelpService`, `AdminHelpController`, `AdminHelpApiDocs`, `InMemoryHelpRepository`
+- Depends: 없음
+- Size: M
+- Status: [x] done
+
+### Checkpoint: after Task 1
+- [x] Admin help 요청 키가 page/size다
+- [x] Product help 커서는 그대로다
+
+### Task 2: Admin 위스키 룩업을 Product lookup에서 분리
+- Acceptance: Admin `GET /alcohols/lookup`이 Product `AlcoholLookupService`/`AlcoholLookupRequest`를 직접 쓰지 않고 `page`+`size`로 동작한다. Product lookup HMAC cursor와 `data.items`는 유지된다.
+- Verification: `./gradlew :bottlenote-mono:compileJava :bottlenote-admin-api:compileKotlin :bottlenote-product-api:compileJava -q`
+- Files (advisory): Admin lookup request/service, `AdminAlcoholsController`, `AdminAlcoholsApiDocs`, lookup unit test
+- Depends: 없음
+- Size: M
+- Status: [ ] not done
+
+### Checkpoint: after Task 2
+- [ ] Admin lookup이 Product lookup 요청/서비스를 직접 쓰지 않는다
+- [ ] Product lookup 계약이 유지된다
+
+### Task 3: Admin을 Product 목록 서비스에서 분리하고 cursor secret을 제거한다
+- Acceptance: Admin 컨트롤러가 Product 목록 Service(`AlcoholQueryService`, `AlcoholLookupService`)를 주입하지 않는다. Admin yml/테스트 yml에서 `PAGINATION_CURSOR_SECRET`이 없고, Admin 기동이 cursor secret 없이 된다.
+- Verification: `./gradlew :bottlenote-admin-api:compileKotlin :bottlenote-mono:compileJava -q` 및 Admin 기동 경로에서 cursor 설정이 없는지 확인
+- Files (advisory): `AdminAlcoholQueryService`, `AdminAlcoholsController`, `AlcoholQueryService`, `PaginationConfiguration`, Admin `application.yml`, Admin `application-test.yml`
+- Depends: Task 2
+- Size: M
+- Status: [ ] not done
+
+## Progress Log
+
+- 2026-08-16: /define. #404 WHAT 초안 작성. Admin 목록 전수 감사 포함.
+- 2026-08-16: Execution Mode 확정. delegated, scope=plan/implement/test/commit/push/pr. local verify 생략, PR 후 GitHub Actions 트래킹.
+- 2026-08-16: /plan. Task 3개로 분해. help 원복 → lookup 분리 → Product 서비스 분리+secret 제거.
+- 2026-08-16: Task 1 완료. Admin help를 page/size + fromPage로 원복. Product help HMAC 커서는 유지. AdminHelpServiceTest 통과.


### PR DESCRIPTION
## 변경 사항
- Admin 문의 목록(`GET /helps`)을 `page`+`size`와 `GlobalResponse.fromPage`로 원복한다. Product `GET /api/v1/help` HMAC cursor는 유지한다.
- Admin 위스키 룩업을 Product `AlcoholLookupService`/`AlcoholLookupRequest`에서 분리하고 Admin 전용 `page`+`size`로 조회한다.
- Admin 위스키 목록/상세/카테고리 조회를 `AdminAlcoholQueryService`로 옮겨, Admin 컨트롤러가 Product 목록 서비스를 직접 쓰지 않게 한다.
- Admin `application.yml`과 테스트 yml에서 `PAGINATION_CURSOR_SECRET`을 제거한다. Product만 `CursorSecretValidator`로 secret 미주입 시 기동 실패한다.

## 배경
bottle-note/workspace#404

#402에서 Product 목록을 HMAC keyset cursor로 옮기며 Admin help·lookup이 같은 계약을 따라갔다. Admin은 page/size, Product는 cursor라는 모듈 계약을 다시 분리한다.

## 검증
- `AdminHelpServiceTest`, `AdminAlcoholLookupServiceTest`, `AlcoholLookupServiceTest`, `PaginationConfigurationTest` 단위 테스트
- 로컬 `/verify`는 생략하고 이 PR의 GitHub Actions로 검증한다.

## 제외
- Product 목록 HMAC cursor 20개 재구현
- Admin 목록 전면 커서 전환
- Access-control `max` 목록, `GET /v2/curation-specs` 전량 참조 목록

## Admin 목록 감사
이미 page/size: 위스키 검색, 리뷰, 유저, 배너, 큐레이션, 스펙 큐레이션, 지역, 증류소, 테이스팅 태그.
이번 원복: help, lookup.
범위 밖: access-control(`max`), curation-specs(전량).